### PR TITLE
feat: add Dostoevsky + Critchley to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -118,5 +118,8 @@
   "The Rebel|Albert Camus": {"asin": "0679733841", "category": "books", "description": "Camus's devastating critique of revolutionary violence — when rebellion loses its limits, it becomes tyranny."},
   "The Plague|Albert Camus": {"asin": "0679720219", "category": "books", "description": "A town besieged by plague becomes Camus's image of solidarity in the face of absurdity."},
   "The Stranger|Albert Camus": {"asin": "0679720200", "category": "books", "description": "Meursault kills an Arab on an Algerian beach — and refuses to pretend he feels what society demands."},
-  "2010: Odyssey Two|Arthur C. Clarke": {"asin": "0345303067", "category": "books", "description": "Clarke's sequel to 2001 — a mission to Jupiter's moons and the discovery of alien life on Europa."}
+  "2010: Odyssey Two|Arthur C. Clarke": {"asin": "0345303067", "category": "books", "description": "Clarke's sequel to 2001 — a mission to Jupiter's moons and the discovery of alien life on Europa."},
+  "Notes from Underground|Fyodor Dostoevsky": {"asin": "067973452X", "category": "books", "description": "The underground man rages against rationalism — Dostoevsky's first great portrait of nihilism and self-sabotage."},
+  "Crime and Punishment|Fyodor Dostoevsky": {"asin": "0679734503", "category": "books", "description": "Raskolnikov murders a pawnbroker to prove he's extraordinary — then discovers he's not."},
+  "Tragedy, the Greeks, and Us|Simon Critchley": {"asin": "0525564640", "category": "books", "description": "Why Greek tragedy still matters — ambiguity, fragility, and what modern philosophy has lost."}
 }


### PR DESCRIPTION
## Summary
- Added 3 new books to `content/affiliate-books.json`: Notes from Underground, Crime and Punishment (both Dostoevsky), Tragedy the Greeks and Us (Critchley)
- Updated affiliate_links in DB for 5 articles:
  - **Dostoevsky - Notes From Underground** → Notes from Underground (direct), Darkness at Noon (curated)
  - **I built a QR code with my bare hands** → The Design of Everyday Things (curated)
  - **Dostoevsky - Crime and Punishment** → Crime and Punishment (direct), Notes from Underground (direct)
  - **Nietzsche and Critchley on Amor Fati** → Tragedy the Greeks and Us (direct), Meditations (curated)
  - **The Self-Overcoming of Nihilism - Nishitani** → Meditations (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)