### PR TITLE
feat: single deployer service for static site

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "job:send-weekly": "tsx tools/jobs/send-weekly.ts",
     "job:build-weekly": "bash tools/cron/build-weekly.sh",
     "job:friday-publish": "bash tools/cron/friday-publish.sh",
+    "deploy:auto": "bash tools/cron/auto-deploy.sh",
     "claude:start": "bash tools/claude-loop/start-session.sh",
     "claude:attach": "tmux attach -t claude-editor",
     "claude:check-prs": "bash tools/claude-loop/check-prs.sh",

--- a/tools/claude-loop/editorial-prompt.md
+++ b/tools/claude-loop/editorial-prompt.md
@@ -68,12 +68,13 @@ For each recent article, check and fix:
 
 ## Priority 3: Site Verification
 
-After any changes that affect the public site:
-1. Regenerate the static site: `npm run static:generate`
-2. Commit and push the updated `docs/` directory
-3. Wait for GitHub Pages to update (~2 min)
-4. Verify the production site: `curl -s https://hex-index.com | head -20`
-5. Check the most recently changed article renders correctly
+**Do NOT deploy directly.** The auto-deploy service (`tools/cron/auto-deploy.sh`) runs every 30 minutes and is the ONLY thing that regenerates the static site and deploys to GitHub Pages. All other jobs (including this editorial loop) should only write to DB + `library/`.
+
+After making content changes:
+1. The auto-deploy service will pick up changes within 30 minutes
+2. For urgent deploys (e.g., Friday epub fixes), call `bash tools/cron/auto-deploy.sh` directly
+3. After deploy, verify the production site: `curl -s https://hex-index.com | head -20`
+4. Check the most recently changed article renders correctly
 
 ## Priority 4: Housekeeping
 

--- a/tools/cron/affiliate-suggest.sh
+++ b/tools/cron/affiliate-suggest.sh
@@ -13,7 +13,6 @@ OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
 
 TIME_BUDGET=1500        # 25 minutes — fits odd-hour Qwen slot
 SECS_PER_ITEM=10
-DEPLOY_OVERHEAD=90
 
 mkdir -p "$PROJECT_DIR/logs"
 cd "$PROJECT_DIR"
@@ -72,7 +71,7 @@ PENDING=$(docker compose exec -T postgres psql -U postgres -d hex-index -t -c "
     SELECT COUNT(*) FROM app.articles
     WHERE rewritten_content_path IS NOT NULL AND jsonb_array_length(affiliate_links) = 0;
 " 2>/dev/null | tr -d ' ')
-LIMIT=$(( (TIME_BUDGET - DEPLOY_OVERHEAD) / SECS_PER_ITEM ))
+LIMIT=$(( TIME_BUDGET / SECS_PER_ITEM ))
 [ "$LIMIT" -gt "${PENDING:-0}" ] && LIMIT="${PENDING:-0}"
 [ "$LIMIT" -lt 1 ] && LIMIT=1
 log "Pending: ${PENDING:-?}, Budget: ${TIME_BUDGET}s, Limit: $LIMIT"
@@ -82,10 +81,6 @@ timeout "$TIME_BUDGET" npx tsx tools/jobs/affiliate-suggest.ts --limit "$LIMIT" 
     EC=$?
     [ "$EC" -eq 124 ] && warn "Hit time budget" || warn "Failed (exit $EC)"
 }
-step_done
-
-step_start "Deploy"
-bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: affiliate links $(date +%Y-%m-%d\ %H:%M)" 2>&1 | tee -a "$LOG_FILE"
 step_done
 
 RUN_E=$(( $(date +%s) - RUN_START ))

--- a/tools/cron/article-rewrite.sh
+++ b/tools/cron/article-rewrite.sh
@@ -13,7 +13,6 @@ OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
 
 TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot
 SECS_PER_ITEM=50
-DEPLOY_OVERHEAD=90
 
 mkdir -p "$PROJECT_DIR/logs"
 cd "$PROJECT_DIR"
@@ -71,7 +70,7 @@ step_done
 PENDING=$(docker compose exec -T postgres psql -U postgres -d hex-index -t -c "
     SELECT COUNT(*) FROM app.articles WHERE full_content_path IS NOT NULL AND (rewritten_content_path IS NULL OR rewrite_dirty = true);
 " 2>/dev/null | tr -d ' ')
-LIMIT=$(( (TIME_BUDGET - DEPLOY_OVERHEAD) / SECS_PER_ITEM ))
+LIMIT=$(( TIME_BUDGET / SECS_PER_ITEM ))
 [ "$LIMIT" -gt "${PENDING:-0}" ] && LIMIT="${PENDING:-0}"
 [ "$LIMIT" -lt 1 ] && LIMIT=1
 log "Pending rewrites: ${PENDING:-?}, Budget: ${TIME_BUDGET}s, Limit: $LIMIT (est $(( LIMIT * SECS_PER_ITEM / 60 ))m)"
@@ -81,10 +80,6 @@ timeout "$TIME_BUDGET" npx tsx tools/jobs/article-rewrite.ts --limit "$LIMIT" 2>
     EC=$?
     [ "$EC" -eq 124 ] && warn "Hit time budget" || warn "Failed (exit $EC)"
 }
-step_done
-
-step_start "Deploy"
-bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: article rewrites $(date +%Y-%m-%d\ %H:%M)" 2>&1 | tee -a "$LOG_FILE"
 step_done
 
 RUN_E=$(( $(date +%s) - RUN_START ))

--- a/tools/cron/auto-deploy.sh
+++ b/tools/cron/auto-deploy.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Single deployer service — the ONLY thing that regenerates the static site
+# and deploys to GitHub Pages. All other jobs write to DB + library/ only.
+#
+# Runs every 30 minutes via launchd, or called directly by build-weekly.sh
+# and friday-publish.sh for immediate deploys.
+#
+# Flow:
+#   1. Acquire lock (prevent racing with itself)
+#   2. Pull latest main
+#   3. Regenerate static site from DB
+#   4. If docs/ changed: create branch, PR, auto-merge
+#   5. Clean up
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LOCK_FILE="$PROJECT_DIR/logs/auto-deploy.lock"
+LOG_FILE="$PROJECT_DIR/logs/auto-deploy-$(date +%Y%m%d-%H%M%S).log"
+
+mkdir -p "$PROJECT_DIR/logs"
+cd "$PROJECT_DIR"
+
+log()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
+warn() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] WARN: $*" | tee -a "$LOG_FILE" >&2; }
+die()  { echo "[$(date '+%Y-%m-%d %H:%M:%S')] FATAL: $*" | tee -a "$LOG_FILE" >&2; exit 1; }
+
+step_start() { STEP_NAME="$1"; STEP_START=$(date +%s); log "── $STEP_NAME ──"; }
+step_done()  { local e=$(( $(date +%s) - STEP_START )); log "── $STEP_NAME done ($(( e/60 ))m $(( e%60 ))s) ──"; }
+
+# ── Lock: only one auto-deploy at a time ────────────────────────────
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    log "Another auto-deploy is running. Exiting."
+    exit 0
+fi
+echo $$ >"$LOCK_FILE"
+trap 'rm -f "$LOCK_FILE"; exec 9>&-' EXIT
+
+RUN_START=$(date +%s)
+log "=== Auto-Deploy (PID $$) ==="
+
+# ── Step 1: Get latest main ──────────────────────────────────────────
+step_start "Pull latest main"
+git checkout main 2>&1 | tee -a "$LOG_FILE"
+git pull --rebase 2>&1 | tee -a "$LOG_FILE" || {
+    warn "Rebase failed, aborting and retrying with merge"
+    git rebase --abort 2>/dev/null || true
+    git pull 2>&1 | tee -a "$LOG_FILE" || die "Cannot pull latest main"
+}
+step_done
+
+# ── Step 2: Ensure Postgres is running ───────────────────────────────
+step_start "Postgres"
+docker compose up -d postgres 2>&1 | tee -a "$LOG_FILE"
+PG_RETRIES=0
+until docker compose exec -T postgres pg_isready -U postgres -q 2>/dev/null; do
+    PG_RETRIES=$((PG_RETRIES + 1))
+    [ "$PG_RETRIES" -ge 30 ] && die "Postgres not ready after 30s"
+    sleep 1
+done
+log "Postgres ready (${PG_RETRIES}s)"
+step_done
+
+# ── Step 3: Regenerate static site ───────────────────────────────────
+step_start "Static site generation"
+npm run static:generate 2>&1 | tee -a "$LOG_FILE"
+step_done
+
+# ── Step 4: Check for changes ────────────────────────────────────────
+if git diff --quiet docs/ && git diff --quiet --cached docs/; then
+    log "Nothing to deploy — docs/ unchanged"
+    RUN_E=$(( $(date +%s) - RUN_START ))
+    log "=== Auto-Deploy complete, no changes ($(( RUN_E/60 ))m $(( RUN_E%60 ))s) ==="
+    ln -sf "$LOG_FILE" "$PROJECT_DIR/logs/auto-deploy-latest.log"
+    find "$PROJECT_DIR/logs" -name "auto-deploy-*.log" -not -name "auto-deploy-latest.log" -mtime +7 -delete
+    exit 0
+fi
+
+log "Changes detected in docs/"
+git diff --stat docs/ 2>&1 | tee -a "$LOG_FILE"
+
+# ── Step 5: Create deploy branch ─────────────────────────────────────
+BRANCH="deploy/auto-$(date +%Y%m%d-%H%M%S)"
+step_start "Create branch $BRANCH"
+git checkout -b "$BRANCH" 2>&1 | tee -a "$LOG_FILE"
+git add docs/
+git commit -m "$(cat <<'EOF'
+chore: auto-deploy static site
+EOF
+)" 2>&1 | tee -a "$LOG_FILE"
+step_done
+
+# ── Step 6: Push and create PR ───────────────────────────────────────
+step_start "Push and create PR"
+git push -u origin "$BRANCH" 2>&1 | tee -a "$LOG_FILE"
+
+PR_URL=$(gh pr create \
+    --title "chore: auto-deploy static site" \
+    --body "$(cat <<'EOF'
+Automated static site regeneration from current DB state.
+
+This PR was created by the auto-deploy service. It regenerates `docs/` from the current database and deploys to GitHub Pages.
+EOF
+)" 2>&1 | tee -a "$LOG_FILE" | tail -1)
+
+log "PR created: $PR_URL"
+
+# Extract PR number
+PR_NUMBER=$(echo "$PR_URL" | grep -o '[0-9]*$')
+
+# Admin merge — docs/ is generated output, doesn't need CI review
+gh pr merge "$PR_NUMBER" --squash --admin 2>&1 | tee -a "$LOG_FILE" && MERGED=true || {
+    warn "Admin merge failed, falling back to auto-merge"
+    gh pr merge "$PR_NUMBER" --squash --auto 2>&1 | tee -a "$LOG_FILE" || warn "Auto-merge also failed"
+    MERGED=false
+}
+step_done
+
+# ── Step 8: Return to main ───────────────────────────────────────────
+step_start "Return to main"
+git checkout main 2>&1 | tee -a "$LOG_FILE"
+if [ "$MERGED" = true ]; then
+    git pull 2>&1 | tee -a "$LOG_FILE"
+    # Clean up merged branch
+    git branch -d "$BRANCH" 2>/dev/null || true
+    git push origin --delete "$BRANCH" 2>/dev/null || true
+    log "Cleaned up branch $BRANCH"
+fi
+step_done
+
+# ── Summary ──────────────────────────────────────────────────────────
+RUN_E=$(( $(date +%s) - RUN_START ))
+log "=== Auto-Deploy complete ($(( RUN_E/60 ))m $(( RUN_E%60 ))s) ==="
+ln -sf "$LOG_FILE" "$PROJECT_DIR/logs/auto-deploy-latest.log"
+find "$PROJECT_DIR/logs" -name "auto-deploy-*.log" -not -name "auto-deploy-latest.log" -mtime +7 -delete

--- a/tools/cron/build-weekly.sh
+++ b/tools/cron/build-weekly.sh
@@ -24,9 +24,9 @@ trap 'rm -f "$LOCK_FILE"; exec 9>&-' EXIT
 RUN_START=$(date +%s)
 log "=== Build Weekly Reader Edition (PID $$) ==="
 
-bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: weekly Reader edition $(date +%Y-%m-%d)" 2>&1 | tee -a "$LOG_FILE" || {
+bash "$PROJECT_DIR/tools/cron/auto-deploy.sh" 2>&1 | tee -a "$LOG_FILE" || {
     EC=$?
-    die "deploy.sh failed (exit $EC)"
+    die "auto-deploy.sh failed (exit $EC)"
 }
 
 RUN_E=$(( $(date +%s) - RUN_START ))

--- a/tools/cron/friday-publish.sh
+++ b/tools/cron/friday-publish.sh
@@ -86,9 +86,9 @@ step_done
 
 # ── Step 5: Build epub + deploy (fully deterministic) ────────────
 step_start "Build weekly epub + deploy"
-bash "$PROJECT_DIR/tools/cron/build-weekly.sh" 2>&1 | tee -a "$LOG_FILE" || {
+bash "$PROJECT_DIR/tools/cron/auto-deploy.sh" 2>&1 | tee -a "$LOG_FILE" || {
     EC=$?
-    die "build-weekly failed (exit $EC)"
+    die "auto-deploy failed (exit $EC)"
 }
 step_done
 

--- a/tools/cron/generate-images.sh
+++ b/tools/cron/generate-images.sh
@@ -12,8 +12,7 @@ LOG_FILE="$PROJECT_DIR/logs/gen-images-$(date +%Y%m%d-%H%M%S).log"
 
 TIME_BUDGET=1200        # 20 minutes total
 SECS_PER_ITEM=3         # ~3 sec per image (Gemini API + ImageMagick)
-DEPLOY_OVERHEAD=90
-BATCH_SIZE=25           # Deploy every 25 images
+BATCH_SIZE=50           # Process in batches of 50
 
 mkdir -p "$PROJECT_DIR/logs"
 cd "$PROJECT_DIR"
@@ -49,7 +48,7 @@ step_done
 PENDING=$(docker compose exec -T postgres psql -U postgres -d hex-index -t -c "
     SELECT COUNT(*) FROM app.articles WHERE image_path IS NULL AND content_path IS NOT NULL;
 " 2>/dev/null | tr -d ' ')
-TOTAL_LIMIT=$(( (TIME_BUDGET - DEPLOY_OVERHEAD * 4) / SECS_PER_ITEM ))  # budget for ~4 deploys
+TOTAL_LIMIT=$(( TIME_BUDGET / SECS_PER_ITEM ))
 [ "$TOTAL_LIMIT" -gt "${PENDING:-0}" ] && TOTAL_LIMIT="${PENDING:-0}"
 [ "$TOTAL_LIMIT" -lt 1 ] && { log "No articles need images"; exit 0; }
 log "Pending: ${PENDING:-?}, Budget: ${TIME_BUDGET}s, Total limit: $TOTAL_LIMIT"
@@ -73,10 +72,6 @@ while [ "$GENERATED" -lt "$TOTAL_LIMIT" ]; do
     GENERATED=$(( GENERATED + THIS_BATCH ))
 
     [ "$NEW_IMAGES" -eq 0 ] && { log "No more articles need images"; break; }
-    step_done
-
-    step_start "Deploy batch ($NEW_IMAGES images)"
-    bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: ${NEW_IMAGES} article images" 2>&1 | tee -a "$LOG_FILE"
     step_done
 done
 

--- a/tools/cron/ingest-and-publish.sh
+++ b/tools/cron/ingest-and-publish.sh
@@ -123,46 +123,9 @@ else
     log "Skipping Wikipedia enrichment (Ollama unavailable)"
 fi
 
-# ── Static site generation ───────────────────────────────────────────
-step_start "Static site"
-npm run static:generate 2>&1 | tee -a "$LOG_FILE"
-step_done
-
-# ── Git: commit and push with conflict handling ──────────────────────
-step_start "Publish"
-
-if git diff --quiet docs/ && git diff --quiet --cached docs/; then
-    log "No new content to publish"
-else
-    git add docs/
-
-    COMMIT_MSG="feat: auto-publish $(date +%Y-%m-%d %H:%M)"
-    git commit -m "$COMMIT_MSG" 2>&1 | tee -a "$LOG_FILE"
-
-    PUSH_RETRIES=0
-    PUSH_MAX=3
-    while [ "$PUSH_RETRIES" -lt "$PUSH_MAX" ]; do
-        if git push 2>&1 | tee -a "$LOG_FILE"; then
-            log "Pushed successfully"
-            break
-        else
-            PUSH_RETRIES=$((PUSH_RETRIES + 1))
-            if [ "$PUSH_RETRIES" -ge "$PUSH_MAX" ]; then
-                warn "Push failed after $PUSH_MAX attempts — commit is local, will retry next run"
-                break
-            fi
-            log "Push failed, pulling with rebase (attempt $PUSH_RETRIES/$PUSH_MAX)..."
-            if ! git pull --rebase 2>&1 | tee -a "$LOG_FILE"; then
-                warn "Rebase conflict — aborting rebase, commit stays local"
-                git rebase --abort 2>/dev/null || true
-                break
-            fi
-        fi
-    done
-fi
-step_done
-
 # ── Summary ──────────────────────────────────────────────────────────
+# NOTE: Static site generation and deploy are handled by auto-deploy.sh
+# which runs every 30 minutes. This script only writes to DB + library/.
 RUN_ELAPSED=$(( $(date +%s) - RUN_START ))
 RUN_MINS=$(( RUN_ELAPSED / 60 ))
 RUN_SECS=$(( RUN_ELAPSED % 60 ))

--- a/tools/cron/ingest.sh
+++ b/tools/cron/ingest.sh
@@ -50,11 +50,6 @@ step_start "RSS ingestion"
 npm run ingest -- --source content/ingest-subscribed.json --no-enrich 2>&1 | tee -a "$LOG_FILE"
 step_done
 
-# Deploy (shared lock — regenerate, commit, push)
-step_start "Deploy"
-bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: ingest $(date +%Y-%m-%d\ %H:%M)" 2>&1 | tee -a "$LOG_FILE"
-step_done
-
 RUN_E=$(( $(date +%s) - RUN_START ))
 log "=== Job 1 complete ($(( RUN_E/60 ))m $(( RUN_E%60 ))s) ==="
 ln -sf "$LOG_FILE" "$PROJECT_DIR/logs/ingest-latest.log"

--- a/tools/cron/tag-articles.sh
+++ b/tools/cron/tag-articles.sh
@@ -16,7 +16,6 @@ OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
 
 TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot
 SECS_PER_ITEM=15
-DEPLOY_OVERHEAD=90
 
 mkdir -p "$PROJECT_DIR/logs"
 cd "$PROJECT_DIR"
@@ -76,7 +75,7 @@ PENDING=$(docker compose exec -T postgres psql -U postgres -d hex-index -t -c "
     WHERE a.full_content_path IS NOT NULL
       AND NOT EXISTS (SELECT 1 FROM app.article_tags at WHERE at.article_id = a.id);
 " 2>/dev/null | tr -d ' ')
-LIMIT=$(( (TIME_BUDGET - DEPLOY_OVERHEAD) / SECS_PER_ITEM ))
+LIMIT=$(( TIME_BUDGET / SECS_PER_ITEM ))
 [ "$LIMIT" -gt "${PENDING:-0}" ] && LIMIT="${PENDING:-0}"
 [ "$LIMIT" -lt 1 ] && LIMIT=1
 log "Pending tags: ${PENDING:-?}, Budget: ${TIME_BUDGET}s, Limit: $LIMIT (est $(( LIMIT * SECS_PER_ITEM / 60 ))m)"
@@ -86,10 +85,6 @@ timeout "$TIME_BUDGET" npx tsx tools/jobs/tag-articles.ts --limit "$LIMIT" 2>&1 
     EC=$?
     [ "$EC" -eq 124 ] && warn "Hit time budget" || warn "Failed (exit $EC)"
 }
-step_done
-
-step_start "Deploy"
-bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: tag articles $(date +%Y-%m-%d\ %H:%M)" 2>&1 | tee -a "$LOG_FILE"
 step_done
 
 RUN_E=$(( $(date +%s) - RUN_START ))

--- a/tools/cron/wikipedia-discover.sh
+++ b/tools/cron/wikipedia-discover.sh
@@ -14,7 +14,6 @@ OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
 # Tuning constants
 TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot
 SECS_PER_ITEM=30
-DEPLOY_OVERHEAD=90
 
 mkdir -p "$PROJECT_DIR/logs"
 cd "$PROJECT_DIR"
@@ -79,7 +78,7 @@ PENDING=$(docker compose exec -T postgres psql -U postgres -d hex-index -t -c "
     LEFT JOIN (SELECT article_id, COUNT(*) AS cnt FROM app.article_wikipedia_links GROUP BY article_id) wc ON wc.article_id = a.id
     WHERE a.content_path IS NOT NULL AND COALESCE(wc.cnt, 0) < 3;
 " 2>/dev/null | tr -d ' ')
-LIMIT=$(( (TIME_BUDGET - DEPLOY_OVERHEAD) / SECS_PER_ITEM ))
+LIMIT=$(( TIME_BUDGET / SECS_PER_ITEM ))
 [ "$LIMIT" -gt "${PENDING:-0}" ] && LIMIT="${PENDING:-0}"
 [ "$LIMIT" -lt 1 ] && LIMIT=1
 log "Pending: ${PENDING:-?}, Budget: ${TIME_BUDGET}s, Limit: $LIMIT (est $(( LIMIT * SECS_PER_ITEM / 60 ))m)"
@@ -90,11 +89,6 @@ timeout "$TIME_BUDGET" npx tsx tools/jobs/wikipedia-discover.ts --limit "$LIMIT"
     EC=$?
     [ "$EC" -eq 124 ] && warn "Hit time budget" || warn "Failed (exit $EC)"
 }
-step_done
-
-# Deploy (shared lock)
-step_start "Deploy"
-bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: wikipedia topics $(date +%Y-%m-%d\ %H:%M)" 2>&1 | tee -a "$LOG_FILE"
 step_done
 
 RUN_E=$(( $(date +%s) - RUN_START ))

--- a/tools/cron/wikipedia-rewrite.sh
+++ b/tools/cron/wikipedia-rewrite.sh
@@ -13,7 +13,6 @@ OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
 
 TIME_BUDGET=1500        # 25 minutes — fits odd-hour Qwen slot
 SECS_PER_ITEM=80
-DEPLOY_OVERHEAD=90
 
 mkdir -p "$PROJECT_DIR/logs"
 cd "$PROJECT_DIR"
@@ -71,7 +70,7 @@ step_done
 PENDING=$(docker compose exec -T postgres psql -U postgres -d hex-index -t -c "
     SELECT COUNT(*) FROM app.wikipedia_articles WHERE status = 'stub' OR rewrite_dirty = true;
 " 2>/dev/null | tr -d ' ')
-LIMIT=$(( (TIME_BUDGET - DEPLOY_OVERHEAD) / SECS_PER_ITEM ))
+LIMIT=$(( TIME_BUDGET / SECS_PER_ITEM ))
 [ "$LIMIT" -gt "${PENDING:-0}" ] && LIMIT="${PENDING:-0}"
 [ "$LIMIT" -lt 1 ] && LIMIT=1
 log "Pending stubs: ${PENDING:-?}, Budget: ${TIME_BUDGET}s, Limit: $LIMIT (est $(( LIMIT * SECS_PER_ITEM / 60 ))m)"
@@ -81,10 +80,6 @@ timeout "$TIME_BUDGET" npx tsx tools/jobs/wikipedia-rewrite.ts --limit "$LIMIT" 
     EC=$?
     [ "$EC" -eq 124 ] && warn "Hit time budget" || warn "Failed (exit $EC)"
 }
-step_done
-
-step_start "Deploy"
-bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: wikipedia rewrites $(date +%Y-%m-%d\ %H:%M)" 2>&1 | tee -a "$LOG_FILE"
 step_done
 
 RUN_E=$(( $(date +%s) - RUN_START ))

--- a/tools/cron/yt-ingest.sh
+++ b/tools/cron/yt-ingest.sh
@@ -52,11 +52,6 @@ step_start "YouTube ingestion"
 npx tsx tools/jobs/yt-ingest.ts --source content/youtube-sources.json 2>&1 | tee -a "$LOG_FILE"
 step_done
 
-# Deploy (shared lock — regenerate, commit, push)
-step_start "Deploy"
-bash "$PROJECT_DIR/tools/cron/deploy.sh" "feat: youtube ingest $(date +%Y-%m-%d\ %H:%M)" 2>&1 | tee -a "$LOG_FILE"
-step_done
-
 RUN_E=$(( $(date +%s) - RUN_START ))
 log "=== Job 6 complete ($(( RUN_E/60 ))m $(( RUN_E%60 ))s) ==="
 ln -sf "$LOG_FILE" "$PROJECT_DIR/logs/yt-ingest-latest.log"


### PR DESCRIPTION
## Summary

- Create `tools/cron/auto-deploy.sh` as the single deployer service -- the ONLY thing that regenerates `docs/` and deploys to GitHub Pages
- Strip deploy.sh calls from 9 cron scripts (ingest, yt-ingest, article-rewrite, wikipedia-discover, wikipedia-rewrite, tag-articles, affiliate-suggest, generate-images, ingest-and-publish)
- Remove DEPLOY_OVERHEAD from time budgets so jobs get more processing time
- Route build-weekly.sh and friday-publish.sh through auto-deploy.sh for immediate deploys
- Update editorial-prompt.md to document that the editorial loop should not deploy directly
- Add `npm run deploy:auto` script

## How it works

All cron jobs now only write to DB + `library/`. The auto-deploy service runs every 30 minutes (via launchd) and:
1. Acquires a lock to prevent racing
2. Pulls latest main
3. Regenerates static site from DB state
4. If `docs/` changed: creates a deploy branch, PR, and admin-merges
5. Cleans up the branch

For urgent deploys (weekly epub, Friday publish), scripts call `auto-deploy.sh` directly.

`deploy.sh` is kept intact for manual use.

## Test plan

- [x] Lint passes
- [x] Typecheck passes
- [x] Unit tests pass (143/143)
- [ ] Verify no cron script references deploy.sh anymore (confirmed via grep)
- [ ] Verify auto-deploy.sh is executable


🤖 Generated with [Claude Code](https://claude.com/claude-code)