### PR TITLE
fix: switch all LLM defaults to Qwen 3.5 122B

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,7 +483,7 @@ This project assumes:
 - **API**: Express.js with TypeScript
 - **Frontend**: Vite with TypeScript
 - **Testing**: Vitest (not Jest), Playwright for E2E
-- **Local LLM**: Qwen 3 235B via Ollama (88% GPU / 12% CPU on Mac Studio M2 Ultra)
+- **Local LLM**: Qwen 3.5 122B via Ollama on Mac Studio M2 Ultra
 - **Cloud LLM**: Claude Opus 4.6 via Max subscription (`claude -p`), Sonnet 4.6 via API for batch jobs
 - **Image Generation**: Gemini 2.5 Flash Image API
 - **Deployment**: GitHub Pages (static site), local (private library)

--- a/src/wikipedia/ollama.ts
+++ b/src/wikipedia/ollama.ts
@@ -9,7 +9,7 @@
  */
 
 const OLLAMA_URL = process.env.OLLAMA_URL || 'http://127.0.0.1:11434';
-const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'hf.co/unsloth/MiniMax-M2.5-GGUF:latest';
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'qwen3.5:122b-a10b';
 const DEFAULT_TIMEOUT = parseInt(process.env.HEX_TASK_TIMEOUT_MS || '900000', 10);
 
 interface GenerateOptions {

--- a/tools/cron/affiliate-suggest.sh
+++ b/tools/cron/affiliate-suggest.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/affiliate-suggest.lock"
 LOG_FILE="$PROJECT_DIR/logs/affiliate-suggest-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
 
 TIME_BUDGET=1500        # 25 minutes — fits odd-hour Qwen slot
 SECS_PER_ITEM=10

--- a/tools/cron/article-rewrite.sh
+++ b/tools/cron/article-rewrite.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/article-rewrite.lock"
 LOG_FILE="$PROJECT_DIR/logs/article-rewrite-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
 
 TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot
 SECS_PER_ITEM=50

--- a/tools/cron/claude-quality.sh
+++ b/tools/cron/claude-quality.sh
@@ -2,8 +2,8 @@
 # Claude Quality Guardian
 #
 # Daily job that uses Claude Opus 4.6 (via Max subscription) to audit
-# and improve content that MiniMax generated. Runs at 05:00 UTC when
-# MiniMax jobs are quiet.
+# and improve content that Qwen generated. Runs at 05:00 UTC when
+# Qwen jobs are quiet.
 #
 # Claude reads recently created/modified HTML files and:
 #   1. Strips any remaining LLM artifacts regex missed
@@ -11,7 +11,7 @@
 #   3. Ensures editorial quality standards
 #   4. Reports what it fixed
 #
-# This is NOT a rewrite — Claude makes surgical fixes to MiniMax output.
+# This is NOT a rewrite — Claude makes surgical fixes to Qwen output.
 
 set -euo pipefail
 
@@ -69,7 +69,7 @@ done <<< "$ALL_FILES"
 # Uses Max subscription (Opus 4.6) — no API key needed
 log "Launching Claude Opus 4.6 quality guardian..."
 
-timeout 3600 claude -p "You are the quality guardian for a curated reading library. A local LLM (MiniMax 122B) generates article commentary and Wikipedia essays. Your job: read each file, judge quality, and rewrite anything that falls short. You own the final quality.
+timeout 3600 claude -p "You are the quality guardian for a curated reading library. A local LLM (Qwen 3.5 122B) generates article commentary and Wikipedia essays. Your job: read each file, judge quality, and rewrite anything that falls short. You own the final quality.
 
 FILES TO AUDIT AND IMPROVE:
 ${FILE_LIST}
@@ -114,7 +114,7 @@ Essays should read like engaging magazine features, not encyclopedias:
 ## HOW TO FIX
 
 - For artifacts, garble, and structural issues: edit surgically.
-- For weak writing: REWRITE the section or paragraph to meet the standard above. You are not preserving MiniMax's voice — you are replacing it with quality editorial prose.
+- For weak writing: REWRITE the section or paragraph to meet the standard above. You are not preserving Qwen's voice — you are replacing it with quality editorial prose.
 - If a file meets quality standards, skip it silently.
 - If a file needs heavy rewriting (more than 30% of content), rewrite the whole thing.
 - Edit files in place using the Edit tool.

--- a/tools/cron/ingest-and-publish.sh
+++ b/tools/cron/ingest-and-publish.sh
@@ -19,7 +19,7 @@ LOG_FILE="$PROJECT_DIR/logs/ingest-$(date +%Y%m%d-%H%M%S).log"
 LATEST_LOG="$PROJECT_DIR/logs/ingestion-latest.log"
 ENRICHMENT_TIMEOUT=18000  # 5 hours
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
 
 mkdir -p "$PROJECT_DIR/logs"
 cd "$PROJECT_DIR"

--- a/tools/cron/tag-articles.sh
+++ b/tools/cron/tag-articles.sh
@@ -12,7 +12,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/tag-articles.lock"
 LOG_FILE="$PROJECT_DIR/logs/tag-articles-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
 
 TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot
 SECS_PER_ITEM=15

--- a/tools/cron/wikipedia-discover.sh
+++ b/tools/cron/wikipedia-discover.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/wiki-discover.lock"
 LOG_FILE="$PROJECT_DIR/logs/wiki-discover-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
 
 # Tuning constants
 TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot

--- a/tools/cron/wikipedia-rewrite.sh
+++ b/tools/cron/wikipedia-rewrite.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/wiki-rewrite.lock"
 LOG_FILE="$PROJECT_DIR/logs/wiki-rewrite-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3:235b-a22b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
 
 TIME_BUDGET=1500        # 25 minutes — fits odd-hour Qwen slot
 SECS_PER_ITEM=80

--- a/tools/jobs/audit-html.ts
+++ b/tools/jobs/audit-html.ts
@@ -2,7 +2,7 @@
  * Audit and fix JSON metadata contamination in library HTML files.
  *
  * Scans all rewritten article and Wikipedia HTML files for JSON artifacts
- * left by MiniMax LLM output, and cleans them in-place.
+ * left by LLM output, and cleans them in-place.
  *
  * Usage:
  *   npx tsx tools/jobs/audit-html.ts                    # dry run (report only)

--- a/tools/jobs/clean-llm-output.ts
+++ b/tools/jobs/clean-llm-output.ts
@@ -1,6 +1,6 @@
 /**
  * Shared LLM output cleanup — strips JSON artifacts, think tags,
- * preamble, and other MiniMax quirks from generated text.
+ * preamble, and other LLM quirks from generated text.
  *
  * Used by article-rewrite.ts, wikipedia-rewrite.ts, and audit-html.ts.
  *
@@ -19,7 +19,7 @@
  *   - --- separators with short preamble
  *   - Common LLM preamble phrases
  *   - JSON wrappers: {"content": "..."}, {"text": "..."}, etc.
- *   - Malformed JSON prefixes from MiniMax
+ *   - Malformed JSON prefixes from LLM
  *   - JSON array variants: {"content": ["..."]}
  *   - Multi-key JSON objects with title/author/pitch/body fields
  *   - Nested JSON: {"": {"title": ...}}
@@ -121,7 +121,7 @@ export function cleanPreamble(text: string): string {
   // 10. Strip JSON metadata prefix: title", "author": "Name", "piece": "actual content
   cleaned = cleaned.replace(/^[^"]*",\s*"(?:author|title|source)":\s*"[^"]*",\s*"(?:piece|content|text|essay|commentary)":\s*"/, '').trim();
 
-  // 11. Strip {"content": ["text... (array variant from MiniMax)
+  // 11. Strip {"content": ["text... (array variant from LLM)
   cleaned = cleaned.replace(/^\s*\{\s*"(?:content|text|piece|essay|commentary)"\s*:\s*\[\s*"?/, '').trim();
   cleaned = cleaned.replace(/"\s*\]?\s*\}\s*$/, '').trim();
 
@@ -129,7 +129,7 @@ export function cleanPreamble(text: string): string {
   cleaned = cleaned.replace(/"\s*\}\s*$/, '').trim();
 
   // 13. Strip trailing ```json {...} blocks anywhere in text
-  //     MiniMax sometimes appends JSON after seemingly complete content
+  //     LLM sometimes appends JSON after seemingly complete content
   cleaned = cleaned.replace(/\s*```\s*json\s*\{[\s\S]*?\}\s*```\s*/g, '').trim();
   // Also without closing fence
   cleaned = cleaned.replace(/\s*```\s*json\s*\{[\s\S]*$/g, '').trim();
@@ -490,7 +490,7 @@ export function cleanHtml(html: string): { cleaned: string; changed: boolean } {
     '$1'
   );
 
-  // Pattern 11: Chinese/garbled characters from MiniMax (non-Latin noise in English text)
+  // Pattern 11: Chinese/garbled characters from LLM (non-Latin noise in English text)
   //   e.g. 不需要人类。 or 核心
   //   Only strip if surrounded by English text (don't strip intentional CJK content)
   // This is a conservative pattern — only strips short CJK sequences mid-English-sentence

--- a/tools/jobs/expand-affiliate-map.ts
+++ b/tools/jobs/expand-affiliate-map.ts
@@ -416,7 +416,7 @@ async function main(): Promise<void> {
   }
 
   const ollamaUrl = process.env.OLLAMA_URL ?? 'http://127.0.0.1:11434';
-  const ollamaModel = process.env.OLLAMA_MODEL ?? 'qwen3:235b-a22b';
+  const ollamaModel = process.env.OLLAMA_MODEL ?? 'qwen3.5:122b-a10b';
 
   const bookMap = await loadBookMap();
   const unresolved = await loadUnresolvedMentions();


### PR DESCRIPTION
## Summary
- Replace all default model references from `qwen3:235b-a22b` and `hf.co/unsloth/MiniMax-M2.5-GGUF:latest` to `qwen3.5:122b-a10b`
- Fix `ingest-and-publish.sh` which had partial tag `qwen3.5:122b` (missing `-a10b` suffix)
- Update MiniMax LLM comments in `claude-quality.sh`, `clean-llm-output.ts`, and `audit-html.ts` to reference Qwen
- Update `CLAUDE.md` architecture section to reflect new model

## Files changed (12)
- `tools/cron/article-rewrite.sh`
- `tools/cron/affiliate-suggest.sh`
- `tools/cron/wikipedia-discover.sh`
- `tools/cron/wikipedia-rewrite.sh`
- `tools/cron/tag-articles.sh`
- `tools/cron/ingest-and-publish.sh`
- `tools/cron/claude-quality.sh`
- `src/wikipedia/ollama.ts`
- `tools/jobs/expand-affiliate-map.ts`
- `tools/jobs/clean-llm-output.ts`
- `tools/jobs/audit-html.ts`
- `CLAUDE.md`

## Test plan
- [x] Lint passes
- [x] Typecheck passes
- [x] All 143 tests pass
- [x] Verified no stale `235b` or `MiniMax` model refs remain (only article content about the MiniMax company in `docs/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)