### PR TITLE
feat: add 3 books to affiliate catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -98,5 +98,8 @@
   "Drift|Rachel Maddow": {"asin": "0307460983", "category": "books", "description": "How America drifted into a state of permanent war without the public noticing or consenting."},
   "Beyond Good and Evil|Friedrich Nietzsche": {"asin": "014044923X", "category": "books", "description": "Nietzsche's assault on conventional morality — arguing that hatred, envy, and power are essential to life."},
   "Silent Spring|Rachel Carson": {"asin": "0618249060", "category": "books", "description": "The book that launched the environmental movement — exposing how pesticides were poisoning the natural world."},
-  "The Closing of the American Mind|Allan Bloom": {"asin": "1451683200", "category": "books", "description": "Bloom's controversial argument that higher education has failed democracy and impoverished students' souls."}
+  "The Closing of the American Mind|Allan Bloom": {"asin": "1451683200", "category": "books", "description": "Bloom's controversial argument that higher education has failed democracy and impoverished students' souls."},
+  "The Gilded Age|Mark Twain": {"asin": "014043920X", "category": "books", "description": "The satirical novel that gave an era its name — Twain and Warner skewering post-Civil War greed and corruption."},
+  "Lifespan|David Sinclair": {"asin": "1797103296", "category": "books", "description": "A Harvard geneticist argues aging is a disease we can treat — and lays out the science for doing it."},
+  "The Music Lesson|Victor Wooten": {"asin": "0425220931", "category": "books", "description": "A bass legend teaches music through story — rhythm, space, and listening as spiritual practice."}
 }


### PR DESCRIPTION
## Summary
- Added 3 new books to `content/affiliate-books.json`: The Gilded Age (Twain), Lifespan (Sinclair), The Music Lesson (Wooten)
- Updated affiliate_links in DB for 5 articles:
  - **This Changes How You See the Entire Guitar Neck** → The Music Lesson (curated)
  - **How They Got Rich!** → The Gilded Age (direct), The Power Broker (curated)
  - **The $285B Sell-Off Was Just the Beginning** → Zero to One, The Second Machine Age (curated)
  - **Evolution designed us to die fast; we can change that** → Lifespan, The Beginning of Infinity (curated)
  - **The Fretboard Cheat Codes Every Guitarist Should Know** → The Music Lesson (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)