### PR TITLE
Restyle affiliate links to match deep dives

### DIFF
--- a/src/api/pages.ts
+++ b/src/api/pages.ts
@@ -351,19 +351,20 @@ export function createPagesRouter(pool: Pool): Router {
       let affiliateSection = '';
       if (affiliateTag && rawAffiliateLinks.length > 0) {
         const affiliateItems = rawAffiliateLinks.map(link =>
-          `<li class="affiliate-item">
+          `<li class="deep-dive-item">
             <a href="https://www.amazon.com/dp/${encodeURIComponent(link.asin)}?tag=${encodeURIComponent(affiliateTag)}" target="_blank" rel="noopener sponsored">
-              <strong>${escapeHtml(link.title)}</strong> by ${escapeHtml(link.author)}
+              <strong>${escapeHtml(link.title)}</strong> \u2192
+              <span class="read-time">by ${escapeHtml(link.author)}</span>
             </a>
-            <p class="affiliate-desc">${escapeHtml(link.description)}</p>
+            <p class="topic-summary">${escapeHtml(link.description)}</p>
           </li>`
         ).join('\n');
         affiliateSection = `
-          <aside class="affiliate-section">
-            <h2>Recommended Reading</h2>
-            <p class="affiliate-disclosure">As an Amazon Associate, Hex Index earns from qualifying purchases.</p>
-            <ul class="affiliate-list">${affiliateItems}</ul>
-          </aside>
+          <section class="deep-dives books-section">
+            <h2>Books</h2>
+            <ul class="deep-dive-list">${affiliateItems}</ul>
+            <small class="affiliate-disclosure">Affiliate links</small>
+          </section>
         `;
       }
 

--- a/tools/static-site/utils.ts
+++ b/tools/static-site/utils.ts
@@ -255,22 +255,23 @@ export function renderAffiliateSection(
   if (!tag || links.length === 0) {return '';}
 
   const items = links.map(link => `
-    <li class="affiliate-item">
+    <li class="deep-dive-item">
       <a href="${buildAmazonUrl(link.asin, tag)}" target="_blank" rel="noopener sponsored">
-        <strong>${escapeHtml(link.title)}</strong> by ${escapeHtml(link.author)}
+        <strong>${escapeHtml(link.title)}</strong> \u2192
+        <span class="read-time">by ${escapeHtml(link.author)}</span>
       </a>
-      <p class="affiliate-desc">${escapeHtml(link.description)}</p>
+      <p class="topic-summary">${escapeHtml(link.description)}</p>
     </li>`
   ).join('\n');
 
   return `
-    <aside class="affiliate-section">
-      <h2>Recommended Reading</h2>
-      <p class="affiliate-disclosure">As an Amazon Associate, Hex Index earns from qualifying purchases.</p>
-      <ul class="affiliate-list">
+    <section class="deep-dives books-section">
+      <h2>Books</h2>
+      <ul class="deep-dive-list">
         ${items}
       </ul>
-    </aside>
+      <small class="affiliate-disclosure">Affiliate links</small>
+    </section>
   `;
 }
 


### PR DESCRIPTION
## Summary
- Replaced ad-like `<aside class="affiliate-section">` with `<section class="deep-dives books-section">` using the same CSS classes as Wikipedia deep dives
- Changed heading from "Recommended Reading" to "Books"
- Each book now uses `deep-dive-item` markup: title as strong link with `→` external indicator, author in `read-time` span, description in `topic-summary` paragraph
- Moved FTC disclosure from prominent paragraph to `<small class="affiliate-disclosure">Affiliate links</small>` footnote
- Updated both static site generator (`tools/static-site/utils.ts`) and Express route (`src/api/pages.ts`)

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests)
- [ ] Visual verification: regenerate static site and confirm books section matches deep dives styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)