### PR TITLE
feat: expand YouTube channels to match Substack coverage breadth

### DIFF
--- a/content/youtube-sources.json
+++ b/content/youtube-sources.json
@@ -143,6 +143,228 @@
       "slug": "hellswelles",
       "url": "https://www.youtube.com/@hellswelles",
       "author": "Hells Welles"
+    },
+    {
+      "name": "Money & Macro",
+      "slug": "moneymacro",
+      "url": "https://www.youtube.com/@MoneyMacro",
+      "author": "Joeri Schasfoort"
+    },
+    {
+      "name": "Unlearning Economics",
+      "slug": "unlearningeconomics",
+      "url": "https://www.youtube.com/@unaboringeconomics",
+      "author": "Unlearning Economics"
+    },
+    {
+      "name": "The Plain Bagel",
+      "slug": "theplainbagel",
+      "url": "https://www.youtube.com/@ThePlainBagel",
+      "author": "Richard Coffin"
+    },
+    {
+      "name": "CaspianReport",
+      "slug": "caspianreport",
+      "url": "https://www.youtube.com/@CaspianReport",
+      "author": "Shirvan Neftchi"
+    },
+    {
+      "name": "PolyMatter",
+      "slug": "polymatter",
+      "url": "https://www.youtube.com/@PolyMatter",
+      "author": "PolyMatter"
+    },
+    {
+      "name": "Good Times Bad Times",
+      "slug": "goodtimesbadtimes",
+      "url": "https://www.youtube.com/@GoodTimesBadTimes",
+      "author": "Good Times Bad Times"
+    },
+    {
+      "name": "TLDR News Global",
+      "slug": "tldrnewsglobal",
+      "url": "https://www.youtube.com/@TLDRnewsGlobal",
+      "author": "TLDR News"
+    },
+    {
+      "name": "Medlife Crisis",
+      "slug": "medlifecrisis",
+      "url": "https://www.youtube.com/@MedlifeCrisis",
+      "author": "Rohin Francis"
+    },
+    {
+      "name": "Dr. John Campbell",
+      "slug": "drjohncampbell",
+      "url": "https://www.youtube.com/@Campbellteaching",
+      "author": "John Campbell"
+    },
+    {
+      "name": "Sabine Hossenfelder",
+      "slug": "sabinehossenfelder",
+      "url": "https://www.youtube.com/@SabineHossenfelder",
+      "author": "Sabine Hossenfelder"
+    },
+    {
+      "name": "PBS Space Time",
+      "slug": "pbsspacetime",
+      "url": "https://www.youtube.com/@pbsspacetime",
+      "author": "Matt O'Dowd"
+    },
+    {
+      "name": "Two Minute Papers",
+      "slug": "twominutepapers",
+      "url": "https://www.youtube.com/@TwoMinutePapers",
+      "author": "Karoly Zsolnai-Feher"
+    },
+    {
+      "name": "Asianometry",
+      "slug": "asianometry",
+      "url": "https://www.youtube.com/@Asianometry",
+      "author": "Asianometry"
+    },
+    {
+      "name": "Fall of Civilizations",
+      "slug": "fallofcivilizations",
+      "url": "https://www.youtube.com/@FallofCivilizations",
+      "author": "Paul Cooper"
+    },
+    {
+      "name": "History Hit",
+      "slug": "historyhit",
+      "url": "https://www.youtube.com/@HistoryHit",
+      "author": "Dan Snow"
+    },
+    {
+      "name": "Kings and Generals",
+      "slug": "kingsandgenerals",
+      "url": "https://www.youtube.com/@KingsandGenerals",
+      "author": "Kings and Generals"
+    },
+    {
+      "name": "City Beautiful",
+      "slug": "citybeautiful",
+      "url": "https://www.youtube.com/@CityBeautiful",
+      "author": "Dave Amos"
+    },
+    {
+      "name": "Not Just Bikes",
+      "slug": "notjustbikes",
+      "url": "https://www.youtube.com/@NotJustBikes",
+      "author": "Jason Slaughter"
+    },
+    {
+      "name": "The Hated One",
+      "slug": "thehatedone",
+      "url": "https://www.youtube.com/@TheHatedOne",
+      "author": "The Hated One"
+    },
+    {
+      "name": "LegalEagle",
+      "slug": "legaleagle",
+      "url": "https://www.youtube.com/@LegalEagle",
+      "author": "Devin Stone"
+    },
+    {
+      "name": "Opening Arguments",
+      "slug": "openingarguments",
+      "url": "https://www.youtube.com/@OpeningArguments",
+      "author": "Opening Arguments"
+    },
+    {
+      "name": "More Perfect Union",
+      "slug": "moreperfectunion",
+      "url": "https://www.youtube.com/@MorePerfectUnion",
+      "author": "More Perfect Union"
+    },
+    {
+      "name": "Wendover Productions",
+      "slug": "wendoverproductions",
+      "url": "https://www.youtube.com/@Wendoverproductions",
+      "author": "Sam Denby"
+    },
+    {
+      "name": "Like Stories of Old",
+      "slug": "likestoriesofold",
+      "url": "https://www.youtube.com/@LikeStoriesofOld",
+      "author": "Tom van der Linden"
+    },
+    {
+      "name": "Then & Now",
+      "slug": "thenandnow",
+      "url": "https://www.youtube.com/@ThenNow",
+      "author": "Then & Now"
+    },
+    {
+      "name": "Perun",
+      "slug": "perun",
+      "url": "https://www.youtube.com/@PerunAU",
+      "author": "Perun"
+    },
+    {
+      "name": "The Chinatown Bureau",
+      "slug": "chinatownbureau",
+      "url": "https://www.youtube.com/@TheChinatownBureau",
+      "author": "The Chinatown Bureau"
+    },
+    {
+      "name": "China Uncensored",
+      "slug": "chinauncensored",
+      "url": "https://www.youtube.com/@ChinaUncensored",
+      "author": "Chris Chappell"
+    },
+    {
+      "name": "Yale Courses",
+      "slug": "yalecourses",
+      "url": "https://www.youtube.com/@YaleCourses",
+      "author": "Yale University"
+    },
+    {
+      "name": "Crash Course",
+      "slug": "crashcourse",
+      "url": "https://www.youtube.com/@crashcourse",
+      "author": "Crash Course"
+    },
+    {
+      "name": "The Rest Is History",
+      "slug": "therestishistory",
+      "url": "https://www.youtube.com/@TheRestIsHistory",
+      "author": "Tom Holland & Dominic Sandbrook"
+    },
+    {
+      "name": "BobbyBroccoli",
+      "slug": "bobbybroccoli",
+      "url": "https://www.youtube.com/@BobbyBroccoli",
+      "author": "BobbyBroccoli"
+    },
+    {
+      "name": "Economics Explained",
+      "slug": "economicsexplained",
+      "url": "https://www.youtube.com/@EconomicsExplained",
+      "author": "Economics Explained"
+    },
+    {
+      "name": "The B1M",
+      "slug": "theb1m",
+      "url": "https://www.youtube.com/@TheB1M",
+      "author": "Fred Mills"
+    },
+    {
+      "name": "Religion For Breakfast",
+      "slug": "religionforbreakfast",
+      "url": "https://www.youtube.com/@ReligionForBreakfast",
+      "author": "Andrew Henry"
+    },
+    {
+      "name": "Just Have a Think",
+      "slug": "justhaveathink",
+      "url": "https://www.youtube.com/@JustHaveaThink",
+      "author": "Dave Borlace"
+    },
+    {
+      "name": "Matt Christman",
+      "slug": "mattchristman",
+      "url": "https://www.youtube.com/@cushvlog",
+      "author": "Matt Christman"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Expands YouTube channels from 24 to 61, filling topic gaps identified in #92
- New channels cover: economics/finance (Money & Macro, Unlearning Economics, The Plain Bagel, Economics Explained), geopolitics (CaspianReport, PolyMatter, Good Times Bad Times, TLDR News Global), science/medicine (Medlife Crisis, Dr. John Campbell, Sabine Hossenfelder, PBS Space Time), technology (Two Minute Papers, Asianometry), history (Fall of Civilizations, History Hit, Kings and Generals, The Rest Is History, BobbyBroccoli), housing/cities (City Beautiful, Not Just Bikes, The B1M), law/rights (LegalEagle, Opening Arguments), labor/journalism (More Perfect Union), defense (Perun), China (The Chinatown Bureau, China Uncensored), faith (Religion For Breakfast), education (Yale Courses, Crash Course), culture/arts (Like Stories of Old, Then & Now), climate/energy (Just Have a Think), privacy/tech (The Hated One), logistics (Wendover Productions), political commentary (Matt Christman)
- All channels match editorial taste: thoughtful, nuanced, long-form content

Closes #92

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] Pre-commit hook passes (secrets, tests, lint, typecheck)
- [ ] Verify YouTube ingestion picks up new channels on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)