### PR TITLE
feat: books are Wikipedia deep dives with purchase links

### DIFF
--- a/src/api/pages.ts
+++ b/src/api/pages.ts
@@ -12,6 +12,8 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'pg';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { loadAffiliateBooks, renderBookPurchaseLinks } from '../../tools/static-site/utils.js';
+import type { ParsedAffiliateBook } from '../../tools/static-site/utils.js';
 
 interface Article {
   id: string;
@@ -196,6 +198,10 @@ export function createPagesRouter(pool: Pool): Router {
   const router = Router();
   const libraryPath = join(process.cwd(), 'library');
 
+  // Load affiliate books map once at router creation
+  let affiliateBooksMap: Map<string, ParsedAffiliateBook> = new Map();
+  void loadAffiliateBooks(process.cwd()).then(map => { affiliateBooksMap = map; });
+
   // Home page - list recent articles
   router.get('/', async (_req: Request, res: Response) => {
     try {
@@ -333,40 +339,38 @@ export function createPagesRouter(pool: Pool): Router {
       // Extract subtitle from tags if present
       const subtitle = article.tags?.subtitle || '';
 
+      // Build book deep dives from affiliate_links — merged into deep dives section
+      const rawAffiliateLinks = Array.isArray(article.affiliate_links) ? article.affiliate_links : [];
+      const bookItems: string[] = [];
+      for (const link of rawAffiliateLinks) {
+        // Check if this book has a Wikipedia page
+        const wikiResult2 = await pool.query<{ slug: string }>(
+          `SELECT slug FROM app.wikipedia_articles WHERE LOWER(title) = LOWER($1) AND status = 'complete' LIMIT 1`,
+          [link.title]
+        );
+        const wikiSlug = wikiResult2.rows[0]?.slug ?? null;
+        const inner = wikiSlug
+          ? `<a href="/wikipedia/${escapeHtml(wikiSlug)}">${escapeHtml(link.title)}</a>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`
+          : `<span class="deep-dive-no-link">${escapeHtml(link.title)}</span>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`;
+        bookItems.push(`<li>${inner}</li>`);
+      }
+
       // Render Wikipedia deep dives section - compact list before content
-      const wikiSection = wikiLinks.length > 0 ? `
+      // Includes both Wikipedia articles and books (merged into one list)
+      const allDeepDiveItems = [
+        ...wikiLinks.map(w => `
+              <li><a href="/wikipedia/${escapeHtml(w.slug)}">${escapeHtml(w.title)}</a>${w.read_time ? ` <span class="read-time">${w.read_time} min</span>` : ''}</li>
+            `),
+        ...bookItems,
+      ];
+      const wikiSection = allDeepDiveItems.length > 0 ? `
         <nav class="deep-dives" aria-label="Related Wikipedia articles">
           <p class="deep-dives-label">Deep Dives</p>
           <ul class="deep-dives-list">
-            ${wikiLinks.map(w => `
-              <li><a href="/wikipedia/${escapeHtml(w.slug)}">${escapeHtml(w.title)}</a>${w.read_time ? ` <span class="read-time">${w.read_time} min</span>` : ''}</li>
-            `).join('')}
+            ${allDeepDiveItems.join('')}
           </ul>
         </nav>
       ` : '';
-
-      // Build affiliate links section
-      const affiliateTag = process.env.AMAZON_AFFILIATE_TAG ?? '';
-      const rawAffiliateLinks = Array.isArray(article.affiliate_links) ? article.affiliate_links : [];
-      let affiliateSection = '';
-      if (affiliateTag && rawAffiliateLinks.length > 0) {
-        const affiliateItems = rawAffiliateLinks.map(link =>
-          `<li class="deep-dive-item">
-            <a href="https://www.amazon.com/dp/${encodeURIComponent(link.asin)}?tag=${encodeURIComponent(affiliateTag)}" target="_blank" rel="noopener sponsored">
-              <strong>${escapeHtml(link.title)}</strong> \u2192
-              <span class="read-time">by ${escapeHtml(link.author)}</span>
-            </a>
-            <p class="topic-summary">${escapeHtml(link.description)}</p>
-          </li>`
-        ).join('\n');
-        affiliateSection = `
-          <section class="deep-dives books-section">
-            <h2>Books</h2>
-            <ul class="deep-dive-list">${affiliateItems}</ul>
-            <small class="affiliate-disclosure">Affiliate links</small>
-          </section>
-        `;
-      }
 
       // Optimized article layout for Speechify:
       // 1. Title (h1) - Speechify starts here by default
@@ -394,7 +398,6 @@ export function createPagesRouter(pool: Pool): Router {
           <div class="article-content">
             ${articleContent}
           </div>
-          ${affiliateSection}
         </article>
       `;
 
@@ -519,11 +522,19 @@ export function createPagesRouter(pool: Pool): Router {
         </nav>
       ` : '';
 
+      // Check if this Wikipedia article is about a book
+      const matchedBook = affiliateBooksMap.get(wiki.title.toLowerCase());
+      const affiliateTag = process.env.AMAZON_AFFILIATE_TAG ?? '';
+      const purchaseLinksHtml = matchedBook
+        ? renderBookPurchaseLinks(matchedBook, affiliateTag)
+        : '';
+
       // Optimized Wikipedia layout for Speechify:
       // 1. Type badge + Title
       // 2. Meta: read time, source link
       // 3. Related Substack articles
       // 4. Content
+      // 5. Purchase links (if it's a book)
       const content = `
         <article class="article content-width wikipedia-article">
           <header class="article-header">
@@ -537,6 +548,7 @@ export function createPagesRouter(pool: Pool): Router {
           <div class="article-content">
             ${wikiContent}
           </div>
+          ${purchaseLinksHtml}
         </article>
       `;
 

--- a/tools/static-site/pages/article.ts
+++ b/tools/static-site/pages/article.ts
@@ -5,7 +5,7 @@
 
 import type { Pool } from 'pg';
 import { staticReadingLayout } from '../templates.js';
-import { writeFile, extractHtmlExcerpt, escapeHtml, formatDate, renderAffiliateSection } from '../utils.js';
+import { writeFile, extractHtmlExcerpt, escapeHtml, formatDate, loadAffiliateBooks } from '../utils.js';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
 
@@ -120,6 +120,16 @@ function injectImageIntoText(html: string, imageSrc: string): string {
 }
 
 /**
+ * A book from affiliate_links that may or may not have a Wikipedia page
+ */
+interface BookDeepDive {
+  title: string;
+  author: string;
+  description: string;
+  wikiSlug: string | null;
+}
+
+/**
  * Generate article excerpt page HTML
  * Layout order: Title/byline → Deep Dives → Excerpt → Link to original
  */
@@ -127,19 +137,17 @@ function generateArticlePage(
   article: ArticleRow,
   contentHtml: string,
   wikipediaLinks: WikipediaLink[],
+  bookDeepDives: BookDeepDive[],
   isFullRewrite: boolean = false,
-  excerptHtml: string = '',
-  affiliateLinks: Array<{ asin: string; title: string; author: string; description: string }> = []
+  excerptHtml: string = ''
 ): string {
   const date = formatDate(article.published_at);
   const pathToRoot = '../../';
 
-  // Deep dives section if Wikipedia links exist - shown FIRST after header
-  let deepDivesHtml = '';
-  if (wikipediaLinks.length > 0) {
-    const linkItems = wikipediaLinks
-      .map(
-        (w) => `
+  // Merge Wikipedia links and books into a single deep dives list
+  const wikiItems = wikipediaLinks
+    .map(
+      (w) => `
       <li class="deep-dive-item">
         <a href="${pathToRoot}wikipedia/${w.slug}/index.html">
           <strong>${escapeHtml(w.title)}</strong>
@@ -147,22 +155,41 @@ function generateArticlePage(
         </a>
         <p class="topic-summary">${escapeHtml(w.topic_summary)}</p>
       </li>`
-      )
-      .join('\n');
+    )
+    .join('\n');
 
+  const bookItems = bookDeepDives
+    .map((b) => {
+      const inner = b.wikiSlug
+        ? `<a href="${pathToRoot}wikipedia/${b.wikiSlug}/index.html">
+          <strong>${escapeHtml(b.title)}</strong>
+          <span class="read-time">by ${escapeHtml(b.author)}</span>
+        </a>`
+        : `<span class="deep-dive-no-link">
+          <strong>${escapeHtml(b.title)}</strong>
+          <span class="read-time">by ${escapeHtml(b.author)}</span>
+        </span>`;
+      return `
+      <li class="deep-dive-item">
+        ${inner}
+        <p class="topic-summary">${escapeHtml(b.description)}</p>
+      </li>`;
+    })
+    .join('\n');
+
+  const allItems = wikiItems + bookItems;
+  let deepDivesHtml = '';
+  if (allItems.trim()) {
     deepDivesHtml = `
       <section id="deep-dives" class="deep-dives">
         <h2>Deep Dives</h2>
         <p class="deep-dives-intro">Explore related topics with these Wikipedia articles, rewritten for enjoyable reading:</p>
         <ul class="deep-dive-list">
-          ${linkItems}
+          ${allItems}
         </ul>
       </section>
     `;
   }
-
-  const affiliateTag = process.env.AMAZON_AFFILIATE_TAG ?? '';
-  const affiliateHtml = renderAffiliateSection(affiliateLinks, affiliateTag);
 
   const authorName = article.author_name ?? 'Unknown';
   const pubName = escapeHtml(article.publication_name);
@@ -230,13 +257,10 @@ function generateArticlePage(
 
       ${deepDivesHtml}
 
-      ${affiliateHtml}
-
       ${excerptSection}
       ` : `
       ${deepDivesHtml}
 
-      ${affiliateHtml}
       <div class="excerpt-card">
         <div class="article-excerpt">
           ${mainContent}
@@ -256,6 +280,20 @@ function generateArticlePage(
 }
 
 /**
+ * Look up a Wikipedia article slug by book title (case-insensitive)
+ */
+async function findWikiSlugForBook(
+  pool: Pool,
+  bookTitle: string
+): Promise<string | null> {
+  const result = await pool.query<{ slug: string }>(
+    `SELECT slug FROM app.wikipedia_articles WHERE LOWER(title) = LOWER($1) AND status = 'complete' LIMIT 1`,
+    [bookTitle]
+  );
+  return result.rows[0]?.slug ?? null;
+}
+
+/**
  * Generate all article pages
  */
 export async function generateArticlePages(
@@ -263,6 +301,7 @@ export async function generateArticlePages(
   outputDir: string
 ): Promise<{ pagesGenerated: number }> {
   const articles = await getAllArticles(pool);
+  const affiliateBooksMap = await loadAffiliateBooks(process.cwd());
   let pagesGenerated = 0;
 
   for (const article of articles) {
@@ -279,8 +318,23 @@ export async function generateArticlePages(
     }
     const wikipediaLinks = await getLinkedWikipedia(pool, article.id);
 
-    const affiliateLinks = Array.isArray(article.affiliate_links) ? article.affiliate_links : [];
-    const html = generateArticlePage(article, displayContent, wikipediaLinks, hasRewrite, hasRewrite ? excerpt : '', affiliateLinks);
+    // Build book deep dives from affiliate_links on the article
+    const rawAffiliateLinks = Array.isArray(article.affiliate_links) ? article.affiliate_links : [];
+    const bookDeepDives: BookDeepDive[] = [];
+    for (const link of rawAffiliateLinks) {
+      // Check if this book has a Wikipedia page
+      const wikiSlug = await findWikiSlugForBook(pool, link.title);
+      // Use description from the affiliate books map if available, fall back to article's affiliate_links
+      const mapEntry = affiliateBooksMap.get(link.title.toLowerCase());
+      bookDeepDives.push({
+        title: link.title,
+        author: link.author,
+        description: mapEntry?.description ?? link.description,
+        wikiSlug,
+      });
+    }
+
+    const html = generateArticlePage(article, displayContent, wikipediaLinks, bookDeepDives, hasRewrite, hasRewrite ? excerpt : '');
     const filePath = join(outputDir, 'article', article.id, 'index.html');
 
     await writeFile(filePath, html);

--- a/tools/static-site/pages/wikipedia.ts
+++ b/tools/static-site/pages/wikipedia.ts
@@ -4,7 +4,8 @@
 
 import type { Pool } from 'pg';
 import { staticReadingLayout } from '../templates.js';
-import { writeFile, escapeHtml, renderAffiliateSection } from '../utils.js';
+import { writeFile, escapeHtml, renderBookPurchaseLinks, loadAffiliateBooks } from '../utils.js';
+import type { ParsedAffiliateBook } from '../utils.js';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
 
@@ -92,11 +93,16 @@ function generateWikipediaPage(
   wiki: WikipediaRow,
   content: string,
   relatedArticles: RelatedArticle[],
-  affiliateLinks: Array<{ asin: string; title: string; author: string; description: string }> = []
+  affiliateBooksMap: Map<string, ParsedAffiliateBook>
 ): string {
   const pathToRoot = '../../';
   const affiliateTag = process.env.AMAZON_AFFILIATE_TAG ?? '';
-  const affiliateHtml = renderAffiliateSection(affiliateLinks, affiliateTag);
+
+  // Check if this Wikipedia article is about a book
+  const matchedBook = affiliateBooksMap.get(wiki.title.toLowerCase());
+  const purchaseLinksHtml = matchedBook
+    ? renderBookPurchaseLinks(matchedBook, affiliateTag)
+    : '';
 
   // Related articles section
   let relatedHtml = '';
@@ -156,7 +162,7 @@ function generateWikipediaPage(
 
       ${contentBlock}
 
-      ${affiliateHtml}
+      ${purchaseLinksHtml}
 
       <footer class="wikipedia-footer">
         <p class="source-link">
@@ -182,14 +188,14 @@ export async function generateWikipediaPages(
   outputDir: string
 ): Promise<{ pagesGenerated: number }> {
   const wikiArticles = await getAllWikipediaArticles(pool);
+  const affiliateBooksMap = await loadAffiliateBooks(process.cwd());
   let pagesGenerated = 0;
 
   for (const wiki of wikiArticles) {
     const content = await readWikipediaContent(wiki.content_path);
     const relatedArticles = await getRelatedArticles(pool, wiki.id);
 
-    const wikiAffiliateLinks = Array.isArray(wiki.affiliate_links) ? wiki.affiliate_links : [];
-    const html = generateWikipediaPage(wiki, content, relatedArticles, wikiAffiliateLinks);
+    const html = generateWikipediaPage(wiki, content, relatedArticles, affiliateBooksMap);
     const filePath = join(outputDir, 'wikipedia', wiki.slug, 'index.html');
 
     await writeFile(filePath, html);

--- a/tools/static-site/utils.ts
+++ b/tools/static-site/utils.ts
@@ -245,33 +245,80 @@ export function buildAmazonUrl(asin: string, tag: string): string {
 }
 
 /**
- * Render an affiliate links section for static HTML pages.
- * Tasteful, at break points — like the deep dives section.
+ * Affiliate book entry from content/affiliate-books.json
  */
-export function renderAffiliateSection(
-  links: Array<{ asin: string; title: string; author: string; description: string }>,
-  tag: string
-): string {
-  if (!tag || links.length === 0) {return '';}
+export interface AffiliateBook {
+  asin: string;
+  category: string;
+  description: string;
+  gutenberg_url?: string;
+  archive_url?: string;
+}
 
-  const items = links.map(link => `
-    <li class="deep-dive-item">
-      <a href="${buildAmazonUrl(link.asin, tag)}" target="_blank" rel="noopener sponsored">
-        <strong>${escapeHtml(link.title)}</strong> \u2192
-        <span class="read-time">by ${escapeHtml(link.author)}</span>
-      </a>
-      <p class="topic-summary">${escapeHtml(link.description)}</p>
-    </li>`
-  ).join('\n');
+/**
+ * Parsed affiliate book with title and author extracted from the key
+ */
+export interface ParsedAffiliateBook extends AffiliateBook {
+  title: string;
+  author: string;
+}
+
+/**
+ * Load and parse the affiliate books map from content/affiliate-books.json.
+ * Call once at the top of a generation run, not per-page.
+ * Returns a Map keyed by lowercase book title for fast lookup.
+ */
+export async function loadAffiliateBooks(projectRoot: string): Promise<Map<string, ParsedAffiliateBook>> {
+  const { readFile } = await import('fs/promises');
+  const { join } = await import('path');
+  const filePath = join(projectRoot, 'content', 'affiliate-books.json');
+  try {
+    const raw = await readFile(filePath, 'utf-8');
+    const data = JSON.parse(raw) as Record<string, AffiliateBook>;
+    const map = new Map<string, ParsedAffiliateBook>();
+    for (const [key, value] of Object.entries(data)) {
+      const [title, author] = key.split('|');
+      if (title && author) {
+        map.set(title.toLowerCase(), { ...value, title, author });
+      }
+    }
+    return map;
+  } catch {
+    console.warn('Warning: Could not load affiliate-books.json');
+    return new Map();
+  }
+}
+
+/**
+ * Render purchase links footer for a Wikipedia page about a book.
+ * Subtle: small text, no heading, just links.
+ * Free sources first, paid second.
+ */
+export function renderBookPurchaseLinks(book: ParsedAffiliateBook, affiliateTag: string): string {
+  const items: string[] = [];
+  const searchQuery = encodeURIComponent(`${book.title} ${book.author}`);
+
+  // Free sources first
+  if (book.gutenberg_url) {
+    items.push(`<li><a href="${book.gutenberg_url}" target="_blank" rel="noopener">Project Gutenberg (free)</a></li>`);
+  }
+  if (book.archive_url) {
+    items.push(`<li><a href="${book.archive_url}" target="_blank" rel="noopener">Internet Archive (free)</a></li>`);
+  }
+
+  // Paid sources
+  if (affiliateTag) {
+    items.push(`<li><a href="${buildAmazonUrl(book.asin, affiliateTag)}" target="_blank" rel="noopener sponsored">Amazon (ebook) <small class="affiliate-disclosure">affiliate</small></a></li>`);
+  }
+  items.push(`<li><a href="https://www.kobo.com/search?query=${searchQuery}" target="_blank" rel="noopener">Kobo (ebook)</a></li>`);
+  items.push(`<li><a href="https://www.betterworldbooks.com/search/results?q=${searchQuery}" target="_blank" rel="noopener">Better World Books</a></li>`);
 
   return `
-    <section class="deep-dives books-section">
-      <h2>Books</h2>
-      <ul class="deep-dive-list">
-        ${items}
+    <footer class="book-links">
+      <ul>
+        ${items.join('\n        ')}
       </ul>
-      <small class="affiliate-disclosure">Affiliate links</small>
-    </section>
+    </footer>
   `;
 }
 


### PR DESCRIPTION
## Summary

Closes #126

- **Wikipedia pages about books** now show subtle purchase links at the bottom (free sources first: Gutenberg, Internet Archive; then paid: Amazon affiliate, Kobo, Better World Books)
- **Article pages** merge books into the Deep Dives section alongside Wikipedia links — no more separate "Books" / affiliate section
- Books that have a corresponding Wikipedia article link directly to it; books without one appear but without a link
- `renderAffiliateSection()` removed from utils; replaced by `renderBookPurchaseLinks()` and `loadAffiliateBooks()`
- Affiliate books map loaded once per generation run, not per-page
- Amazon link only renders when `AMAZON_AFFILIATE_TAG` env var is set

## Files changed

- `tools/static-site/utils.ts` — removed `renderAffiliateSection`, added `loadAffiliateBooks`, `renderBookPurchaseLinks`, affiliate book types
- `tools/static-site/pages/wikipedia.ts` — checks affiliate books map, renders purchase links footer
- `tools/static-site/pages/article.ts` — merges books into deep dives list, removes separate affiliate section
- `src/api/pages.ts` — same changes for the private Express library

## Test plan

- [x] `npm run lint` passes (0 errors, 0 warnings)
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests)
- [ ] Verify Wikipedia pages for books show purchase links at bottom
- [ ] Verify article deep dives section includes books alongside Wikipedia links
- [ ] Verify separate affiliate/books section is gone from article pages
- [ ] Verify Amazon link only renders when AMAZON_AFFILIATE_TAG is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)