### PR TITLE
feat: add 4 books to affiliate catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -87,5 +87,9 @@
   "Spillover|David Quammen": {"asin": "0393346617", "category": "books", "description": "How animal infections jump to humans — the science of the next pandemic, written before COVID."},
   "The Hot Zone|Richard Preston": {"asin": "0385495226", "category": "books", "description": "The terrifying true story of Ebola's emergence — a thriller that reads like fiction but isn't."},
   "The Beatles|Bob Spitz": {"asin": "0316013315", "category": "books", "description": "The definitive biography of the Beatles — exhaustive, intimate, and authoritative."},
-  "Design Patterns|Erich Gamma": {"asin": "0201633612", "category": "books", "description": "The Gang of Four book — 23 reusable design patterns that changed how software is built."}
+  "Design Patterns|Erich Gamma": {"asin": "0201633612", "category": "books", "description": "The Gang of Four book — 23 reusable design patterns that changed how software is built."},
+  "1776|David McCullough": {"asin": "0743226720", "category": "books", "description": "The riveting account of the year that decided America's fate — from the siege of Boston to the crossing of the Delaware."},
+  "Cycles of Time|Roger Penrose": {"asin": "0307278468", "category": "books", "description": "Penrose's radical proposal that the universe cycles through infinite aeons — conformal cyclic cosmology explained."},
+  "How Buildings Learn|Stewart Brand": {"asin": "0140139966", "category": "books", "description": "What happens after buildings are built — how they adapt, evolve, and why some survive while others don't."},
+  "California Crackup|Joe Mathews": {"asin": "0520266560", "category": "books", "description": "How ballot initiatives, term limits, and structural dysfunction broke California's governance."}
 }


### PR DESCRIPTION
## Summary
- Added 4 new books to `content/affiliate-books.json`: 1776 (McCullough), Cycles of Time (Penrose), How Buildings Learn (Brand), California Crackup (Mathews)
- Updated affiliate_links in DB for 5 articles with curated recommendations
- Removed stale `tools/static-site/utils.js` build artifact that was breaking lint

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)