### PR TITLE
feat: add Body by Science to affiliate catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -105,5 +105,6 @@
   "Lyrical Ballads|William Wordsworth": {"asin": "0140424628", "category": "books", "description": "The slim 1798 volume that launched English Romanticism — Wordsworth and Coleridge redefining what poetry could be."},
   "The Prelude|William Wordsworth": {"asin": "0140433694", "category": "books", "description": "Wordsworth's autobiographical epic — the growth of a poet's mind across four landmark texts."},
   "Sense and Sensibility|Jane Austen": {"asin": "0141439661", "category": "books", "description": "Austen's first published novel — two sisters navigating love, money, and society with contrasting temperaments."},
-  "Capital|Karl Marx": {"asin": "0140445684", "category": "books", "description": "Marx's foundational critique of political economy — how capitalism produces and reproduces its own contradictions."}
+  "Capital|Karl Marx": {"asin": "0140445684", "category": "books", "description": "Marx's foundational critique of political economy — how capitalism produces and reproduces its own contradictions."},
+  "Body by Science|Doug McGuff": {"asin": "0071597174", "category": "books", "description": "The research-based case for high-intensity, single-set strength training — maximum results in minimum time."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book to `content/affiliate-books.json`: Body by Science (Doug McGuff)
- Updated affiliate_links in DB for 5 articles:
  - **The Perfect Week of Exercise** → Body by Science (direct), Atomic Habits (curated)
  - **Byung-Chul Han - The Crisis of Narration** → Amusing Ourselves to Death, Technopoly (curated)
  - **Claude Code + Nano Banana 2 = Insane 3D Websites** → The Design of Everyday Things (curated)
  - **They Discontinued This Amazing Overdrive!** → The Music Lesson (curated)
  - **i converted all my n8n agents to real code** → Clean Code (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)