### PR TITLE
feat: add Jesus the Magician to affiliate catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -107,5 +107,6 @@
   "Sense and Sensibility|Jane Austen": {"asin": "0141439661", "category": "books", "description": "Austen's first published novel — two sisters navigating love, money, and society with contrasting temperaments."},
   "Capital|Karl Marx": {"asin": "0140445684", "category": "books", "description": "Marx's foundational critique of political economy — how capitalism produces and reproduces its own contradictions."},
   "Body by Science|Doug McGuff": {"asin": "0071597174", "category": "books", "description": "The research-based case for high-intensity, single-set strength training — maximum results in minimum time."},
-  "Religion and Nothingness|Keiji Nishitani": {"asin": "0520049462", "category": "books", "description": "The Kyoto School philosopher on emptiness, nihilism, and what religion actually is beyond Western utility."}
+  "Religion and Nothingness|Keiji Nishitani": {"asin": "0520049462", "category": "books", "description": "The Kyoto School philosopher on emptiness, nihilism, and what religion actually is beyond Western utility."},
+  "Jesus the Magician|Morton Smith": {"asin": "157174715X", "category": "books", "description": "A historian reveals how Jesus was viewed by contemporaries — miracle worker to allies, sorcerer to enemies."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book to `content/affiliate-books.json`: Jesus the Magician (Morton Smith)
- Updated affiliate_links in DB for 5 articles:
  - **Can Sadiq Khan stop Asif Aziz's mass evictions?** → Evicted (curated)
  - **Was Jesus an Ancient Magician?** → Jesus the Magician (direct), Orientalism (curated)
  - **How Iran Surprised The World** → Destined for War, Prisoners of Geography (curated)
  - **Trump Administration In Chaos Over Iran War Plans** → The Guns of August (curated)
  - **Friction as Financialized Profit** → Debt, The Ascent of Money (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)