### PR TITLE
feat: add Signals (Skyrms) to affiliate catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -108,5 +108,6 @@
   "Capital|Karl Marx": {"asin": "0140445684", "category": "books", "description": "Marx's foundational critique of political economy — how capitalism produces and reproduces its own contradictions."},
   "Body by Science|Doug McGuff": {"asin": "0071597174", "category": "books", "description": "The research-based case for high-intensity, single-set strength training — maximum results in minimum time."},
   "Religion and Nothingness|Keiji Nishitani": {"asin": "0520049462", "category": "books", "description": "The Kyoto School philosopher on emptiness, nihilism, and what religion actually is beyond Western utility."},
-  "Jesus the Magician|Morton Smith": {"asin": "157174715X", "category": "books", "description": "A historian reveals how Jesus was viewed by contemporaries — miracle worker to allies, sorcerer to enemies."}
+  "Jesus the Magician|Morton Smith": {"asin": "157174715X", "category": "books", "description": "A historian reveals how Jesus was viewed by contemporaries — miracle worker to allies, sorcerer to enemies."},
+  "Signals|Brian Skyrms": {"asin": "0199580820", "category": "books", "description": "How meaningful communication evolves from mindless processes — signaling without intelligence."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book to `content/affiliate-books.json`: Signals (Brian Skyrms)
- Updated affiliate_links in DB for 5 articles:
  - **how/when i managed to write another cookbook** → Atomic Habits (curated)
  - **Let's Read! Brian Skyrms, "Signals"** → Signals (direct), Structure of Scientific Revolutions (curated)
  - **Romeo and Juliet - William Shakespeare** → The Prince (curated)
  - **The ONE Thing AI Will Never Understand About Music** → The Music Lesson (curated)
  - **November Q&A | Michael Walker and Ash Sarkar** → Manufacturing Consent (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)