### PR TITLE
feat: add Varieties of Religion Today to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -111,5 +111,6 @@
   "Jesus the Magician|Morton Smith": {"asin": "157174715X", "category": "books", "description": "A historian reveals how Jesus was viewed by contemporaries — miracle worker to allies, sorcerer to enemies."},
   "Signals|Brian Skyrms": {"asin": "0199580820", "category": "books", "description": "How meaningful communication evolves from mindless processes — signaling without intelligence."},
   "Doppelganger|Naomi Klein": {"asin": "0374610320", "category": "books", "description": "Klein explores mirror worlds, conspiracy culture, and the strange doublings of modern politics."},
-  "After Virtue|Alasdair MacIntyre": {"asin": "0268035040", "category": "books", "description": "Why modern moral debates feel hollow — we inherited the language of ethics without the tradition that gave it meaning."}
+  "After Virtue|Alasdair MacIntyre": {"asin": "0268035040", "category": "books", "description": "Why modern moral debates feel hollow — we inherited the language of ethics without the tradition that gave it meaning."},
+  "Varieties of Religion Today|Charles Taylor": {"asin": "0674012534", "category": "books", "description": "Taylor revisits William James to ask what religion means in a secular age — personal experience meets social architecture."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book to `content/affiliate-books.json`: Varieties of Religion Today (Charles Taylor)
- Updated affiliate_links in DB for 5 articles:
  - **The Tragedy of Julius Caesar** → How Democracies Die, The Prince (curated)
  - **Varieties of Religion Today (Charles Taylor)** → Varieties of Religion Today (direct), The Righteous Mind (curated)
  - **The Stoics Are Wrong - Nietzsche, Schopenhauer** → Meditations (curated)
  - **The Indian Genius Nobody Understands** → A Beautiful Mind, Godel Escher Bach (curated)
  - **Funders Behind Far Right AI Rapper EXPOSED** → Weapons of Math Destruction, Age of Surveillance Capitalism (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)