### PR TITLE
feat: add book recommendations to weekly email and text

### DIFF
--- a/tools/jobs/send-weekly.ts
+++ b/tools/jobs/send-weekly.ts
@@ -164,15 +164,16 @@ async function getWeeklyAffiliateBooks(weekLabel: string): Promise<AffiliateBook
     for (const row of rows) {
       for (const link of row.affiliate_links) {
         if (!seen.has(link.asin) && results.length < 3) {
-          seen.add(link.asin);
-          // Link to the first article that has this book recommendation
-          const articleId = row.article_ids[0];
-          results.push({
-            title: link.title,
-            author: link.author,
-            description: link.description,
-            articlePageUrl: `https://hex-index.com/article/${articleId}/index.html`,
-          });
+          const articleId = row.article_ids?.[0];
+          if (articleId) {
+            seen.add(link.asin);
+            results.push({
+              title: link.title,
+              author: link.author,
+              description: link.description,
+              articlePageUrl: `https://hex-index.com/article/${articleId}/index.html`,
+            });
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
- Email now includes top 3 curated book picks in "This Week's Recommended Reading" section
- SMS includes 1 top book pick with link
- All links point to hex-index.com article pages (NOT Amazon directly) per Amazon Associates ToS
- Books loaded from `weekly_consolidated.affiliate_links` JSONB
- Gracefully omitted when no books available

## Test plan
- [ ] Verify `npm run typecheck` passes
- [ ] Verify `npm run test` passes
- [ ] Test email rendering with and without book data
- [ ] Confirm no Amazon URLs appear in email/SMS output

🤖 Generated with [Claude Code](https://claude.com/claude-code)