### PR TITLE
fix: add tag-articles cron script, remove tag badges from cards

### DIFF
--- a/tools/cron/tag-articles.sh
+++ b/tools/cron/tag-articles.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Job 7: Tag articles with curated tags via Ollama/Qwen
+# Schedule: EVEN hours at :35, after article-rewrite completes
+# (Shares the even-hour :35 slot — run after article-rewrite or replace it
+#  when rewrite backlog is clear. Do NOT modify launchd plists here.)
+# Self-budgeting: queries DB for untagged articles, caps --limit to fit TIME_BUDGET
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LOCK_FILE="$PROJECT_DIR/logs/tag-articles.lock"
+LOG_FILE="$PROJECT_DIR/logs/tag-articles-$(date +%Y%m%d-%H%M%S).log"
+OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
+
+TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot
+SECS_PER_ITEM=15
+DEPLOY_OVERHEAD=90
+
+mkdir -p "$PROJECT_DIR/logs"
+cd "$PROJECT_DIR"
+
+log()  { echo "[$(date '+%H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
+warn() { echo "[$(date '+%H:%M:%S')] WARN: $*" | tee -a "$LOG_FILE" >&2; }
+die()  { echo "[$(date '+%H:%M:%S')] FATAL: $*" | tee -a "$LOG_FILE" >&2; exit 1; }
+
+step_start() { STEP_NAME="$1"; STEP_START=$(date +%s); log "── $STEP_NAME ──"; }
+step_done()  { local e=$(( $(date +%s) - STEP_START )); log "── $STEP_NAME done ($(( e/60 ))m $(( e%60 ))s) ──"; }
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then log "Another tag-articles running. Exiting."; exit 0; fi
+echo $$ >"$LOCK_FILE"
+
+LLM_LOCK="$PROJECT_DIR/logs/llm.lock"
+exec 8>"$LLM_LOCK"
+if ! flock -w 300 8; then log "LLM busy for 5 min. Skipping."; exit 0; fi
+
+trap 'rm -f "$LOCK_FILE"; exec 9>&-; exec 8>&-' EXIT
+
+RUN_START=$(date +%s)
+log "=== Job 7: Tag Articles (PID $$) ==="
+
+step_start "Postgres"
+docker compose up -d postgres 2>&1 | tee -a "$LOG_FILE"
+PG_RETRIES=0
+until docker compose exec -T postgres pg_isready -U postgres -q 2>/dev/null; do
+    PG_RETRIES=$((PG_RETRIES + 1))
+    [ "$PG_RETRIES" -ge 30 ] && die "Postgres not ready after 30s"
+    sleep 1
+done
+log "Postgres ready (${PG_RETRIES}s)"
+step_done
+
+step_start "Ollama"
+OLLAMA_OK=false
+for i in 1 2 3; do
+    if curl -sf "${OLLAMA_URL}/api/tags" >/dev/null 2>&1; then
+        LOADED=$(curl -sf "${OLLAMA_URL}/api/ps" | grep -o "\"$OLLAMA_MODEL\"" || true)
+        if [ -n "$LOADED" ]; then
+            OLLAMA_OK=true; log "Ollama ready"; break
+        else
+            warn "Model not loaded, warming up..."
+            curl -sf "${OLLAMA_URL}/api/chat" -d "{\"model\":\"$OLLAMA_MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"options\":{\"num_predict\":1},\"keep_alive\":-1,\"stream\":false}" >/dev/null 2>&1 || true
+            sleep 10
+        fi
+    else
+        warn "Ollama not responding (attempt $i/3)"; sleep 5
+    fi
+done
+[ "$OLLAMA_OK" = false ] && die "Ollama unavailable"
+step_done
+
+PENDING=$(docker compose exec -T postgres psql -U postgres -d hex-index -t -c "
+    SELECT COUNT(*) FROM app.articles a
+    WHERE a.full_content_path IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM app.article_tags at WHERE at.article_id = a.id);
+" 2>/dev/null | tr -d ' ')
+LIMIT=$(( (TIME_BUDGET - DEPLOY_OVERHEAD) / SECS_PER_ITEM ))
+[ "$LIMIT" -gt "${PENDING:-0}" ] && LIMIT="${PENDING:-0}"
+[ "$LIMIT" -lt 1 ] && LIMIT=1
+log "Pending tags: ${PENDING:-?}, Budget: ${TIME_BUDGET}s, Limit: $LIMIT (est $(( LIMIT * SECS_PER_ITEM / 60 ))m)"
+
+step_start "Tag articles ($LIMIT articles)"
+timeout "$TIME_BUDGET" npx tsx tools/jobs/tag-articles.ts --limit "$LIMIT" 2>&1 | tee -a "$LOG_FILE" || {
+    EC=$?
+    [ "$EC" -eq 124 ] && warn "Hit time budget" || warn "Failed (exit $EC)"
+}
+step_done
+
+step_start "Deploy"
+bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: tag articles $(date +%Y-%m-%d\ %H:%M)" 2>&1 | tee -a "$LOG_FILE"
+step_done
+
+RUN_E=$(( $(date +%s) - RUN_START ))
+log "=== Job 7 complete ($(( RUN_E/60 ))m $(( RUN_E%60 ))s) ==="
+ln -sf "$LOG_FILE" "$PROJECT_DIR/logs/tag-articles-latest.log"
+find "$PROJECT_DIR/logs" -name "tag-articles-*.log" -not -name "tag-articles-latest.log" -mtime +7 -delete

--- a/tools/static-site/templates.ts
+++ b/tools/static-site/templates.ts
@@ -242,9 +242,7 @@ export function renderStaticArticleCard(
       </a>
       ${date ? `<span class="separator">&middot;</span><time>${date}</time>` : ''}
       <span class="separator">&middot;</span>
-      <span class="read-time">${article.estimatedReadTimeMinutes} min read</span>${article.displayTag ? `
-      <span class="separator">&middot;</span>
-      <a href="${pathToRoot}tag/${article.displayTag.slug}/index.html" class="article-tag">${escapeHtml(article.displayTag.name)}</a>` : ''}
+      <span class="read-time">${article.estimatedReadTimeMinutes} min read</span>
     </div>
   </div>
   ${thumbHtml}


### PR DESCRIPTION
## Summary
- **Created `tools/cron/tag-articles.sh`** -- the tag-articles job existed but had no cron wrapper, so articles were never tagged automatically. Follows the exact pattern of `article-rewrite.sh` (lock file, LLM lock, Postgres startup, Ollama warmup, self-budgeting, deploy).
- **Removed displayTag badge from `renderStaticArticleCard`** -- Brian explicitly requested no topic tags on home page article cards. The `displayTag` field remains in the `StaticArticle` type (used by tag listing pages), but no longer renders in the card HTML.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (122 tests)
- [ ] Verify `tools/cron/tag-articles.sh` is executable and runs correctly against local Postgres + Ollama
- [ ] Regenerate static site and confirm no tag badges appear on home page cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)