### PR TITLE
feat: add article ingestion pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "gh:issue": "tsx tools/github/create-issue.ts",
     "gh:rate-limit": "tsx tools/github/check-rate-limit.ts",
     "feed:fetch": "tsx tools/feed/fetch.ts",
+    "ingest": "tsx tools/ingest/run.ts",
     "prepare": "husky || true"
   },
   "dependencies": {

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Ingestion module exports
+ */
+
+export * from './types.js';
+export * from './pipeline.js';

--- a/src/ingestion/pipeline.test.ts
+++ b/src/ingestion/pipeline.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for article ingestion pipeline
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { processArticle, ingestSource } from './pipeline.js';
+import { FeedItem, Feed, FetchResult } from '../feed/types.js';
+import { IngestionSource, IngestionOptions } from './types.js';
+import * as storage from '../markdown/storage.js';
+import * as fetcher from '../feed/fetcher.js';
+
+// Mock the modules
+vi.mock('../markdown/storage.js', () => ({
+  articleExists: vi.fn(),
+  storeArticle: vi.fn(),
+}));
+
+vi.mock('../feed/fetcher.js', () => ({
+  fetchFeed: vi.fn(),
+}));
+
+// Mock the parser functions used by converter
+vi.mock('../feed/parser.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../feed/parser.js')>();
+  return {
+    ...actual,
+    countWords: vi.fn(() => 100),
+    estimateReadTime: vi.fn(() => 1),
+  };
+});
+
+const mockFeedItem: FeedItem = {
+  title: 'Test Article',
+  url: 'https://test.substack.com/p/test-article',
+  author: 'Test Author',
+  publishedAt: new Date('2025-01-01'),
+  contentHtml: '<p>Test content</p>',
+};
+
+const mockSource: IngestionSource = {
+  name: 'Test Publication',
+  slug: 'test-publication',
+  feedUrl: 'https://test.substack.com/feed',
+};
+
+const mockOptions: IngestionOptions = {
+  libraryDir: './test-library',
+  fetchDelayMs: 0,
+  dryRun: false,
+  verbose: false,
+};
+
+describe('processArticle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips existing articles', async () => {
+    vi.mocked(storage.articleExists).mockReturnValue(true);
+
+    const result = await processArticle(mockFeedItem, mockSource, mockOptions);
+
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toBe('already exists');
+    expect(storage.storeArticle).not.toHaveBeenCalled();
+  });
+
+  it('skips articles before since date', async () => {
+    vi.mocked(storage.articleExists).mockReturnValue(false);
+
+    const optionsWithSince = {
+      ...mockOptions,
+      since: new Date('2025-06-01'),
+    };
+
+    const result = await processArticle(
+      mockFeedItem,
+      mockSource,
+      optionsWithSince
+    );
+
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toContain('published before');
+  });
+
+  it('converts and stores new articles', async () => {
+    vi.mocked(storage.articleExists).mockReturnValue(false);
+    vi.mocked(storage.storeArticle).mockResolvedValue({
+      success: true,
+      path: './test-library/test-publication/test-article.md',
+    });
+
+    const result = await processArticle(mockFeedItem, mockSource, mockOptions);
+
+    expect(result.skipped).toBe(false);
+    expect(result.converted).toBeDefined();
+    expect(result.stored?.success).toBe(true);
+    expect(storage.storeArticle).toHaveBeenCalled();
+  });
+
+  it('does not store in dry run mode', async () => {
+    vi.mocked(storage.articleExists).mockReturnValue(false);
+
+    const dryRunOptions = { ...mockOptions, dryRun: true };
+    const result = await processArticle(
+      mockFeedItem,
+      mockSource,
+      dryRunOptions
+    );
+
+    expect(result.skipped).toBe(false);
+    expect(result.converted).toBeDefined();
+    expect(result.stored).toBeUndefined();
+    expect(storage.storeArticle).not.toHaveBeenCalled();
+  });
+
+  it('reports storage errors', async () => {
+    vi.mocked(storage.articleExists).mockReturnValue(false);
+    vi.mocked(storage.storeArticle).mockResolvedValue({
+      success: false,
+      error: 'Permission denied',
+    });
+
+    const result = await processArticle(mockFeedItem, mockSource, mockOptions);
+
+    expect(result.skipped).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error?.phase).toBe('store');
+    expect(result.error?.error).toBe('Permission denied');
+  });
+
+  it('overrides author when specified in source', async () => {
+    vi.mocked(storage.articleExists).mockReturnValue(false);
+    vi.mocked(storage.storeArticle).mockResolvedValue({
+      success: true,
+      path: './test.md',
+    });
+
+    const sourceWithAuthor = {
+      ...mockSource,
+      author: 'Custom Author',
+    };
+
+    const result = await processArticle(
+      mockFeedItem,
+      sourceWithAuthor,
+      mockOptions
+    );
+
+    expect(result.converted?.metadata.author).toBe('Custom Author');
+  });
+});
+
+// Helper to create mock Feed
+const createMockFeed = (items: FeedItem[]): Feed => ({
+  title: 'Test Feed',
+  description: 'Test',
+  link: 'https://test.substack.com',
+  feedUrl: 'https://test.substack.com/feed',
+  items,
+});
+
+// Helper to create mock FetchResult
+const createSuccessFetchResult = (feed: Feed): FetchResult => ({
+  success: true,
+  feed,
+  cached: false,
+  fetchedAt: new Date(),
+});
+
+const createFailureFetchResult = (error: string): FetchResult => ({
+  success: false,
+  error,
+  fetchedAt: new Date(),
+});
+
+describe('ingestSource', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns error on fetch failure', async () => {
+    vi.mocked(fetcher.fetchFeed).mockResolvedValue(
+      createFailureFetchResult('Network error')
+    );
+
+    const result = await ingestSource(mockSource, mockOptions);
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].phase).toBe('fetch');
+  });
+
+  it('processes all items in feed', async () => {
+    const feed = createMockFeed([
+      mockFeedItem,
+      { ...mockFeedItem, title: 'Article 2' },
+    ]);
+    vi.mocked(fetcher.fetchFeed).mockResolvedValue(
+      createSuccessFetchResult(feed)
+    );
+    vi.mocked(storage.articleExists).mockReturnValue(false);
+    vi.mocked(storage.storeArticle).mockResolvedValue({
+      success: true,
+      path: './test.md',
+    });
+
+    const result = await ingestSource(mockSource, mockOptions);
+
+    expect(result.success).toBe(true);
+    expect(result.articlesProcessed).toBe(2);
+    expect(result.articlesStored).toBe(2);
+  });
+
+  it('respects maxArticlesPerPub limit', async () => {
+    const feed = createMockFeed([
+      mockFeedItem,
+      { ...mockFeedItem, title: 'Article 2' },
+      { ...mockFeedItem, title: 'Article 3' },
+    ]);
+    vi.mocked(fetcher.fetchFeed).mockResolvedValue(
+      createSuccessFetchResult(feed)
+    );
+    vi.mocked(storage.articleExists).mockReturnValue(false);
+    vi.mocked(storage.storeArticle).mockResolvedValue({
+      success: true,
+      path: './test.md',
+    });
+
+    const result = await ingestSource(mockSource, {
+      ...mockOptions,
+      maxArticlesPerPub: 2,
+    });
+
+    expect(result.articlesProcessed).toBe(2);
+  });
+
+  it('counts skipped articles correctly', async () => {
+    const feed = createMockFeed([
+      mockFeedItem,
+      { ...mockFeedItem, title: 'Article 2' },
+    ]);
+    vi.mocked(fetcher.fetchFeed).mockResolvedValue(
+      createSuccessFetchResult(feed)
+    );
+    // First article exists, second doesn't
+    vi.mocked(storage.articleExists)
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+    vi.mocked(storage.storeArticle).mockResolvedValue({
+      success: true,
+      path: './test.md',
+    });
+
+    const result = await ingestSource(mockSource, mockOptions);
+
+    expect(result.articlesProcessed).toBe(2);
+    expect(result.articlesSkipped).toBe(1);
+    expect(result.articlesStored).toBe(1);
+  });
+});

--- a/src/ingestion/pipeline.ts
+++ b/src/ingestion/pipeline.ts
@@ -1,0 +1,271 @@
+/**
+ * Article ingestion pipeline
+ * Orchestrates: fetch RSS → parse → convert → store
+ */
+
+import { fetchFeed } from '../feed/fetcher.js';
+import { FeedItem } from '../feed/types.js';
+import { convertFeedItem, slugify } from '../markdown/converter.js';
+import { storeArticle, articleExists } from '../markdown/storage.js';
+import { LibraryConfig } from '../markdown/types.js';
+import {
+  IngestionSource,
+  IngestionOptions,
+  IngestionResult,
+  IngestionError,
+  BatchIngestionResult,
+  ArticleProcessResult,
+  DEFAULT_INGESTION_OPTIONS,
+} from './types.js';
+
+/**
+ * Process a single article from a feed item
+ */
+export async function processArticle(
+  item: FeedItem,
+  source: IngestionSource,
+  options: IngestionOptions
+): Promise<ArticleProcessResult> {
+  const config: LibraryConfig = { baseDir: options.libraryDir };
+  const articleSlug = slugify(item.title);
+
+  // Check if article already exists
+  if (articleExists(source.slug, articleSlug, config)) {
+    return {
+      item,
+      skipped: true,
+      skipReason: 'already exists',
+    };
+  }
+
+  // Check date filter
+  if (options.since && item.publishedAt < options.since) {
+    return {
+      item,
+      skipped: true,
+      skipReason: `published before ${options.since.toISOString()}`,
+    };
+  }
+
+  try {
+    // Convert to markdown
+    const converted = convertFeedItem(item, {
+      name: source.name,
+      slug: source.slug,
+    });
+
+    // Override author if specified in source
+    if (source.author) {
+      converted.metadata.author = source.author;
+    }
+
+    // Dry run - don't store
+    if (options.dryRun) {
+      return {
+        item,
+        converted,
+        skipped: false,
+      };
+    }
+
+    // Store to filesystem
+    const stored = await storeArticle(converted, config);
+
+    if (!stored.success) {
+      return {
+        item,
+        converted,
+        skipped: false,
+        error: {
+          articleTitle: item.title,
+          articleUrl: item.url,
+          error: stored.error ?? 'Unknown storage error',
+          phase: 'store',
+        },
+      };
+    }
+
+    return {
+      item,
+      converted,
+      stored,
+      skipped: false,
+    };
+  } catch (err) {
+    return {
+      item,
+      skipped: false,
+      error: {
+        articleTitle: item.title,
+        articleUrl: item.url,
+        error: err instanceof Error ? err.message : String(err),
+        phase: 'convert',
+      },
+    };
+  }
+}
+
+/**
+ * Ingest articles from a single source
+ */
+export async function ingestSource(
+  source: IngestionSource,
+  options: Partial<IngestionOptions> = {}
+): Promise<IngestionResult> {
+  const opts = { ...DEFAULT_INGESTION_OPTIONS, ...options };
+  const startTime = Date.now();
+  const errors: IngestionError[] = [];
+  let articlesProcessed = 0;
+  let articlesSkipped = 0;
+  let articlesStored = 0;
+
+  if (opts.verbose) {
+    console.info(`Ingesting from ${source.name} (${source.feedUrl})`);
+  }
+
+  // Fetch the feed (fetcher already parses)
+  const fetchResult = await fetchFeed(source.feedUrl, {
+    delayMs: opts.fetchDelayMs,
+  });
+
+  if (!fetchResult.success || !fetchResult.feed) {
+    return {
+      source,
+      success: false,
+      articlesProcessed: 0,
+      articlesSkipped: 0,
+      articlesStored: 0,
+      errors: [
+        {
+          error: fetchResult.error ?? 'Failed to fetch feed',
+          phase: 'fetch',
+        },
+      ],
+      duration: Date.now() - startTime,
+    };
+  }
+
+  // Get items from parsed feed
+  let items: FeedItem[] = fetchResult.feed.items;
+
+  // Limit articles if specified
+  if (opts.maxArticlesPerPub && items.length > opts.maxArticlesPerPub) {
+    items = items.slice(0, opts.maxArticlesPerPub);
+  }
+
+  // Process each article
+  for (const item of items) {
+    articlesProcessed++;
+
+    const result = await processArticle(item, source, opts);
+
+    if (result.skipped) {
+      articlesSkipped++;
+      if (opts.verbose) {
+        console.info(`  Skipped: ${item.title} (${result.skipReason})`);
+      }
+    } else if (result.error) {
+      errors.push(result.error);
+      if (opts.verbose) {
+        console.info(`  Error: ${item.title} - ${result.error.error}`);
+      }
+    } else if (result.stored?.success) {
+      articlesStored++;
+      if (opts.verbose) {
+        console.info(`  Stored: ${item.title} → ${result.stored.path}`);
+      }
+    } else if (opts.dryRun) {
+      articlesStored++; // Count as stored in dry run
+      if (opts.verbose) {
+        console.info(`  Would store: ${item.title}`);
+      }
+    }
+  }
+
+  return {
+    source,
+    success: errors.length === 0,
+    articlesProcessed,
+    articlesSkipped,
+    articlesStored,
+    errors,
+    duration: Date.now() - startTime,
+  };
+}
+
+/**
+ * Ingest articles from multiple sources
+ */
+export async function ingestBatch(
+  sources: IngestionSource[],
+  options: Partial<IngestionOptions> = {}
+): Promise<BatchIngestionResult> {
+  const opts = { ...DEFAULT_INGESTION_OPTIONS, ...options };
+  const startTime = Date.now();
+  const results: IngestionResult[] = [];
+
+  for (const source of sources) {
+    const result = await ingestSource(source, opts);
+    results.push(result);
+
+    // Delay between sources
+    if (sources.indexOf(source) < sources.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, opts.fetchDelayMs));
+    }
+  }
+
+  const successfulSources = results.filter((r) => r.success).length;
+  const failedSources = results.filter((r) => !r.success).length;
+  const totalArticlesProcessed = results.reduce(
+    (sum, r) => sum + r.articlesProcessed,
+    0
+  );
+  const totalArticlesStored = results.reduce(
+    (sum, r) => sum + r.articlesStored,
+    0
+  );
+  const totalErrors = results.reduce((sum, r) => sum + r.errors.length, 0);
+
+  return {
+    totalSources: sources.length,
+    successfulSources,
+    failedSources,
+    totalArticlesProcessed,
+    totalArticlesStored,
+    totalErrors,
+    results,
+    duration: Date.now() - startTime,
+  };
+}
+
+/**
+ * Load sources from a JSON file
+ */
+export async function loadSourcesFromFile(
+  filePath: string
+): Promise<IngestionSource[]> {
+  const { readFile } = await import('fs/promises');
+  const content = await readFile(filePath, 'utf-8');
+  const data = JSON.parse(content) as {
+    publications?: Array<{
+      name: string;
+      slug: string;
+      feedUrl?: string;
+      url?: string;
+      author?: string;
+    }>;
+  };
+
+  if (!data.publications || !Array.isArray(data.publications)) {
+    throw new Error('Invalid sources file: expected { publications: [...] }');
+  }
+
+  return data.publications
+    .filter((pub) => pub.feedUrl ?? pub.url)
+    .map((pub) => ({
+      name: pub.name,
+      slug: pub.slug,
+      feedUrl: pub.feedUrl ?? `${pub.url}/feed`,
+      author: pub.author,
+    }));
+}

--- a/src/ingestion/types.ts
+++ b/src/ingestion/types.ts
@@ -1,0 +1,76 @@
+/**
+ * Types for article ingestion pipeline
+ */
+
+import { FeedItem } from '../feed/types.js';
+import { ConvertedArticle, StorageResult } from '../markdown/types.js';
+
+export interface IngestionSource {
+  /** Publication name */
+  name: string;
+  /** Publication slug for storage */
+  slug: string;
+  /** RSS feed URL */
+  feedUrl: string;
+  /** Optional author override */
+  author?: string;
+}
+
+export interface IngestionOptions {
+  /** Base directory for article storage (default: ./library) */
+  libraryDir: string;
+  /** Delay between feed fetches in ms (default: 1000) */
+  fetchDelayMs: number;
+  /** Maximum articles to process per publication (default: unlimited) */
+  maxArticlesPerPub?: number;
+  /** Skip articles older than this date */
+  since?: Date;
+  /** Dry run - don't write files */
+  dryRun: boolean;
+  /** Verbose logging */
+  verbose: boolean;
+}
+
+export const DEFAULT_INGESTION_OPTIONS: IngestionOptions = {
+  libraryDir: './library',
+  fetchDelayMs: 1000,
+  dryRun: false,
+  verbose: false,
+};
+
+export interface IngestionResult {
+  source: IngestionSource;
+  success: boolean;
+  articlesProcessed: number;
+  articlesSkipped: number;
+  articlesStored: number;
+  errors: IngestionError[];
+  duration: number;
+}
+
+export interface IngestionError {
+  articleTitle?: string;
+  articleUrl?: string;
+  error: string;
+  phase: 'fetch' | 'parse' | 'convert' | 'store';
+}
+
+export interface BatchIngestionResult {
+  totalSources: number;
+  successfulSources: number;
+  failedSources: number;
+  totalArticlesProcessed: number;
+  totalArticlesStored: number;
+  totalErrors: number;
+  results: IngestionResult[];
+  duration: number;
+}
+
+export interface ArticleProcessResult {
+  item: FeedItem;
+  converted?: ConvertedArticle;
+  stored?: StorageResult;
+  skipped: boolean;
+  skipReason?: string;
+  error?: IngestionError;
+}

--- a/tools/ingest/run.ts
+++ b/tools/ingest/run.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env npx tsx
+/**
+ * CLI tool for running article ingestion
+ *
+ * Usage:
+ *   npx tsx tools/ingest/run.ts --source sources.json
+ *   npx tsx tools/ingest/run.ts --feed https://example.substack.com/feed --name "Example" --slug example
+ *   npx tsx tools/ingest/run.ts --source sources.json --dry-run --verbose
+ */
+
+import { parseArgs } from 'util';
+import {
+  ingestSource,
+  ingestBatch,
+  loadSourcesFromFile,
+  IngestionSource,
+  IngestionOptions,
+} from '../../src/ingestion/index.js';
+
+const { values } = parseArgs({
+  options: {
+    source: { type: 'string', short: 's' },
+    feed: { type: 'string', short: 'f' },
+    name: { type: 'string', short: 'n' },
+    slug: { type: 'string' },
+    author: { type: 'string', short: 'a' },
+    library: { type: 'string', short: 'l', default: './library' },
+    delay: { type: 'string', short: 'd', default: '1000' },
+    max: { type: 'string', short: 'm' },
+    since: { type: 'string' },
+    'dry-run': { type: 'boolean', default: false },
+    verbose: { type: 'boolean', short: 'v', default: false },
+    help: { type: 'boolean', short: 'h', default: false },
+  },
+  allowPositionals: true,
+});
+
+function printHelp(): void {
+  console.info(`
+Article Ingestion Tool
+
+Usage:
+  npx tsx tools/ingest/run.ts [options]
+
+Options:
+  -s, --source <file>   JSON file with publication sources
+  -f, --feed <url>      Single feed URL to ingest
+  -n, --name <name>     Publication name (required with --feed)
+      --slug <slug>     Publication slug (required with --feed)
+  -a, --author <name>   Override author name
+  -l, --library <dir>   Library directory (default: ./library)
+  -d, --delay <ms>      Delay between fetches in ms (default: 1000)
+  -m, --max <n>         Max articles per publication
+      --since <date>    Skip articles before this date (ISO format)
+      --dry-run         Don't write files, just show what would happen
+  -v, --verbose         Verbose output
+  -h, --help            Show this help
+
+Examples:
+  # Ingest from a sources file
+  npx tsx tools/ingest/run.ts --source content/sources.json --verbose
+
+  # Ingest a single feed
+  npx tsx tools/ingest/run.ts --feed https://example.substack.com/feed \\
+    --name "Example Blog" --slug example --verbose
+
+  # Dry run to see what would be ingested
+  npx tsx tools/ingest/run.ts --source sources.json --dry-run --verbose
+
+  # Ingest only recent articles
+  npx tsx tools/ingest/run.ts --source sources.json --since 2025-01-01
+`);
+}
+
+async function main(): Promise<void> {
+  if (values.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  // Build options
+  const options: Partial<IngestionOptions> = {
+    libraryDir: values.library ?? './library',
+    fetchDelayMs: parseInt(values.delay ?? '1000', 10),
+    dryRun: values['dry-run'] ?? false,
+    verbose: values.verbose ?? false,
+  };
+
+  if (values.max) {
+    options.maxArticlesPerPub = parseInt(values.max, 10);
+  }
+
+  if (values.since) {
+    options.since = new Date(values.since);
+  }
+
+  // Determine sources
+  let sources: IngestionSource[];
+
+  if (values.source) {
+    // Load from file
+    try {
+      sources = await loadSourcesFromFile(values.source);
+      console.info(`Loaded ${sources.length} sources from ${values.source}`);
+    } catch (err) {
+      console.error(
+        `Error loading sources: ${err instanceof Error ? err.message : String(err)}`
+      );
+      process.exit(1);
+    }
+  } else if (values.feed) {
+    // Single feed
+    if (!values.name || !values.slug) {
+      console.error('Error: --name and --slug are required with --feed');
+      process.exit(1);
+    }
+
+    sources = [
+      {
+        name: values.name,
+        slug: values.slug,
+        feedUrl: values.feed,
+        author: values.author,
+      },
+    ];
+  } else {
+    console.error('Error: Either --source or --feed is required');
+    printHelp();
+    process.exit(1);
+  }
+
+  // Run ingestion
+  console.info(
+    `\nStarting ingestion${options.dryRun ? ' (dry run)' : ''}...\n`
+  );
+
+  if (sources.length === 1) {
+    const result = await ingestSource(sources[0], options);
+
+    console.info(`\nResults for ${result.source.name}:`);
+    console.info(`  Status: ${result.success ? 'SUCCESS' : 'FAILED'}`);
+    console.info(`  Articles processed: ${result.articlesProcessed}`);
+    console.info(`  Articles skipped: ${result.articlesSkipped}`);
+    console.info(`  Articles stored: ${result.articlesStored}`);
+    console.info(`  Errors: ${result.errors.length}`);
+    console.info(`  Duration: ${result.duration}ms`);
+
+    if (result.errors.length > 0) {
+      console.info('\nErrors:');
+      for (const error of result.errors) {
+        console.info(`  - [${error.phase}] ${error.error}`);
+        if (error.articleTitle) {
+          console.info(`    Article: ${error.articleTitle}`);
+        }
+      }
+    }
+
+    process.exit(result.success ? 0 : 1);
+  } else {
+    const result = await ingestBatch(sources, options);
+
+    console.info('\n=== Batch Ingestion Results ===');
+    console.info(`Total sources: ${result.totalSources}`);
+    console.info(`Successful: ${result.successfulSources}`);
+    console.info(`Failed: ${result.failedSources}`);
+    console.info(`Total articles processed: ${result.totalArticlesProcessed}`);
+    console.info(`Total articles stored: ${result.totalArticlesStored}`);
+    console.info(`Total errors: ${result.totalErrors}`);
+    console.info(`Total duration: ${result.duration}ms`);
+
+    if (result.failedSources > 0) {
+      console.info('\nFailed sources:');
+      for (const r of result.results.filter((r) => !r.success)) {
+        console.info(`  - ${r.source.name}: ${r.errors[0]?.error ?? 'Unknown error'}`);
+      }
+    }
+
+    process.exit(result.failedSources === 0 ? 0 : 1);
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Orchestrates the complete ingestion flow: fetch RSS feeds, parse content, convert to markdown, store to filesystem
- Supports single source and batch ingestion with deduplication
- CLI tool with dry run mode, verbose output, and date filtering

## Components
- `src/ingestion/types.ts` - Types for ingestion sources, options, and results
- `src/ingestion/pipeline.ts` - Core pipeline logic (processArticle, ingestSource, ingestBatch)
- `tools/ingest/run.ts` - CLI tool for running ingestion

## Usage
```bash
# Single feed
npm run ingest -- --feed https://example.substack.com/feed --name "Example" --slug example

# From sources file
npm run ingest -- --source sources.json --verbose

# Dry run
npm run ingest -- --source sources.json --dry-run --verbose
```

## Test plan
- [x] 10 unit tests covering processArticle and ingestSource
- [x] Tests for deduplication, date filtering, dry run mode
- [x] Tests for error handling (fetch failures, storage errors)
- [ ] Manual test with real Substack feed

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)