### PR TITLE
feat: add 4 books (Camus + Clarke) to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -114,5 +114,9 @@
   "After Virtue|Alasdair MacIntyre": {"asin": "0268035040", "category": "books", "description": "Why modern moral debates feel hollow — we inherited the language of ethics without the tradition that gave it meaning."},
   "Varieties of Religion Today|Charles Taylor": {"asin": "0674012534", "category": "books", "description": "Taylor revisits William James to ask what religion means in a secular age — personal experience meets social architecture."},
   "The Trial|Franz Kafka": {"asin": "0805209999", "category": "books", "description": "Kafka's nightmare of bureaucratic persecution — Joseph K is arrested, tried, and condemned by a system he can never understand."},
-  "Animal Farm|George Orwell": {"asin": "0451526341", "category": "books", "description": "Orwell's allegory of revolution betrayed — the animals overthrow the farmer, then become worse than what they replaced."}
+  "Animal Farm|George Orwell": {"asin": "0451526341", "category": "books", "description": "Orwell's allegory of revolution betrayed — the animals overthrow the farmer, then become worse than what they replaced."},
+  "The Rebel|Albert Camus": {"asin": "0679733841", "category": "books", "description": "Camus's devastating critique of revolutionary violence — when rebellion loses its limits, it becomes tyranny."},
+  "The Plague|Albert Camus": {"asin": "0679720219", "category": "books", "description": "A town besieged by plague becomes Camus's image of solidarity in the face of absurdity."},
+  "The Stranger|Albert Camus": {"asin": "0679720200", "category": "books", "description": "Meursault kills an Arab on an Algerian beach — and refuses to pretend he feels what society demands."},
+  "2010: Odyssey Two|Arthur C. Clarke": {"asin": "0345303067", "category": "books", "description": "Clarke's sequel to 2001 — a mission to Jupiter's moons and the discovery of alien life on Europa."}
 }


### PR DESCRIPTION
## Summary
- Added 4 new books to `content/affiliate-books.json`: The Rebel, The Plague, The Stranger (all Camus), 2010: Odyssey Two (Clarke)
- Updated affiliate_links in DB for 5 articles:
  - **Albert Camus - The Rebel** → The Rebel (direct), The Origins of Totalitarianism (curated)
  - **Britain's Secret Prehistoric Masterpiece** → Sapiens (curated)
  - **We Might Find Alien Life In 1827 Days** → 2010: Odyssey Two (direct), The Beginning of Infinity (curated)
  - **Thermite Part 1** → The Structure of Scientific Revolutions (curated)
  - **Albert Camus - The Plague** → The Plague (direct), The Stranger (direct)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)