### PR TITLE
feat: add Verbal Behavior (Skinner) to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -122,5 +122,6 @@
   "Notes from Underground|Fyodor Dostoevsky": {"asin": "067973452X", "category": "books", "description": "The underground man rages against rationalism — Dostoevsky's first great portrait of nihilism and self-sabotage."},
   "Crime and Punishment|Fyodor Dostoevsky": {"asin": "0679734503", "category": "books", "description": "Raskolnikov murders a pawnbroker to prove he's extraordinary — then discovers he's not."},
   "Tragedy, the Greeks, and Us|Simon Critchley": {"asin": "0525564640", "category": "books", "description": "Why Greek tragedy still matters — ambiguity, fragility, and what modern philosophy has lost."},
-  "Frankenstein|Mary Shelley": {"asin": "0141439475", "category": "books", "description": "The Modern Prometheus — a teenager's warning about science without ethics that launched an entire genre."}
+  "Frankenstein|Mary Shelley": {"asin": "0141439475", "category": "books", "description": "The Modern Prometheus — a teenager's warning about science without ethics that launched an entire genre."},
+  "Verbal Behavior|B.F. Skinner": {"asin": "1626540136", "category": "books", "description": "Skinner's behaviorist account of language — the book Chomsky demolished in the most famous review in intellectual history."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book to `content/affiliate-books.json`: Verbal Behavior (B.F. Skinner)
- Updated affiliate_links in DB for 5 articles:
  - **Forbes Has a Fraud Problem!** → The Big Short (curated)
  - **Hardcore History - Human Resources** → The Wretched of the Earth (curated)
  - **Chomsky's Review of Skinner's Verbal Behavior** → Verbal Behavior (direct), Godel Escher Bach (curated)
  - **How To Earthquake-Proof A House** → The Design of Everyday Things (curated)
  - **The Closest We've Come to a Theory of Everything** → The Beginning of Infinity (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)