### PR TITLE
feat: add The Trial + Animal Farm to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -112,5 +112,7 @@
   "Signals|Brian Skyrms": {"asin": "0199580820", "category": "books", "description": "How meaningful communication evolves from mindless processes — signaling without intelligence."},
   "Doppelganger|Naomi Klein": {"asin": "0374610320", "category": "books", "description": "Klein explores mirror worlds, conspiracy culture, and the strange doublings of modern politics."},
   "After Virtue|Alasdair MacIntyre": {"asin": "0268035040", "category": "books", "description": "Why modern moral debates feel hollow — we inherited the language of ethics without the tradition that gave it meaning."},
-  "Varieties of Religion Today|Charles Taylor": {"asin": "0674012534", "category": "books", "description": "Taylor revisits William James to ask what religion means in a secular age — personal experience meets social architecture."}
+  "Varieties of Religion Today|Charles Taylor": {"asin": "0674012534", "category": "books", "description": "Taylor revisits William James to ask what religion means in a secular age — personal experience meets social architecture."},
+  "The Trial|Franz Kafka": {"asin": "0805209999", "category": "books", "description": "Kafka's nightmare of bureaucratic persecution — Joseph K is arrested, tried, and condemned by a system he can never understand."},
+  "Animal Farm|George Orwell": {"asin": "0451526341", "category": "books", "description": "Orwell's allegory of revolution betrayed — the animals overthrow the farmer, then become worse than what they replaced."}
 }


### PR DESCRIPTION
## Summary
- Added 2 new books to `content/affiliate-books.json`: The Trial (Franz Kafka), Animal Farm (George Orwell)
- Updated affiliate_links in DB for 5 articles:
  - **Aella: Sex and Ideology in the 21st Century** → The Righteous Mind (curated)
  - **Hope as an Existentialism (Ernst Bloch)** → The Origins of Totalitarianism (curated)
  - **Bubble or No Bubble, AI Keeps Progressing** → Superintelligence (curated)
  - **Kafka and Totalitarianism (Arendt, Adorno)** → The Trial (direct), Animal Farm (direct)
  - **Clearing Up the Inflation Target Misinformation** → The End of Alchemy, Factfulness (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)