### PR TITLE
feat: add Sense and Sensibility to affiliate catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -103,5 +103,6 @@
   "Lifespan|David Sinclair": {"asin": "1797103296", "category": "books", "description": "A Harvard geneticist argues aging is a disease we can treat — and lays out the science for doing it."},
   "The Music Lesson|Victor Wooten": {"asin": "0425220931", "category": "books", "description": "A bass legend teaches music through story — rhythm, space, and listening as spiritual practice."},
   "Lyrical Ballads|William Wordsworth": {"asin": "0140424628", "category": "books", "description": "The slim 1798 volume that launched English Romanticism — Wordsworth and Coleridge redefining what poetry could be."},
-  "The Prelude|William Wordsworth": {"asin": "0140433694", "category": "books", "description": "Wordsworth's autobiographical epic — the growth of a poet's mind across four landmark texts."}
+  "The Prelude|William Wordsworth": {"asin": "0140433694", "category": "books", "description": "Wordsworth's autobiographical epic — the growth of a poet's mind across four landmark texts."},
+  "Sense and Sensibility|Jane Austen": {"asin": "0141439661", "category": "books", "description": "Austen's first published novel — two sisters navigating love, money, and society with contrasting temperaments."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book to `content/affiliate-books.json`: Sense and Sensibility (Austen)
- Updated affiliate_links in DB for 5 articles:
  - **human evolution questions that keep me up at night** → Sapiens (curated)
  - **10 Minute Masterclass: Claude Code Skills** → Atomic Habits (curated)
  - **Claude Code + Nano Banana = Beautiful Animated Websites** → The Design of Everyday Things (curated)
  - **The Biggest Misconception in Football (ft. Tom Brady)** → Structure of Scientific Revolutions, The Book of Why (curated)
  - **Sense & Sensibility | Chapter 1-6 Lecture** → Sense and Sensibility (direct), Lyrical Ballads (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)