### PR TITLE
feat: add 2 books to affiliate catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -101,5 +101,7 @@
   "The Closing of the American Mind|Allan Bloom": {"asin": "1451683200", "category": "books", "description": "Bloom's controversial argument that higher education has failed democracy and impoverished students' souls."},
   "The Gilded Age|Mark Twain": {"asin": "014043920X", "category": "books", "description": "The satirical novel that gave an era its name — Twain and Warner skewering post-Civil War greed and corruption."},
   "Lifespan|David Sinclair": {"asin": "1797103296", "category": "books", "description": "A Harvard geneticist argues aging is a disease we can treat — and lays out the science for doing it."},
-  "The Music Lesson|Victor Wooten": {"asin": "0425220931", "category": "books", "description": "A bass legend teaches music through story — rhythm, space, and listening as spiritual practice."}
+  "The Music Lesson|Victor Wooten": {"asin": "0425220931", "category": "books", "description": "A bass legend teaches music through story — rhythm, space, and listening as spiritual practice."},
+  "Lyrical Ballads|William Wordsworth": {"asin": "0140424628", "category": "books", "description": "The slim 1798 volume that launched English Romanticism — Wordsworth and Coleridge redefining what poetry could be."},
+  "The Prelude|William Wordsworth": {"asin": "0140433694", "category": "books", "description": "Wordsworth's autobiographical epic — the growth of a poet's mind across four landmark texts."}
 }


### PR DESCRIPTION
## Summary
- Added 2 new books to `content/affiliate-books.json`: Lyrical Ballads (Wordsworth & Coleridge), The Prelude (Wordsworth)
- Updated affiliate_links in DB for 5 articles:
  - **Nightmare Fuzz Face Kit** → The Music Lesson (curated)
  - **The Friendship that Changed English Poetry** → Lyrical Ballads, The Prelude (both direct)
  - **The Problem With Science Communication** → Factfulness, The Structure of Scientific Revolutions (curated)
  - **The Future of Veritasium** → Deep Work, Atomic Habits (curated)
  - **Kevin Shirley: Stranded, Broke, and Deported** → The Music Lesson (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)