### PR TITLE
feat: optimize job schedule for near-realtime article processing

### DIFF
--- a/tools/cron/affiliate-suggest.sh
+++ b/tools/cron/affiliate-suggest.sh
@@ -11,7 +11,7 @@ LOG_FILE="$PROJECT_DIR/logs/affiliate-suggest-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
 OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
 
-TIME_BUDGET=600         # 10 minutes — lightweight job
+TIME_BUDGET=1500        # 25 minutes — fits odd-hour Qwen slot
 SECS_PER_ITEM=10
 DEPLOY_OVERHEAD=90
 

--- a/tools/cron/article-rewrite.sh
+++ b/tools/cron/article-rewrite.sh
@@ -11,7 +11,7 @@ LOG_FILE="$PROJECT_DIR/logs/article-rewrite-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
 OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
 
-TIME_BUDGET=2400        # 40 minutes — highest priority job
+TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot
 SECS_PER_ITEM=50
 DEPLOY_OVERHEAD=90
 

--- a/tools/cron/wikipedia-discover.sh
+++ b/tools/cron/wikipedia-discover.sh
@@ -12,7 +12,7 @@ OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
 OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
 
 # Tuning constants
-TIME_BUDGET=900         # 15 minutes — reduced as backlog clears
+TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot
 SECS_PER_ITEM=30
 DEPLOY_OVERHEAD=90
 

--- a/tools/cron/wikipedia-rewrite.sh
+++ b/tools/cron/wikipedia-rewrite.sh
@@ -11,7 +11,7 @@ LOG_FILE="$PROJECT_DIR/logs/wiki-rewrite-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
 OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
 
-TIME_BUDGET=900         # 15 minutes — reduced as backlog clears
+TIME_BUDGET=1500        # 25 minutes — fits odd-hour Qwen slot
 SECS_PER_ITEM=80
 DEPLOY_OVERHEAD=90
 


### PR DESCRIPTION
## Summary

- **Standardize all Qwen GPU job budgets to 25 minutes (1500s)** — wiki-discover was at 15 min and timing out every run, processing 0 articles. article-rewrite was at 40 min, affiliate-suggest at 10 min. Now all fit cleanly in 30-min slots.
- **Even/odd hour separation eliminates GPU contention** — Qwen jobs no longer overlap. Even hours run wiki-discover (:05) then article-rewrite (:35). Odd hours run wiki-rewrite (:05) then affiliate-suggest (:35).
- **Non-GPU jobs (ingest, yt-ingest, gen-images) run at even hour :00** without conflicting with GPU slots.

## Schedule

| Time | Even Hours (0,2,4,...,22) | Odd Hours (1,3,5,...,23) |
|------|--------------------------|-------------------------|
| :00 | ingest + yt-ingest + gen-images | — |
| :05 | wiki-discover (Qwen, 25m) | wiki-rewrite (Qwen, 25m) |
| :35 | article-rewrite (Qwen, 25m) | affiliate-suggest (Qwen, 25m) |

## Changes

**In-repo (this PR):** Time budget updates in 4 cron shell scripts.

**On-disk (already applied to ~/Library/LaunchAgents/):** Updated StartCalendarInterval in 5 plist files (gen-images, wiki-discover, article-rewrite, wiki-rewrite, affiliate-suggest). These need `svc reload` to take effect.

## Notes

- wikipedia-discover.ts already orders by `published_at DESC NULLS LAST`, so newest articles get topics first (no change needed)
- Daily claude-quality (05:00), weekly build (Thu 23:00), weekly send (Fri 07:30), and postgres-watchdog (every 5 min) are unchanged

## Test plan

- [ ] Verify `svc status` shows updated schedules after reload
- [ ] Monitor next wiki-discover run to confirm it processes articles instead of timing out
- [ ] Check logs after 2 full cycles to confirm no GPU job overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)