### PR TITLE
Add article markdown converter and filesystem storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "hex-index",
       "version": "0.1.0",
       "dependencies": {
+        "@types/turndown": "^5.0.6",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "fast-xml-parser": "^5.3.3",
         "pg": "^8.13.0",
+        "turndown": "^7.2.2",
         "zod": "^4.1.13"
       },
       "bin": {
@@ -812,6 +814,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@playwright/test": {
       "version": "1.57.0",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
@@ -1294,6 +1302,12 @@
         "@types/http-errors": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.49.0",
@@ -4229,6 +4243,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
+      "integrity": "sha512-1F7db8BiExOKxjSMU2b7if62D/XOyQyZbPKq/nUwopfgnHlqXHqQ0lvfUTeUIr1lZJzOPFn43dODyMSIfvWRKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
     "prepare": "husky || true"
   },
   "dependencies": {
+    "@types/turndown": "^5.0.6",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "fast-xml-parser": "^5.3.3",
     "pg": "^8.13.0",
+    "turndown": "^7.2.2",
     "zod": "^4.1.13"
   },
   "devDependencies": {

--- a/src/markdown/converter.test.ts
+++ b/src/markdown/converter.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for markdown converter
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  htmlToMarkdown,
+  extractLinks,
+  generateFrontmatter,
+  slugify,
+} from './converter.js';
+
+describe('htmlToMarkdown', () => {
+  it('converts paragraphs', () => {
+    const html = '<p>Hello world</p>';
+    expect(htmlToMarkdown(html)).toBe('Hello world');
+  });
+
+  it('converts headings', () => {
+    const html = '<h1>Title</h1><h2>Subtitle</h2><h3>Section</h3>';
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('# Title');
+    expect(md).toContain('## Subtitle');
+    expect(md).toContain('### Section');
+  });
+
+  it('converts bold and italic', () => {
+    const html = '<p><strong>bold</strong> and <em>italic</em></p>';
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('**bold**');
+    expect(md).toContain('*italic*');
+  });
+
+  it('converts links', () => {
+    const html = '<p>Check out <a href="https://example.com">this link</a></p>';
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('[this link](https://example.com)');
+  });
+
+  it('converts lists', () => {
+    const html = '<ul><li>Item 1</li><li>Item 2</li></ul>';
+    const md = htmlToMarkdown(html);
+    // Turndown adds some spacing, so check for the essential parts
+    expect(md).toMatch(/-\s+Item 1/);
+    expect(md).toMatch(/-\s+Item 2/);
+  });
+
+  it('converts code blocks', () => {
+    const html = '<pre><code class="language-javascript">const x = 1;</code></pre>';
+    const md = htmlToMarkdown(html);
+    expect(md).toContain('```javascript');
+    expect(md).toContain('const x = 1;');
+    expect(md).toContain('```');
+  });
+
+  it('removes empty paragraphs', () => {
+    const html = '<p>Hello</p><p></p><p>World</p>';
+    const md = htmlToMarkdown(html);
+    expect(md).not.toMatch(/\n{4,}/);
+  });
+});
+
+describe('extractLinks', () => {
+  it('extracts links from HTML', () => {
+    const html = '<p>Check out <a href="https://example.com">this link</a></p>';
+    const links = extractLinks(html, 'https://test.substack.com/p/article');
+
+    expect(links).toHaveLength(1);
+    expect(links[0].url).toBe('https://example.com');
+    expect(links[0].text).toBe('this link');
+    expect(links[0].type).toBe('external');
+  });
+
+  it('categorizes internal links', () => {
+    const html = '<a href="https://test.substack.com/p/other-article">link</a>';
+    const links = extractLinks(html, 'https://test.substack.com/p/article');
+
+    expect(links[0].type).toBe('internal');
+  });
+
+  it('categorizes cross-publication links', () => {
+    const html = '<a href="https://other.substack.com/p/article">link</a>';
+    const links = extractLinks(html, 'https://test.substack.com/p/article');
+
+    expect(links[0].type).toBe('cross-publication');
+    expect(links[0].targetSlug).toBe('other/article');
+  });
+
+  it('ignores mailto and anchor links', () => {
+    const html = '<a href="mailto:test@test.com">email</a><a href="#section">anchor</a>';
+    const links = extractLinks(html, 'https://test.substack.com/p/article');
+
+    expect(links).toHaveLength(0);
+  });
+});
+
+describe('generateFrontmatter', () => {
+  it('generates valid YAML frontmatter', () => {
+    const metadata = {
+      title: 'Test Article',
+      author: 'Test Author',
+      publication: 'Test Publication',
+      publication_slug: 'test-publication',
+      published_at: '2025-12-13T00:00:00.000Z',
+      source_url: 'https://test.substack.com/p/test-article',
+      word_count: 1000,
+      estimated_read_time: 5,
+    };
+
+    const frontmatter = generateFrontmatter(metadata);
+
+    expect(frontmatter).toContain('---');
+    expect(frontmatter).toContain('title: "Test Article"');
+    expect(frontmatter).toContain('author: "Test Author"');
+    expect(frontmatter).toContain('word_count: 1000');
+    expect(frontmatter).toContain('estimated_read_time: 5');
+  });
+
+  it('escapes special characters in strings', () => {
+    const metadata = {
+      title: 'Article: "With Quotes"',
+      author: 'Author',
+      publication: 'Pub',
+      publication_slug: 'pub',
+      published_at: '2025-12-13T00:00:00.000Z',
+      source_url: 'https://test.substack.com/p/test',
+      word_count: 100,
+      estimated_read_time: 1,
+    };
+
+    const frontmatter = generateFrontmatter(metadata);
+    expect(frontmatter).toContain('title: "Article: \\"With Quotes\\""');
+  });
+
+  it('includes tags when present', () => {
+    const metadata = {
+      title: 'Test',
+      author: 'Author',
+      publication: 'Pub',
+      publication_slug: 'pub',
+      published_at: '2025-12-13T00:00:00.000Z',
+      source_url: 'https://test.substack.com/p/test',
+      word_count: 100,
+      estimated_read_time: 1,
+      tags: { topic: 'economics', subtopic: 'inflation' },
+    };
+
+    const frontmatter = generateFrontmatter(metadata);
+    expect(frontmatter).toContain('tags:');
+    expect(frontmatter).toContain('topic: "economics"');
+    expect(frontmatter).toContain('subtopic: "inflation"');
+  });
+});
+
+describe('slugify', () => {
+  it('converts title to slug', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('removes special characters', () => {
+    expect(slugify("Hello, World! It's great")).toBe('hello-world-its-great');
+  });
+
+  it('handles multiple spaces and dashes', () => {
+    expect(slugify('Hello   World---Test')).toBe('hello-world-test');
+  });
+
+  it('truncates long titles', () => {
+    const longTitle = 'a'.repeat(150);
+    expect(slugify(longTitle).length).toBeLessThanOrEqual(100);
+  });
+});

--- a/src/markdown/converter.ts
+++ b/src/markdown/converter.ts
@@ -1,0 +1,222 @@
+/**
+ * HTML to Markdown converter
+ * Handles Substack-specific HTML patterns
+ */
+
+import TurndownService from 'turndown';
+import {
+  ArticleMetadata,
+  ConvertedArticle,
+  ExtractedLink,
+} from './types.js';
+import { FeedItem } from '../feed/types.js';
+import { countWords, estimateReadTime } from '../feed/parser.js';
+
+// Configure Turndown for clean markdown output
+const turndown = new TurndownService({
+  headingStyle: 'atx',
+  codeBlockStyle: 'fenced',
+  bulletListMarker: '-',
+  emDelimiter: '*',
+  strongDelimiter: '**',
+  linkStyle: 'inlined',
+});
+
+// Custom rule for Substack image captions
+turndown.addRule('substackCaption', {
+  filter: (node) => {
+    return node.nodeName === 'FIGCAPTION' ||
+      (node.nodeName === 'DIV' && node.classList?.contains('image-caption'));
+  },
+  replacement: (content) => {
+    return content ? `\n*${content.trim()}*\n` : '';
+  },
+});
+
+// Custom rule for Substack buttons/CTAs (remove them)
+turndown.addRule('substackCTA', {
+  filter: (node) => {
+    const classList = node.classList;
+    return classList?.contains('subscribe-widget') ||
+      classList?.contains('subscription-widget') ||
+      classList?.contains('button-wrapper');
+  },
+  replacement: () => '',
+});
+
+// Custom rule for code blocks with language hints
+turndown.addRule('codeBlock', {
+  filter: (node) => {
+    return node.nodeName === 'PRE' && node.querySelector('code') !== null;
+  },
+  replacement: (_content, node) => {
+    const code = (node).querySelector('code');
+    if (!code) {return '';}
+
+    const text = code.textContent ?? '';
+    const lang = code.className?.match(/language-(\w+)/)?.[1] ?? '';
+
+    return `\n\`\`\`${lang}\n${text}\n\`\`\`\n`;
+  },
+});
+
+/**
+ * Convert HTML to Markdown
+ */
+export function htmlToMarkdown(html: string): string {
+  // Pre-process HTML to handle common issues
+  const processed = html
+    // Remove empty paragraphs
+    .replace(/<p>\s*<\/p>/gi, '')
+    // Convert Substack dividers
+    .replace(/<hr\s*\/?>/gi, '\n---\n')
+    // Clean up excessive whitespace
+    .replace(/\n{3,}/g, '\n\n');
+
+  return turndown.turndown(processed).trim();
+}
+
+/**
+ * Extract all links from HTML content
+ */
+export function extractLinks(html: string, sourceUrl: string): ExtractedLink[] {
+  const links: ExtractedLink[] = [];
+
+  // Simple regex to extract links - works for our RSS content
+  const linkRegex = /<a[^>]*href=["']([^"']+)["'][^>]*>([^<]*)<\/a>/gi;
+  let match;
+
+  while ((match = linkRegex.exec(html)) !== null) {
+    const url = match[1];
+    const text = match[2].trim();
+
+    // Skip empty links, anchors, mailto, etc.
+    if (!url || url.startsWith('#') || url.startsWith('mailto:') || url.startsWith('javascript:')) {
+      continue;
+    }
+
+    const link: ExtractedLink = {
+      url,
+      text,
+      type: categorizeLink(url, sourceUrl),
+    };
+
+    // Extract slug for Substack links
+    const slugMatch = url.match(/([a-z0-9-]+)\.substack\.com\/p\/([a-z0-9-]+)/i);
+    if (slugMatch) {
+      link.targetSlug = `${slugMatch[1]}/${slugMatch[2]}`;
+    }
+
+    links.push(link);
+  }
+
+  return links;
+}
+
+/**
+ * Categorize a link as internal, cross-publication, or external
+ */
+function categorizeLink(linkUrl: string, sourceUrl: string): 'internal' | 'cross-publication' | 'external' {
+  try {
+    const link = new URL(linkUrl);
+    const source = new URL(sourceUrl);
+
+    // Same host = internal
+    if (link.host === source.host) {
+      return 'internal';
+    }
+
+    // Another Substack = cross-publication
+    if (link.host.endsWith('.substack.com')) {
+      return 'cross-publication';
+    }
+
+    // Everything else = external
+    return 'external';
+  } catch {
+    // If URL parsing fails, assume external
+    return 'external';
+  }
+}
+
+/**
+ * Generate YAML frontmatter from metadata
+ */
+export function generateFrontmatter(metadata: ArticleMetadata): string {
+  const lines = [
+    '---',
+    `title: "${escapeYamlString(metadata.title)}"`,
+    `author: "${escapeYamlString(metadata.author)}"`,
+    `publication: "${escapeYamlString(metadata.publication)}"`,
+    `publication_slug: "${metadata.publication_slug}"`,
+    `published_at: "${metadata.published_at}"`,
+    `source_url: "${metadata.source_url}"`,
+    `word_count: ${metadata.word_count}`,
+    `estimated_read_time: ${metadata.estimated_read_time}`,
+  ];
+
+  if (metadata.tags && Object.keys(metadata.tags).length > 0) {
+    lines.push('tags:');
+    for (const [key, value] of Object.entries(metadata.tags)) {
+      lines.push(`  ${key}: "${escapeYamlString(value)}"`);
+    }
+  }
+
+  lines.push('---');
+  return lines.join('\n');
+}
+
+/**
+ * Escape special characters in YAML strings
+ */
+function escapeYamlString(str: string): string {
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n');
+}
+
+/**
+ * Generate a slug from a title
+ */
+export function slugify(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 100);
+}
+
+/**
+ * Convert a feed item to a ConvertedArticle
+ */
+export function convertFeedItem(
+  item: FeedItem,
+  publication: { name: string; slug: string }
+): ConvertedArticle {
+  const markdown = htmlToMarkdown(item.contentHtml);
+  const links = extractLinks(item.contentHtml, item.url);
+
+  const metadata: ArticleMetadata = {
+    title: item.title,
+    author: item.author,
+    publication: publication.name,
+    publication_slug: publication.slug,
+    published_at: item.publishedAt.toISOString(),
+    source_url: item.url,
+    word_count: countWords(item.contentHtml),
+    estimated_read_time: estimateReadTime(item.contentHtml),
+  };
+
+  return { metadata, markdown, links };
+}
+
+/**
+ * Generate full markdown file content with frontmatter
+ */
+export function generateMarkdownFile(article: ConvertedArticle): string {
+  const frontmatter = generateFrontmatter(article.metadata);
+  return `${frontmatter}\n\n${article.markdown}`;
+}

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Markdown module exports
+ */
+
+export * from './types.js';
+export * from './converter.js';
+export * from './storage.js';

--- a/src/markdown/storage.ts
+++ b/src/markdown/storage.ts
@@ -1,0 +1,218 @@
+/**
+ * Filesystem storage for articles
+ * Stores markdown files in library/{publication-slug}/{article-slug}.md
+ */
+
+import { mkdir, writeFile, readFile, readdir, stat } from 'fs/promises';
+import { join, dirname } from 'path';
+import { existsSync } from 'fs';
+import {
+  ConvertedArticle,
+  StorageResult,
+  LibraryConfig,
+  DEFAULT_LIBRARY_CONFIG,
+} from './types.js';
+import { generateMarkdownFile, slugify } from './converter.js';
+
+/**
+ * Ensure directory exists
+ */
+async function ensureDir(dir: string): Promise<void> {
+  if (!existsSync(dir)) {
+    await mkdir(dir, { recursive: true });
+  }
+}
+
+/**
+ * Get the storage path for an article
+ */
+export function getArticlePath(
+  publicationSlug: string,
+  articleSlug: string,
+  config: LibraryConfig = DEFAULT_LIBRARY_CONFIG
+): string {
+  return join(config.baseDir, publicationSlug, `${articleSlug}.md`);
+}
+
+/**
+ * Store an article to the filesystem
+ */
+export async function storeArticle(
+  article: ConvertedArticle,
+  config: LibraryConfig = DEFAULT_LIBRARY_CONFIG
+): Promise<StorageResult> {
+  try {
+    const articleSlug = slugify(article.metadata.title);
+    const path = getArticlePath(article.metadata.publication_slug, articleSlug, config);
+
+    // Ensure directory exists
+    await ensureDir(dirname(path));
+
+    // Generate and write markdown
+    const content = generateMarkdownFile(article);
+    await writeFile(path, content, 'utf-8');
+
+    return { success: true, path };
+  } catch (err) {
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Check if an article already exists
+ */
+export function articleExists(
+  publicationSlug: string,
+  articleSlug: string,
+  config: LibraryConfig = DEFAULT_LIBRARY_CONFIG
+): boolean {
+  const path = getArticlePath(publicationSlug, articleSlug, config);
+  return existsSync(path);
+}
+
+/**
+ * Read an article from the filesystem
+ */
+export async function readArticle(
+  publicationSlug: string,
+  articleSlug: string,
+  config: LibraryConfig = DEFAULT_LIBRARY_CONFIG
+): Promise<string | null> {
+  const path = getArticlePath(publicationSlug, articleSlug, config);
+  try {
+    return await readFile(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List all publications in the library
+ */
+export async function listPublications(
+  config: LibraryConfig = DEFAULT_LIBRARY_CONFIG
+): Promise<string[]> {
+  try {
+    const entries = await readdir(config.baseDir, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * List all articles in a publication
+ */
+export async function listArticles(
+  publicationSlug: string,
+  config: LibraryConfig = DEFAULT_LIBRARY_CONFIG
+): Promise<string[]> {
+  try {
+    const pubDir = join(config.baseDir, publicationSlug);
+    const entries = await readdir(pubDir);
+    return entries
+      .filter((e) => e.endsWith('.md'))
+      .map((e) => e.replace('.md', ''))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get library statistics
+ */
+export async function getLibraryStats(
+  config: LibraryConfig = DEFAULT_LIBRARY_CONFIG
+): Promise<{
+  publications: number;
+  articles: number;
+  totalSize: number;
+}> {
+  let publications = 0;
+  let articles = 0;
+  let totalSize = 0;
+
+  try {
+    const pubs = await listPublications(config);
+    publications = pubs.length;
+
+    for (const pub of pubs) {
+      const arts = await listArticles(pub, config);
+      articles += arts.length;
+
+      for (const art of arts) {
+        const path = getArticlePath(pub, art, config);
+        const stats = await stat(path);
+        totalSize += stats.size;
+      }
+    }
+  } catch {
+    // Ignore errors
+  }
+
+  return { publications, articles, totalSize };
+}
+
+/**
+ * Parse frontmatter from a markdown file
+ */
+export function parseFrontmatter(markdown: string): Record<string, unknown> | null {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) {return null;}
+
+  const yaml = match[1];
+  const result: Record<string, unknown> = {};
+
+  // Simple YAML parser for our frontmatter format
+  const lines = yaml.split('\n');
+  let currentKey: string | null = null;
+  let currentObject: Record<string, string> | null = null;
+
+  for (const line of lines) {
+    // Nested object entry
+    if (line.startsWith('  ') && currentKey) {
+      const match = line.match(/^\s+(\w+):\s*"?([^"]*)"?$/);
+      if (match && currentObject) {
+        currentObject[match[1]] = match[2];
+      }
+      continue;
+    }
+
+    // Top-level entry
+    const keyMatch = line.match(/^(\w+):\s*(.*)$/);
+    if (keyMatch) {
+      const key = keyMatch[1];
+      let value: unknown = keyMatch[2];
+
+      // Handle quoted strings
+      if (typeof value === 'string' && value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\n/g, '\n');
+      }
+
+      // Handle numbers
+      if (typeof value === 'string' && /^\d+$/.test(value)) {
+        value = parseInt(value, 10);
+      }
+
+      // Check if this is a nested object start
+      if (value === '') {
+        currentKey = key;
+        currentObject = {};
+        result[key] = currentObject;
+      } else {
+        result[key] = value;
+        currentKey = null;
+        currentObject = null;
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/markdown/types.ts
+++ b/src/markdown/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Types for markdown conversion and storage
+ */
+
+export interface ArticleMetadata {
+  title: string;
+  author: string;
+  publication: string;
+  publication_slug: string;
+  published_at: string;
+  source_url: string;
+  word_count: number;
+  estimated_read_time: number;
+  tags?: Record<string, string>;
+}
+
+export interface ConvertedArticle {
+  metadata: ArticleMetadata;
+  markdown: string;
+  links: ExtractedLink[];
+}
+
+export interface ExtractedLink {
+  url: string;
+  text: string;
+  context?: string;
+  type: 'internal' | 'cross-publication' | 'external';
+  targetSlug?: string; // For internal/cross-publication links
+}
+
+export interface StorageResult {
+  success: boolean;
+  path?: string;
+  error?: string;
+}
+
+export interface LibraryConfig {
+  /** Base directory for library storage (default: ./library) */
+  baseDir: string;
+}
+
+export const DEFAULT_LIBRARY_CONFIG: LibraryConfig = {
+  baseDir: './library',
+};


### PR DESCRIPTION
## Summary
- HTML to Markdown conversion for Substack content
- Filesystem storage with organized directory structure
- Link extraction for article relationship tracking

## Changes
- `src/markdown/` - Markdown conversion module
- 18 unit tests for converter functionality

## Test plan
- [x] TypeScript compiles without errors
- [x] ESLint passes with zero warnings
- [x] Unit tests pass (18 tests)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)