### PR TITLE
fix: move affiliate-books utilities into src/ to fix broken build

### DIFF
--- a/src/api/pages.ts
+++ b/src/api/pages.ts
@@ -12,8 +12,8 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'pg';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { loadAffiliateBooks, renderBookPurchaseLinks } from '../../tools/static-site/utils.js';
-import type { ParsedAffiliateBook } from '../../tools/static-site/utils.js';
+import { loadAffiliateBooks, renderBookPurchaseLinks } from '../lib/affiliate-books.js';
+import type { ParsedAffiliateBook } from '../lib/affiliate-books.js';
 
 interface Article {
   id: string;

--- a/src/lib/affiliate-books.ts
+++ b/src/lib/affiliate-books.ts
@@ -1,0 +1,92 @@
+/**
+ * Affiliate book utilities for the private library server.
+ *
+ * Copied from tools/static-site/utils.ts to keep everything under src/
+ * and avoid cross-boundary imports that break tsconfig.api.json rootDir.
+ */
+
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+/**
+ * Build an Amazon affiliate URL from ASIN and tag
+ */
+export function buildAmazonUrl(asin: string, tag: string): string {
+  return `https://www.amazon.com/dp/${encodeURIComponent(asin)}?tag=${encodeURIComponent(tag)}`;
+}
+
+/**
+ * Affiliate book entry from content/affiliate-books.json
+ */
+export interface AffiliateBook {
+  asin: string;
+  category: string;
+  description: string;
+  gutenberg_url?: string;
+  archive_url?: string;
+}
+
+/**
+ * Parsed affiliate book with title and author extracted from the key
+ */
+export interface ParsedAffiliateBook extends AffiliateBook {
+  title: string;
+  author: string;
+}
+
+/**
+ * Load and parse the affiliate books map from content/affiliate-books.json.
+ * Call once at the top of a generation run, not per-page.
+ * Returns a Map keyed by lowercase book title for fast lookup.
+ */
+export async function loadAffiliateBooks(projectRoot: string): Promise<Map<string, ParsedAffiliateBook>> {
+  const filePath = join(projectRoot, 'content', 'affiliate-books.json');
+  try {
+    const raw = await readFile(filePath, 'utf-8');
+    const data = JSON.parse(raw) as Record<string, AffiliateBook>;
+    const map = new Map<string, ParsedAffiliateBook>();
+    for (const [key, value] of Object.entries(data)) {
+      const [title, author] = key.split('|');
+      if (title && author) {
+        map.set(title.toLowerCase(), { ...value, title, author });
+      }
+    }
+    return map;
+  } catch {
+    console.warn('Warning: Could not load affiliate-books.json');
+    return new Map();
+  }
+}
+
+/**
+ * Render purchase links footer for a Wikipedia page about a book.
+ * Subtle: small text, no heading, just links.
+ * Free sources first, paid second.
+ */
+export function renderBookPurchaseLinks(book: ParsedAffiliateBook, affiliateTag: string): string {
+  const items: string[] = [];
+  const searchQuery = encodeURIComponent(`${book.title} ${book.author}`);
+
+  // Free sources first
+  if (book.gutenberg_url) {
+    items.push(`<li><a href="${book.gutenberg_url}" target="_blank" rel="noopener">Project Gutenberg (free)</a></li>`);
+  }
+  if (book.archive_url) {
+    items.push(`<li><a href="${book.archive_url}" target="_blank" rel="noopener">Internet Archive (free)</a></li>`);
+  }
+
+  // Paid sources
+  if (affiliateTag) {
+    items.push(`<li><a href="${buildAmazonUrl(book.asin, affiliateTag)}" target="_blank" rel="noopener sponsored">Amazon (ebook) <small class="affiliate-disclosure">affiliate</small></a></li>`);
+  }
+  items.push(`<li><a href="https://www.kobo.com/search?query=${searchQuery}" target="_blank" rel="noopener">Kobo (ebook)</a></li>`);
+  items.push(`<li><a href="https://www.betterworldbooks.com/search/results?q=${searchQuery}" target="_blank" rel="noopener">Better World Books</a></li>`);
+
+  return `
+    <footer class="book-links">
+      <ul>
+        ${items.join('\n        ')}
+      </ul>
+    </footer>
+  `;
+}

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -5,5 +5,5 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/api/**/*", "src/db/**/*"]
+  "include": ["src/api/**/*", "src/db/**/*", "src/lib/**/*"]
 }


### PR DESCRIPTION
## Summary
- Main branch build is broken: `src/api/pages.ts` imports from `tools/static-site/utils.ts` which is outside `tsconfig.api.json` rootDir (`src/`)
- Created `src/lib/affiliate-books.ts` with the needed functions (`loadAffiliateBooks`, `renderBookPurchaseLinks`, `buildAmazonUrl`) and types (`AffiliateBook`, `ParsedAffiliateBook`)
- Updated `src/api/pages.ts` imports to use the new local module
- Added `src/lib/**/*` to `tsconfig.api.json` include paths

## Test plan
- [x] `npm run build` passes (was failing with TS6059)
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests, 9 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)