### PR TITLE
Add database schema with JSONB flexible metadata

### DIFF
--- a/src/db/init.sql
+++ b/src/db/init.sql
@@ -8,12 +8,12 @@ CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 -- Create a schema for the application
 CREATE SCHEMA IF NOT EXISTS app;
 
--- Example table structure (customize for your project)
--- DELETE THIS AND REPLACE WITH YOUR ACTUAL SCHEMA
+-- Migrations tracking table
 CREATE TABLE IF NOT EXISTS app.migrations (
     id SERIAL PRIMARY KEY,
     name VARCHAR(255) NOT NULL UNIQUE,
     applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
--- Add any initial seed data or setup here
+-- Note: Main schema is in src/db/migrations/001_initial_schema.sql
+-- Run `npm run db:migrate` after `npm run db:up` to apply migrations

--- a/src/db/migrations/001_initial_schema.sql
+++ b/src/db/migrations/001_initial_schema.sql
@@ -1,0 +1,159 @@
+-- Initial schema for hex-index personal library
+-- Publications, Articles, and Article Links with JSONB flexible metadata
+
+-- Publications table
+CREATE TABLE IF NOT EXISTS app.publications (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL UNIQUE,
+    base_url VARCHAR(512) NOT NULL,
+    feed_url VARCHAR(512) NOT NULL,
+    description TEXT,
+    author_name VARCHAR(255),
+    last_fetched_at TIMESTAMP WITH TIME ZONE,
+    article_count INTEGER DEFAULT 0,
+    quality_score NUMERIC(3,2) DEFAULT 0.00,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Index for publication lookups
+CREATE INDEX IF NOT EXISTS idx_publications_slug ON app.publications(slug);
+CREATE INDEX IF NOT EXISTS idx_publications_quality ON app.publications(quality_score DESC);
+
+-- Articles table
+CREATE TABLE IF NOT EXISTS app.articles (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    publication_id UUID NOT NULL REFERENCES app.publications(id) ON DELETE CASCADE,
+    title VARCHAR(512) NOT NULL,
+    slug VARCHAR(512) NOT NULL,
+    original_url VARCHAR(1024) NOT NULL UNIQUE,
+    content_path VARCHAR(512),
+    author_name VARCHAR(255),
+    published_at TIMESTAMP WITH TIME ZONE,
+    word_count INTEGER,
+    estimated_read_time_minutes INTEGER,
+    tags JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    full_text_search TSVECTOR,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for article queries
+CREATE INDEX IF NOT EXISTS idx_articles_publication ON app.articles(publication_id);
+CREATE INDEX IF NOT EXISTS idx_articles_published ON app.articles(published_at DESC);
+CREATE INDEX IF NOT EXISTS idx_articles_publication_published
+    ON app.articles(publication_id, published_at DESC);
+
+-- GIN index for JSONB tag queries
+-- Allows efficient queries like: tags @> '{"topic": "economics"}'
+CREATE INDEX IF NOT EXISTS idx_articles_tags ON app.articles USING GIN (tags);
+
+-- GIN index for full-text search
+CREATE INDEX IF NOT EXISTS idx_articles_fts ON app.articles USING GIN (full_text_search);
+
+-- Article links table (for inter-article graph)
+CREATE TABLE IF NOT EXISTS app.article_links (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    source_article_id UUID NOT NULL REFERENCES app.articles(id) ON DELETE CASCADE,
+    target_article_id UUID REFERENCES app.articles(id) ON DELETE SET NULL,
+    target_url VARCHAR(1024) NOT NULL,
+    link_text VARCHAR(512),
+    context TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for link traversal
+CREATE INDEX IF NOT EXISTS idx_article_links_source ON app.article_links(source_article_id);
+CREATE INDEX IF NOT EXISTS idx_article_links_target ON app.article_links(target_article_id);
+
+-- Function to update full_text_search on article insert/update
+CREATE OR REPLACE FUNCTION app.update_article_fts()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.full_text_search :=
+        setweight(to_tsvector('english', COALESCE(NEW.title, '')), 'A') ||
+        setweight(to_tsvector('english', COALESCE(NEW.author_name, '')), 'B');
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger for automatic FTS update
+DROP TRIGGER IF EXISTS trigger_article_fts ON app.articles;
+CREATE TRIGGER trigger_article_fts
+    BEFORE INSERT OR UPDATE OF title, author_name
+    ON app.articles
+    FOR EACH ROW
+    EXECUTE FUNCTION app.update_article_fts();
+
+-- Function to update updated_at timestamp
+CREATE OR REPLACE FUNCTION app.update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Triggers for updated_at
+DROP TRIGGER IF EXISTS trigger_publications_updated ON app.publications;
+CREATE TRIGGER trigger_publications_updated
+    BEFORE UPDATE ON app.publications
+    FOR EACH ROW
+    EXECUTE FUNCTION app.update_updated_at();
+
+DROP TRIGGER IF EXISTS trigger_articles_updated ON app.articles;
+CREATE TRIGGER trigger_articles_updated
+    BEFORE UPDATE ON app.articles
+    FOR EACH ROW
+    EXECUTE FUNCTION app.update_updated_at();
+
+-- Function to update publication article_count
+CREATE OR REPLACE FUNCTION app.update_publication_article_count()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        UPDATE app.publications
+        SET article_count = article_count + 1
+        WHERE id = NEW.publication_id;
+    ELSIF TG_OP = 'DELETE' THEN
+        UPDATE app.publications
+        SET article_count = article_count - 1
+        WHERE id = OLD.publication_id;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger for article_count maintenance
+DROP TRIGGER IF EXISTS trigger_article_count ON app.articles;
+CREATE TRIGGER trigger_article_count
+    AFTER INSERT OR DELETE ON app.articles
+    FOR EACH ROW
+    EXECUTE FUNCTION app.update_publication_article_count();
+
+-- Useful views
+
+-- View for searching articles with publication info
+CREATE OR REPLACE VIEW app.articles_with_publication AS
+SELECT
+    a.*,
+    p.name as publication_name,
+    p.slug as publication_slug,
+    p.author_name as publication_author
+FROM app.articles a
+JOIN app.publications p ON a.publication_id = p.id;
+
+-- View for article link counts (incoming links = influence)
+CREATE OR REPLACE VIEW app.article_influence AS
+SELECT
+    a.id,
+    a.title,
+    a.publication_id,
+    COUNT(al.id) as incoming_links
+FROM app.articles a
+LEFT JOIN app.article_links al ON al.target_article_id = a.id
+GROUP BY a.id, a.title, a.publication_id
+ORDER BY incoming_links DESC;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,0 +1,347 @@
+/**
+ * Database query helpers for hex-index
+ * Provides typed functions for common operations
+ */
+
+import { Pool, PoolClient } from 'pg';
+import {
+  Publication,
+  Article,
+  ArticleWithPublication,
+  ArticleLink,
+  CreatePublicationInput,
+  CreateArticleInput,
+  CreateArticleLinkInput,
+  ArticleSearchParams,
+  SearchResult,
+} from './types.js';
+
+// Re-export types for convenience
+export * from './types.js';
+
+/**
+ * Create a database connection pool
+ */
+export function createPool(connectionString: string): Pool {
+  return new Pool({ connectionString });
+}
+
+// ============ Publications ============
+
+export async function createPublication(
+  client: Pool | PoolClient,
+  input: CreatePublicationInput
+): Promise<Publication> {
+  const { rows } = await client.query<Publication>(
+    `INSERT INTO app.publications (name, slug, base_url, feed_url, description, author_name, quality_score, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+     RETURNING *`,
+    [
+      input.name,
+      input.slug,
+      input.base_url,
+      input.feed_url,
+      input.description ?? null,
+      input.author_name ?? null,
+      input.quality_score ?? 0,
+      JSON.stringify(input.metadata ?? {}),
+    ]
+  );
+  return rows[0];
+}
+
+export async function getPublicationBySlug(
+  client: Pool | PoolClient,
+  slug: string
+): Promise<Publication | null> {
+  const { rows } = await client.query<Publication>(
+    'SELECT * FROM app.publications WHERE slug = $1',
+    [slug]
+  );
+  return rows[0] ?? null;
+}
+
+export async function getPublicationById(
+  client: Pool | PoolClient,
+  id: string
+): Promise<Publication | null> {
+  const { rows } = await client.query<Publication>(
+    'SELECT * FROM app.publications WHERE id = $1',
+    [id]
+  );
+  return rows[0] ?? null;
+}
+
+export async function listPublications(
+  client: Pool | PoolClient,
+  options?: { limit?: number; offset?: number; minQuality?: number }
+): Promise<Publication[]> {
+  const limit = options?.limit ?? 50;
+  const offset = options?.offset ?? 0;
+  const minQuality = options?.minQuality ?? 0;
+
+  const { rows } = await client.query<Publication>(
+    `SELECT * FROM app.publications
+     WHERE quality_score >= $1
+     ORDER BY quality_score DESC, article_count DESC
+     LIMIT $2 OFFSET $3`,
+    [minQuality, limit, offset]
+  );
+  return rows;
+}
+
+export async function updatePublicationLastFetched(
+  client: Pool | PoolClient,
+  id: string
+): Promise<void> {
+  await client.query(
+    'UPDATE app.publications SET last_fetched_at = NOW() WHERE id = $1',
+    [id]
+  );
+}
+
+// ============ Articles ============
+
+export async function createArticle(
+  client: Pool | PoolClient,
+  input: CreateArticleInput
+): Promise<Article> {
+  const { rows } = await client.query<Article>(
+    `INSERT INTO app.articles
+     (publication_id, title, slug, original_url, content_path, author_name,
+      published_at, word_count, estimated_read_time_minutes, tags, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+     RETURNING *`,
+    [
+      input.publication_id,
+      input.title,
+      input.slug,
+      input.original_url,
+      input.content_path ?? null,
+      input.author_name ?? null,
+      input.published_at ?? null,
+      input.word_count ?? null,
+      input.estimated_read_time_minutes ?? null,
+      JSON.stringify(input.tags ?? {}),
+      JSON.stringify(input.metadata ?? {}),
+    ]
+  );
+  return rows[0];
+}
+
+export async function getArticleByUrl(
+  client: Pool | PoolClient,
+  url: string
+): Promise<Article | null> {
+  const { rows } = await client.query<Article>(
+    'SELECT * FROM app.articles WHERE original_url = $1',
+    [url]
+  );
+  return rows[0] ?? null;
+}
+
+export async function getArticleById(
+  client: Pool | PoolClient,
+  id: string
+): Promise<ArticleWithPublication | null> {
+  const { rows } = await client.query<ArticleWithPublication>(
+    'SELECT * FROM app.articles_with_publication WHERE id = $1',
+    [id]
+  );
+  return rows[0] ?? null;
+}
+
+/**
+ * Search articles with full-text search and JSONB tag filtering
+ */
+export async function searchArticles(
+  client: Pool | PoolClient,
+  params: ArticleSearchParams
+): Promise<SearchResult> {
+  const conditions: string[] = [];
+  const values: unknown[] = [];
+  let paramIndex = 1;
+
+  // Full-text search
+  if (params.query) {
+    conditions.push(`full_text_search @@ plainto_tsquery('english', $${paramIndex})`);
+    values.push(params.query);
+    paramIndex++;
+  }
+
+  // JSONB tag filtering
+  if (params.tags && Object.keys(params.tags).length > 0) {
+    conditions.push(`tags @> $${paramIndex}`);
+    values.push(JSON.stringify(params.tags));
+    paramIndex++;
+  }
+
+  // Publication filter
+  if (params.publication_id) {
+    conditions.push(`publication_id = $${paramIndex}`);
+    values.push(params.publication_id);
+    paramIndex++;
+  }
+
+  // Read time filters
+  if (params.min_read_time) {
+    conditions.push(`estimated_read_time_minutes >= $${paramIndex}`);
+    values.push(params.min_read_time);
+    paramIndex++;
+  }
+  if (params.max_read_time) {
+    conditions.push(`estimated_read_time_minutes <= $${paramIndex}`);
+    values.push(params.max_read_time);
+    paramIndex++;
+  }
+
+  // Date filters
+  if (params.from_date) {
+    conditions.push(`published_at >= $${paramIndex}`);
+    values.push(params.from_date);
+    paramIndex++;
+  }
+  if (params.to_date) {
+    conditions.push(`published_at <= $${paramIndex}`);
+    values.push(params.to_date);
+    paramIndex++;
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  const limit = params.limit ?? 20;
+  const offset = params.offset ?? 0;
+
+  // Get total count
+  const countQuery = `SELECT COUNT(*) FROM app.articles_with_publication ${whereClause}`;
+  const { rows: countRows } = await client.query<{ count: string }>(countQuery, values);
+  const total = parseInt(countRows[0].count, 10);
+
+  // Get articles with relevance ranking
+  let orderBy = 'published_at DESC';
+  if (params.query) {
+    orderBy = `ts_rank(full_text_search, plainto_tsquery('english', $1)) DESC, ${orderBy}`;
+  }
+
+  const articlesQuery = `
+    SELECT * FROM app.articles_with_publication
+    ${whereClause}
+    ORDER BY ${orderBy}
+    LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
+  `;
+  values.push(limit, offset);
+
+  const { rows: articles } = await client.query<ArticleWithPublication>(
+    articlesQuery,
+    values
+  );
+
+  return { articles, total, query: params };
+}
+
+/**
+ * Get articles by JSONB tag
+ * Example: getArticlesByTag(pool, 'topic', 'economics')
+ */
+export async function getArticlesByTag(
+  client: Pool | PoolClient,
+  key: string,
+  value: string,
+  options?: { limit?: number; offset?: number }
+): Promise<ArticleWithPublication[]> {
+  const limit = options?.limit ?? 20;
+  const offset = options?.offset ?? 0;
+
+  const { rows } = await client.query<ArticleWithPublication>(
+    `SELECT * FROM app.articles_with_publication
+     WHERE tags @> $1
+     ORDER BY published_at DESC
+     LIMIT $2 OFFSET $3`,
+    [JSON.stringify({ [key]: value }), limit, offset]
+  );
+  return rows;
+}
+
+/**
+ * Get all unique tag keys and their value distributions
+ */
+export async function getTagDistribution(
+  client: Pool | PoolClient
+): Promise<Map<string, Map<string, number>>> {
+  const { rows } = await client.query<{ key: string; value: string; count: string }>(`
+    SELECT
+      key,
+      value,
+      COUNT(*) as count
+    FROM app.articles,
+         jsonb_each_text(tags) AS t(key, value)
+    GROUP BY key, value
+    ORDER BY key, count DESC
+  `);
+
+  const distribution = new Map<string, Map<string, number>>();
+  for (const row of rows) {
+    if (!distribution.has(row.key)) {
+      distribution.set(row.key, new Map());
+    }
+    distribution.get(row.key)!.set(row.value, parseInt(row.count, 10));
+  }
+  return distribution;
+}
+
+// ============ Article Links ============
+
+export async function createArticleLink(
+  client: Pool | PoolClient,
+  input: CreateArticleLinkInput
+): Promise<ArticleLink> {
+  const { rows } = await client.query<ArticleLink>(
+    `INSERT INTO app.article_links
+     (source_article_id, target_article_id, target_url, link_text, context)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING *`,
+    [
+      input.source_article_id,
+      input.target_article_id ?? null,
+      input.target_url,
+      input.link_text ?? null,
+      input.context ?? null,
+    ]
+  );
+  return rows[0];
+}
+
+export async function getArticleLinks(
+  client: Pool | PoolClient,
+  articleId: string
+): Promise<ArticleLink[]> {
+  const { rows } = await client.query<ArticleLink>(
+    'SELECT * FROM app.article_links WHERE source_article_id = $1',
+    [articleId]
+  );
+  return rows;
+}
+
+export async function getArticleBacklinks(
+  client: Pool | PoolClient,
+  articleId: string
+): Promise<ArticleLink[]> {
+  const { rows } = await client.query<ArticleLink>(
+    'SELECT * FROM app.article_links WHERE target_article_id = $1',
+    [articleId]
+  );
+  return rows;
+}
+
+export async function getMostLinkedArticles(
+  client: Pool | PoolClient,
+  limit = 20
+): Promise<ArticleWithPublication[]> {
+  const { rows } = await client.query<ArticleWithPublication>(
+    `SELECT a.* FROM app.articles_with_publication a
+     JOIN app.article_influence i ON a.id = i.id
+     ORDER BY i.incoming_links DESC
+     LIMIT $1`,
+    [limit]
+  );
+  return rows;
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -1,0 +1,114 @@
+/**
+ * Database types for hex-index
+ * These match the schema in migrations/001_initial_schema.sql
+ */
+
+export interface Publication {
+  id: string;
+  name: string;
+  slug: string;
+  base_url: string;
+  feed_url: string;
+  description: string | null;
+  author_name: string | null;
+  last_fetched_at: Date | null;
+  article_count: number;
+  quality_score: number;
+  metadata: Record<string, unknown>;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface Article {
+  id: string;
+  publication_id: string;
+  title: string;
+  slug: string;
+  original_url: string;
+  content_path: string | null;
+  author_name: string | null;
+  published_at: Date | null;
+  word_count: number | null;
+  estimated_read_time_minutes: number | null;
+  tags: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  full_text_search: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface ArticleWithPublication extends Article {
+  publication_name: string;
+  publication_slug: string;
+  publication_author: string | null;
+}
+
+export interface ArticleLink {
+  id: string;
+  source_article_id: string;
+  target_article_id: string | null;
+  target_url: string;
+  link_text: string | null;
+  context: string | null;
+  created_at: Date;
+}
+
+export interface ArticleInfluence {
+  id: string;
+  title: string;
+  publication_id: string;
+  incoming_links: number;
+}
+
+// Input types for creating records
+export interface CreatePublicationInput {
+  name: string;
+  slug: string;
+  base_url: string;
+  feed_url: string;
+  description?: string;
+  author_name?: string;
+  quality_score?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateArticleInput {
+  publication_id: string;
+  title: string;
+  slug: string;
+  original_url: string;
+  content_path?: string;
+  author_name?: string;
+  published_at?: Date;
+  word_count?: number;
+  estimated_read_time_minutes?: number;
+  tags?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateArticleLinkInput {
+  source_article_id: string;
+  target_article_id?: string;
+  target_url: string;
+  link_text?: string;
+  context?: string;
+}
+
+// Query types
+export interface ArticleSearchParams {
+  query?: string;
+  tags?: Record<string, string>;
+  publication_id?: string;
+  min_read_time?: number;
+  max_read_time?: number;
+  from_date?: Date;
+  to_date?: Date;
+  limit?: number;
+  offset?: number;
+}
+
+export interface SearchResult {
+  articles: ArticleWithPublication[];
+  total: number;
+  query: ArticleSearchParams;
+}


### PR DESCRIPTION
## Summary
- Implements PostgreSQL schema foundation for hex-index personal library
- publications, articles, and article_links tables with JSONB metadata
- Full-text search with tsvector and GIN indexes
- TypeScript types and query helpers

## Changes
- `src/db/migrations/001_initial_schema.sql` - Full schema with triggers and views
- `src/db/types.ts` - TypeScript interfaces for all tables
- `src/db/queries.ts` - Query helpers for CRUD, search, and tag filtering

## Test plan
- [x] TypeScript compiles without errors
- [x] ESLint passes with zero warnings
- [x] Unit tests pass
- [ ] Manual: `npm run db:up && npm run db:migrate` creates schema

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)