### PR TITLE
fix: add --dangerously-skip-permissions to claude loop

### DIFF
--- a/tools/claude-loop/start-session.sh
+++ b/tools/claude-loop/start-session.sh
@@ -23,7 +23,9 @@ tmux kill-session -t "$SESSION" 2>/dev/null || true
 tmux new-session -d -s "$SESSION" -c "$PROJECT_DIR"
 
 # Send the claude command
-tmux send-keys -t "$SESSION" "claude" Enter
+# --dangerously-skip-permissions: the editorial loop runs autonomously in tmux
+# and cannot respond to interactive permission prompts
+tmux send-keys -t "$SESSION" "claude --dangerously-skip-permissions" Enter
 
 # Wait for Claude to start
 sleep 5


### PR DESCRIPTION
## Summary
- Adds `--dangerously-skip-permissions` flag when launching Claude Code in the editorial loop tmux session
- The loop runs autonomously and cannot respond to interactive permission prompts

## Test plan
- [ ] Verify `start-session.sh` launches Claude with the flag in tmux

🤖 Generated with [Claude Code](https://claude.com/claude-code)