### PR TITLE
feat: add Religion and Nothingness to affiliate catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -106,5 +106,6 @@
   "The Prelude|William Wordsworth": {"asin": "0140433694", "category": "books", "description": "Wordsworth's autobiographical epic — the growth of a poet's mind across four landmark texts."},
   "Sense and Sensibility|Jane Austen": {"asin": "0141439661", "category": "books", "description": "Austen's first published novel — two sisters navigating love, money, and society with contrasting temperaments."},
   "Capital|Karl Marx": {"asin": "0140445684", "category": "books", "description": "Marx's foundational critique of political economy — how capitalism produces and reproduces its own contradictions."},
-  "Body by Science|Doug McGuff": {"asin": "0071597174", "category": "books", "description": "The research-based case for high-intensity, single-set strength training — maximum results in minimum time."}
+  "Body by Science|Doug McGuff": {"asin": "0071597174", "category": "books", "description": "The research-based case for high-intensity, single-set strength training — maximum results in minimum time."},
+  "Religion and Nothingness|Keiji Nishitani": {"asin": "0520049462", "category": "books", "description": "The Kyoto School philosopher on emptiness, nihilism, and what religion actually is beyond Western utility."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book to `content/affiliate-books.json`: Religion and Nothingness (Keiji Nishitani)
- Updated affiliate_links in DB for 5 articles:
  - **Elon Musk Admits DOGE Was a Failure!** → Why Nations Fail, The Tyranny of Merit (curated)
  - **Jennifer C. Pan: Selling Social Justice** → The New Jim Crow, Caste (curated)
  - **Religion and Nothingness - Kyoto School pt. 2** → Religion and Nothingness (direct), Meditations (curated)
  - **Tone Controls For The Electra Distortion** → The Music Lesson (curated)
  - **Dubai Airport SHUT DOWN By Iran Drone Strike** → Prisoners of Geography (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)