### PR TITLE
feat: add Han + Eliot to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -123,5 +123,8 @@
   "Crime and Punishment|Fyodor Dostoevsky": {"asin": "0679734503", "category": "books", "description": "Raskolnikov murders a pawnbroker to prove he's extraordinary — then discovers he's not."},
   "Tragedy, the Greeks, and Us|Simon Critchley": {"asin": "0525564640", "category": "books", "description": "Why Greek tragedy still matters — ambiguity, fragility, and what modern philosophy has lost."},
   "Frankenstein|Mary Shelley": {"asin": "0141439475", "category": "books", "description": "The Modern Prometheus — a teenager's warning about science without ethics that launched an entire genre."},
-  "Verbal Behavior|B.F. Skinner": {"asin": "1626540136", "category": "books", "description": "Skinner's behaviorist account of language — the book Chomsky demolished in the most famous review in intellectual history."}
+  "Verbal Behavior|B.F. Skinner": {"asin": "1626540136", "category": "books", "description": "Skinner's behaviorist account of language — the book Chomsky demolished in the most famous review in intellectual history."},
+  "The Philosophy of Zen Buddhism|Byung-Chul Han": {"asin": "1509545093", "category": "books", "description": "Han peels back Western selfhood to reveal what Zen offers — emptiness, dwelling nowhere, friendliness."},
+  "The Burnout Society|Byung-Chul Han": {"asin": "0804795096", "category": "books", "description": "How neoliberal self-optimization turned us into exhausted entrepreneurs of ourselves."},
+  "Four Quartets|T.S. Eliot": {"asin": "0156332256", "category": "books", "description": "Eliot's late masterpiece — time, memory, and the still point of the turning world."}
 }


### PR DESCRIPTION
## Summary
- Added 3 new books to `content/affiliate-books.json`: The Philosophy of Zen Buddhism (Han), The Burnout Society (Han), Four Quartets (Eliot)
- Updated affiliate_links in DB for 5 articles:
  - **The Philosophy of Zen Buddhism - Byung-Chul Han** → Zen Buddhism + Burnout Society (both direct)
  - **Bitcoin Green Revolution** → Antifragile (curated)
  - **The Sublime Explained (Longinus to Kant)** → The Beginning of Infinity (curated)
  - **How Our Creativity Was Stolen** → Amusing Ourselves to Death, Deep Work (curated)
  - **How Poetry Becomes Music - Burnt Norton** → Four Quartets (direct)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)