### PR TITLE
feat: add Doppelganger + After Virtue to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -109,5 +109,7 @@
   "Body by Science|Doug McGuff": {"asin": "0071597174", "category": "books", "description": "The research-based case for high-intensity, single-set strength training — maximum results in minimum time."},
   "Religion and Nothingness|Keiji Nishitani": {"asin": "0520049462", "category": "books", "description": "The Kyoto School philosopher on emptiness, nihilism, and what religion actually is beyond Western utility."},
   "Jesus the Magician|Morton Smith": {"asin": "157174715X", "category": "books", "description": "A historian reveals how Jesus was viewed by contemporaries — miracle worker to allies, sorcerer to enemies."},
-  "Signals|Brian Skyrms": {"asin": "0199580820", "category": "books", "description": "How meaningful communication evolves from mindless processes — signaling without intelligence."}
+  "Signals|Brian Skyrms": {"asin": "0199580820", "category": "books", "description": "How meaningful communication evolves from mindless processes — signaling without intelligence."},
+  "Doppelganger|Naomi Klein": {"asin": "0374610320", "category": "books", "description": "Klein explores mirror worlds, conspiracy culture, and the strange doublings of modern politics."},
+  "After Virtue|Alasdair MacIntyre": {"asin": "0268035040", "category": "books", "description": "Why modern moral debates feel hollow — we inherited the language of ethics without the tradition that gave it meaning."}
 }


### PR DESCRIPTION
## Summary
- Added 2 new books to `content/affiliate-books.json`: Doppelganger (Naomi Klein), After Virtue (Alasdair MacIntyre)
- Updated affiliate_links in DB for 5 articles:
  - **September Q&A | Aaron Bastani & Rivkah Brown** → Doppelganger (direct), Manufacturing Consent (curated)
  - **After Virtue - Alasdair MacIntyre** → After Virtue (direct), The Righteous Mind (curated)
  - **Does OpenAI expect a Government Bailout?** → Too Big to Fail, The Black Swan (curated)
  - **China is killing the US on energy** → The Rise and Fall of the Great Powers (curated)
  - **AI Literacy 2.2: Symbolic and Neural Approaches** → Thinking Fast and Slow, Godel Escher Bach (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)