### PR TITLE
fix: clicking article image navigates to article page

### DIFF
--- a/tools/static-site/templates.ts
+++ b/tools/static-site/templates.ts
@@ -226,7 +226,7 @@ export function renderStaticArticleCard(
   const articleUrl = `${pathToRoot}article/${article.id}/index.html${fromTag ? `?from=${fromTag}` : ''}`;
 
   const thumbHtml = article.imagePath
-    ? `<img class="article-thumb" src="${pathToRoot}${article.imagePath}" alt="" loading="lazy" width="180" height="94">`
+    ? `<a href="${articleUrl}" class="article-thumb-link"><img class="article-thumb" src="${pathToRoot}${article.imagePath}" alt="" loading="lazy" width="180" height="94"></a>`
     : '';
 
   return `<article class="article-card">


### PR DESCRIPTION
## Summary
- Wraps article thumbnail `<img>` tags in `<a>` links pointing to the article page URL
- Affects `renderStaticArticleCard` in `tools/static-site/templates.ts`
- One-line change: the image now gets the same `articleUrl` as the title link

Closes #106

## Test plan
- [ ] Regenerate static site and verify thumbnail images are clickable links
- [ ] Verify the link destination matches the article title link
- [ ] Verify no visual regression (image should look the same)

🤖 Generated with [Claude Code](https://claude.com/claude-code)