### PR TITLE
Add RSS feed parser tool for Substack /feed URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "fast-xml-parser": "^5.3.3",
         "pg": "^8.13.0",
         "zod": "^4.1.13"
       },
@@ -2525,6 +2526,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.3.tgz",
+      "integrity": "sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4065,6 +4084,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
     "discord:read": "tsx tools/discord/read.ts",
     "gh:issue": "tsx tools/github/create-issue.ts",
     "gh:rate-limit": "tsx tools/github/check-rate-limit.ts",
+    "feed:fetch": "tsx tools/feed/fetch.ts",
     "prepare": "husky || true"
   },
   "dependencies": {
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "fast-xml-parser": "^5.3.3",
     "pg": "^8.13.0",
     "zod": "^4.1.13"
   },

--- a/src/feed/fetcher.ts
+++ b/src/feed/fetcher.ts
@@ -1,0 +1,188 @@
+/**
+ * RSS/Atom feed fetcher with rate limiting and caching
+ */
+
+import { Feed, FetchOptions, FetchResult, DEFAULT_FETCH_OPTIONS } from './types.js';
+import { parseFeed } from './parser.js';
+
+// Simple in-memory cache
+const feedCache = new Map<string, { feed: Feed; fetchedAt: Date }>();
+const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
+
+// Rate limiting state
+let lastFetchTime = 0;
+
+/**
+ * Sleep for specified milliseconds
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Ensure rate limit is respected
+ */
+async function waitForRateLimit(delayMs: number): Promise<void> {
+  const now = Date.now();
+  const elapsed = now - lastFetchTime;
+  if (elapsed < delayMs) {
+    await sleep(delayMs - elapsed);
+  }
+  lastFetchTime = Date.now();
+}
+
+/**
+ * Fetch a URL with timeout
+ */
+async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number,
+  userAgent: string
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': userAgent,
+        Accept: 'application/rss+xml, application/atom+xml, application/xml, text/xml',
+      },
+    });
+    return response;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Fetch and parse an RSS/Atom feed
+ */
+export async function fetchFeed(
+  feedUrl: string,
+  options: FetchOptions = {}
+): Promise<FetchResult> {
+  const opts = { ...DEFAULT_FETCH_OPTIONS, ...options };
+
+  // Check cache first
+  const cached = feedCache.get(feedUrl);
+  if (cached && Date.now() - cached.fetchedAt.getTime() < CACHE_TTL_MS) {
+    return {
+      success: true,
+      feed: cached.feed,
+      cached: true,
+      fetchedAt: cached.fetchedAt,
+    };
+  }
+
+  // Wait for rate limit
+  await waitForRateLimit(opts.delayMs);
+
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < opts.retries; attempt++) {
+    try {
+      const response = await fetchWithTimeout(feedUrl, opts.timeoutMs, opts.userAgent);
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const xml = await response.text();
+      const feed = parseFeed(xml, feedUrl);
+
+      // Update cache
+      const fetchedAt = new Date();
+      feedCache.set(feedUrl, { feed, fetchedAt });
+
+      return {
+        success: true,
+        feed,
+        cached: false,
+        fetchedAt,
+      };
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+
+      // Don't retry on client errors (4xx)
+      if (lastError.message.includes('HTTP 4')) {
+        break;
+      }
+
+      // Wait before retry
+      if (attempt < opts.retries - 1) {
+        await sleep(opts.delayMs * (attempt + 1));
+      }
+    }
+  }
+
+  return {
+    success: false,
+    error: lastError?.message ?? 'Unknown error',
+    fetchedAt: new Date(),
+  };
+}
+
+/**
+ * Fetch multiple feeds with rate limiting
+ */
+export async function fetchFeeds(
+  feedUrls: string[],
+  options: FetchOptions = {},
+  onProgress?: (completed: number, total: number, current: string) => void
+): Promise<Map<string, FetchResult>> {
+  const results = new Map<string, FetchResult>();
+  const total = feedUrls.length;
+
+  for (let i = 0; i < feedUrls.length; i++) {
+    const url = feedUrls[i];
+    if (onProgress) {
+      onProgress(i, total, url);
+    }
+
+    const result = await fetchFeed(url, options);
+    results.set(url, result);
+  }
+
+  if (onProgress) {
+    onProgress(total, total, 'done');
+  }
+
+  return results;
+}
+
+/**
+ * Clear the feed cache
+ */
+export function clearCache(): void {
+  feedCache.clear();
+}
+
+/**
+ * Get cache statistics
+ */
+export function getCacheStats(): { size: number; urls: string[] } {
+  return {
+    size: feedCache.size,
+    urls: Array.from(feedCache.keys()),
+  };
+}
+
+/**
+ * Build a Substack feed URL from a publication slug or base URL
+ */
+export function getSubstackFeedUrl(slugOrUrl: string): string {
+  // If it's already a full URL
+  if (slugOrUrl.startsWith('http')) {
+    const url = new URL(slugOrUrl);
+    // Ensure it ends with /feed
+    if (!url.pathname.endsWith('/feed')) {
+      url.pathname = '/feed';
+    }
+    return url.toString();
+  }
+
+  // It's a slug
+  return `https://${slugOrUrl}.substack.com/feed`;
+}

--- a/src/feed/index.ts
+++ b/src/feed/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Feed module exports
+ */
+
+export * from './types.js';
+export * from './parser.js';
+export * from './fetcher.js';

--- a/src/feed/parser.test.ts
+++ b/src/feed/parser.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for RSS/Atom feed parser
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseFeed, extractTextContent, estimateReadTime, countWords } from './parser.js';
+
+describe('parseFeed', () => {
+  it('parses RSS 2.0 feed', () => {
+    const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0">
+      <channel>
+        <title>Test Publication</title>
+        <description>A test publication</description>
+        <link>https://test.substack.com</link>
+        <item>
+          <title>Test Article</title>
+          <link>https://test.substack.com/p/test-article</link>
+          <pubDate>Mon, 13 Dec 2025 12:00:00 GMT</pubDate>
+          <dc:creator>Test Author</dc:creator>
+          <description>This is a summary.</description>
+          <content:encoded><![CDATA[<p>This is the full content.</p>]]></content:encoded>
+        </item>
+      </channel>
+    </rss>`;
+
+    const feed = parseFeed(rssXml, 'https://test.substack.com/feed');
+
+    expect(feed.title).toBe('Test Publication');
+    expect(feed.description).toBe('A test publication');
+    expect(feed.link).toBe('https://test.substack.com');
+    expect(feed.items).toHaveLength(1);
+
+    const item = feed.items[0];
+    expect(item.title).toBe('Test Article');
+    expect(item.url).toBe('https://test.substack.com/p/test-article');
+    expect(item.author).toBe('Test Author');
+    expect(item.summary).toBe('This is a summary.');
+    expect(item.contentHtml).toContain('This is the full content.');
+  });
+
+  it('parses Atom feed', () => {
+    const atomXml = `<?xml version="1.0" encoding="UTF-8"?>
+    <feed xmlns="http://www.w3.org/2005/Atom">
+      <title>Test Publication</title>
+      <subtitle>A test publication</subtitle>
+      <link href="https://test.substack.com" rel="alternate"/>
+      <link href="https://test.substack.com/feed" rel="self"/>
+      <author><name>Test Author</name></author>
+      <entry>
+        <title>Test Article</title>
+        <link href="https://test.substack.com/p/test-article" rel="alternate"/>
+        <published>2025-12-13T12:00:00Z</published>
+        <author><name>Entry Author</name></author>
+        <summary>This is a summary.</summary>
+        <content type="html"><![CDATA[<p>This is the full content.</p>]]></content>
+      </entry>
+    </feed>`;
+
+    const feed = parseFeed(atomXml, 'https://test.substack.com/feed');
+
+    expect(feed.title).toBe('Test Publication');
+    expect(feed.description).toBe('A test publication');
+    expect(feed.link).toBe('https://test.substack.com');
+    expect(feed.items).toHaveLength(1);
+
+    const item = feed.items[0];
+    expect(item.title).toBe('Test Article');
+    expect(item.url).toBe('https://test.substack.com/p/test-article');
+    expect(item.author).toBe('Entry Author');
+    expect(item.summary).toBe('This is a summary.');
+    expect(item.contentHtml).toContain('This is the full content.');
+  });
+
+  it('throws on unknown feed format', () => {
+    const invalidXml = `<?xml version="1.0"?><unknown><data/></unknown>`;
+    expect(() => parseFeed(invalidXml, 'https://test.com/feed')).toThrow('Unknown feed format');
+  });
+});
+
+describe('extractTextContent', () => {
+  it('strips HTML tags', () => {
+    const html = '<p>Hello <strong>world</strong>!</p>';
+    expect(extractTextContent(html)).toBe('Hello world!');
+  });
+
+  it('decodes HTML entities', () => {
+    const html = '&amp; &lt; &gt; &quot; &#39;';
+    expect(extractTextContent(html)).toBe('& < > " \'');
+  });
+
+  it('normalizes whitespace', () => {
+    const html = '  Hello   \n\n  world  ';
+    expect(extractTextContent(html)).toBe('Hello world');
+  });
+});
+
+describe('estimateReadTime', () => {
+  it('estimates read time for short content', () => {
+    const shortHtml = '<p>' + 'word '.repeat(100) + '</p>';
+    expect(estimateReadTime(shortHtml)).toBe(1); // 100 words = 0.5 min, rounded up to 1
+  });
+
+  it('estimates read time for longer content', () => {
+    const longHtml = '<p>' + 'word '.repeat(600) + '</p>';
+    expect(estimateReadTime(longHtml)).toBe(3); // 600 words = 3 min
+  });
+});
+
+describe('countWords', () => {
+  it('counts words in HTML', () => {
+    const html = '<p>This is a <strong>test</strong> with some words.</p>';
+    expect(countWords(html)).toBe(7);
+  });
+
+  it('handles empty content', () => {
+    expect(countWords('')).toBe(0);
+    expect(countWords('<p></p>')).toBe(0);
+  });
+});

--- a/src/feed/parser.ts
+++ b/src/feed/parser.ts
@@ -1,0 +1,198 @@
+/**
+ * RSS/Atom feed parser
+ * Handles both RSS 2.0 and Atom feed formats
+ */
+
+import { XMLParser } from 'fast-xml-parser';
+import { Feed, FeedItem } from './types.js';
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: '@_',
+  textNodeName: '#text',
+  isArray: (name) => ['item', 'entry'].includes(name),
+});
+
+interface RSSChannel {
+  title: string;
+  description?: string;
+  link: string;
+  lastBuildDate?: string;
+  'atom:link'?: { '@_href'?: string };
+  item?: RSSItem[];
+}
+
+interface RSSItem {
+  title: string;
+  link: string;
+  pubDate?: string;
+  'dc:creator'?: string;
+  author?: string;
+  description?: string;
+  'content:encoded'?: string;
+  guid?: string | { '#text': string };
+  enclosure?: { '@_url'?: string };
+  'media:content'?: { '@_url'?: string };
+}
+
+interface AtomFeed {
+  title: string | { '#text': string };
+  subtitle?: string;
+  link?: AtomLink | AtomLink[];
+  updated?: string;
+  author?: { name?: string };
+  entry?: AtomEntry[];
+}
+
+interface AtomLink {
+  '@_href'?: string;
+  '@_rel'?: string;
+  '@_type'?: string;
+}
+
+interface AtomEntry {
+  title: string | { '#text': string };
+  link?: AtomLink | AtomLink[];
+  published?: string;
+  updated?: string;
+  author?: { name?: string };
+  summary?: string | { '#text': string };
+  content?: string | { '#text': string; '@_type'?: string };
+  id?: string;
+  'media:thumbnail'?: { '@_url'?: string };
+}
+
+/**
+ * Parse XML content into a Feed object
+ */
+export function parseFeed(xml: string, feedUrl: string): Feed {
+  const parsed = parser.parse(xml) as Record<string, unknown>;
+
+  // Check if it's RSS
+  if ('rss' in parsed) {
+    return parseRSS(parsed.rss as { channel: RSSChannel }, feedUrl);
+  }
+
+  // Check if it's Atom
+  if ('feed' in parsed) {
+    return parseAtom(parsed.feed as AtomFeed, feedUrl);
+  }
+
+  throw new Error('Unknown feed format: expected RSS or Atom');
+}
+
+function parseRSS(rss: { channel: RSSChannel }, feedUrl: string): Feed {
+  const channel = rss.channel;
+
+  const items: FeedItem[] = (channel.item ?? []).map((item) => {
+    const contentHtml = item['content:encoded'] ?? item.description ?? '';
+    const summary = item.description && item['content:encoded'] ? item.description : undefined;
+
+    // Extract image from enclosure or media:content
+    let imageUrl: string | undefined;
+    if (item.enclosure?.['@_url']) {
+      imageUrl = item.enclosure['@_url'];
+    } else if (item['media:content']?.['@_url']) {
+      imageUrl = item['media:content']['@_url'];
+    }
+
+    // Extract GUID
+    const guid = typeof item.guid === 'string' ? item.guid : item.guid?.['#text'];
+
+    return {
+      title: item.title,
+      url: item.link,
+      publishedAt: item.pubDate ? new Date(item.pubDate) : new Date(),
+      author: item['dc:creator'] ?? item.author ?? channel.title,
+      contentHtml,
+      summary,
+      imageUrl,
+      guid,
+    };
+  });
+
+  return {
+    title: channel.title,
+    description: channel.description,
+    link: channel.link,
+    feedUrl: channel['atom:link']?.['@_href'] ?? feedUrl,
+    lastBuildDate: channel.lastBuildDate ? new Date(channel.lastBuildDate) : undefined,
+    items,
+  };
+}
+
+function parseAtom(atom: AtomFeed, feedUrl: string): Feed {
+  // Get feed link
+  const links = Array.isArray(atom.link) ? atom.link : atom.link ? [atom.link] : [];
+  const htmlLink = links.find((l) => l['@_rel'] === 'alternate' || !l['@_rel']);
+  const selfLink = links.find((l) => l['@_rel'] === 'self');
+
+  const items: FeedItem[] = (atom.entry ?? []).map((entry) => {
+    // Get entry link
+    const entryLinks = Array.isArray(entry.link) ? entry.link : entry.link ? [entry.link] : [];
+    const entryHtmlLink = entryLinks.find((l) => l['@_rel'] === 'alternate' || !l['@_rel']);
+
+    // Extract content
+    const content = typeof entry.content === 'string' ? entry.content : entry.content?.['#text'] ?? '';
+    const summary = typeof entry.summary === 'string' ? entry.summary : entry.summary?.['#text'];
+    const title = typeof entry.title === 'string' ? entry.title : entry.title?.['#text'] ?? '';
+
+    return {
+      title,
+      url: entryHtmlLink?.['@_href'] ?? '',
+      publishedAt: entry.published ? new Date(entry.published) : entry.updated ? new Date(entry.updated) : new Date(),
+      author: entry.author?.name ?? atom.author?.name ?? '',
+      contentHtml: content,
+      summary,
+      imageUrl: entry['media:thumbnail']?.['@_url'],
+      guid: entry.id,
+    };
+  });
+
+  const title = typeof atom.title === 'string' ? atom.title : atom.title?.['#text'] ?? '';
+
+  return {
+    title,
+    description: atom.subtitle,
+    link: htmlLink?.['@_href'] ?? '',
+    feedUrl: selfLink?.['@_href'] ?? feedUrl,
+    author: atom.author?.name,
+    lastBuildDate: atom.updated ? new Date(atom.updated) : undefined,
+    items,
+  };
+}
+
+/**
+ * Extract text content from potentially HTML string
+ */
+export function extractTextContent(html: string): string {
+  // Simple HTML tag stripping - for more complex needs, use a proper HTML parser
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Estimate read time from HTML content
+ */
+export function estimateReadTime(html: string): number {
+  const text = extractTextContent(html);
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+  // Average reading speed: 200 words per minute
+  return Math.ceil(wordCount / 200);
+}
+
+/**
+ * Count words in HTML content
+ */
+export function countWords(html: string): number {
+  const text = extractTextContent(html);
+  return text.split(/\s+/).filter(Boolean).length;
+}

--- a/src/feed/types.ts
+++ b/src/feed/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Types for RSS/Atom feed parsing
+ */
+
+export interface FeedItem {
+  title: string;
+  url: string;
+  publishedAt: Date;
+  author: string;
+  contentHtml: string;
+  summary?: string;
+  imageUrl?: string;
+  guid?: string;
+}
+
+export interface Feed {
+  title: string;
+  description?: string;
+  link: string;
+  feedUrl: string;
+  author?: string;
+  lastBuildDate?: Date;
+  items: FeedItem[];
+}
+
+export interface FetchOptions {
+  /** Delay between requests in milliseconds (default: 2000) */
+  delayMs?: number;
+  /** Number of retry attempts (default: 3) */
+  retries?: number;
+  /** Timeout in milliseconds (default: 30000) */
+  timeoutMs?: number;
+  /** User agent string */
+  userAgent?: string;
+}
+
+export interface FetchResult {
+  success: boolean;
+  feed?: Feed;
+  error?: string;
+  cached?: boolean;
+  fetchedAt: Date;
+}
+
+export const DEFAULT_FETCH_OPTIONS: Required<FetchOptions> = {
+  delayMs: 2000,
+  retries: 3,
+  timeoutMs: 30000,
+  userAgent: 'hex-index/1.0 (Personal Library; https://github.com/bedwards/hex-index)',
+};

--- a/tools/feed/fetch.ts
+++ b/tools/feed/fetch.ts
@@ -1,0 +1,168 @@
+/**
+ * Feed Fetch CLI Tool
+ *
+ * Fetches and parses Substack RSS feeds.
+ *
+ * Usage:
+ *   npm run feed:fetch -- --url https://example.substack.com/feed
+ *   npm run feed:fetch -- --publication example
+ *   npm run feed:fetch -- --url https://example.substack.com/feed --json
+ */
+
+import { config } from 'dotenv';
+import {
+  fetchFeed,
+  getSubstackFeedUrl,
+  estimateReadTime,
+  countWords,
+} from '../../src/feed/index.js';
+
+config();
+
+interface CLIOptions {
+  url?: string;
+  publication?: string;
+  json?: boolean;
+  verbose?: boolean;
+}
+
+function parseArgs(): CLIOptions {
+  const args = process.argv.slice(2);
+  const options: CLIOptions = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const value = args[i + 1];
+
+    switch (arg) {
+      case '--url':
+      case '-u':
+        options.url = value;
+        i++;
+        break;
+      case '--publication':
+      case '-p':
+        options.publication = value;
+        i++;
+        break;
+      case '--json':
+      case '-j':
+        options.json = true;
+        break;
+      case '--verbose':
+      case '-v':
+        options.verbose = true;
+        break;
+    }
+  }
+
+  return options;
+}
+
+function printUsage(): void {
+  console.info(`
+Feed Fetch Tool - Fetch and parse Substack RSS feeds
+
+Usage:
+  npm run feed:fetch -- --url <feed-url>
+  npm run feed:fetch -- --publication <slug>
+  npm run feed:fetch -- -p <slug> --json
+
+Options:
+  --url, -u         Full feed URL
+  --publication, -p Publication slug (e.g., "example" for example.substack.com)
+  --json, -j        Output as JSON
+  --verbose, -v     Show detailed output
+
+Examples:
+  npm run feed:fetch -- -p heathercoxrichardson
+  npm run feed:fetch -- --url https://noahpinion.substack.com/feed
+  npm run feed:fetch -- -p astralcodexten --json
+`);
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+
+  // Get feed URL
+  let feedUrl: string;
+  if (options.url) {
+    feedUrl = options.url;
+  } else if (options.publication) {
+    feedUrl = getSubstackFeedUrl(options.publication);
+  } else {
+    printUsage();
+    process.exit(1);
+  }
+
+  console.info(`Fetching feed: ${feedUrl}`);
+
+  const result = await fetchFeed(feedUrl);
+
+  if (!result.success || !result.feed) {
+    console.error(`Error: ${result.error}`);
+    process.exit(1);
+  }
+
+  const feed = result.feed;
+
+  if (options.json) {
+    // JSON output
+    const output = {
+      title: feed.title,
+      description: feed.description,
+      link: feed.link,
+      feedUrl: feed.feedUrl,
+      author: feed.author,
+      lastBuildDate: feed.lastBuildDate?.toISOString(),
+      itemCount: feed.items.length,
+      items: feed.items.map((item) => ({
+        title: item.title,
+        url: item.url,
+        publishedAt: item.publishedAt.toISOString(),
+        author: item.author,
+        wordCount: countWords(item.contentHtml),
+        readTimeMinutes: estimateReadTime(item.contentHtml),
+        summary: item.summary?.slice(0, 200),
+        imageUrl: item.imageUrl,
+      })),
+    };
+    console.info(JSON.stringify(output, null, 2));
+  } else {
+    // Human-readable output
+    console.info(`\n📰 ${feed.title}`);
+    if (feed.description) {
+      console.info(`   ${feed.description.slice(0, 100)}${feed.description.length > 100 ? '...' : ''}`);
+    }
+    console.info(`   ${feed.link}`);
+    console.info(`   ${feed.items.length} articles found\n`);
+
+    console.info('Recent articles:');
+    console.info('─'.repeat(60));
+
+    for (const item of feed.items.slice(0, 10)) {
+      const readTime = estimateReadTime(item.contentHtml);
+      const wordCount = countWords(item.contentHtml);
+      const date = item.publishedAt.toLocaleDateString();
+
+      console.info(`\n📄 ${item.title}`);
+      console.info(`   📅 ${date} | ⏱️ ${readTime} min read | 📝 ${wordCount} words`);
+      console.info(`   🔗 ${item.url}`);
+
+      if (options.verbose && item.summary) {
+        console.info(`   ${item.summary.slice(0, 150)}...`);
+      }
+    }
+
+    if (feed.items.length > 10) {
+      console.info(`\n... and ${feed.items.length - 10} more articles`);
+    }
+
+    console.info(`\n${result.cached ? '(from cache)' : '(fetched fresh)'}`);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('Error:', err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- RSS/Atom feed parser with rate limiting and caching
- CLI tool for fetching Substack feeds
- Extracts content, metadata, read time estimates

## Changes
- `src/feed/` - Feed parsing module (types, parser, fetcher)
- `tools/feed/fetch.ts` - CLI tool
- `src/feed/parser.test.ts` - 10 unit tests

## Test plan
- [x] TypeScript compiles without errors
- [x] ESLint passes with zero warnings
- [x] Unit tests pass (10 tests)
- [x] Manual: `npm run feed:fetch -- -p heathercoxrichardson` works

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)