### PR TITLE
feat: add Iliad + Blake to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -126,5 +126,7 @@
   "Verbal Behavior|B.F. Skinner": {"asin": "1626540136", "category": "books", "description": "Skinner's behaviorist account of language — the book Chomsky demolished in the most famous review in intellectual history."},
   "The Philosophy of Zen Buddhism|Byung-Chul Han": {"asin": "1509545093", "category": "books", "description": "Han peels back Western selfhood to reveal what Zen offers — emptiness, dwelling nowhere, friendliness."},
   "The Burnout Society|Byung-Chul Han": {"asin": "0804795096", "category": "books", "description": "How neoliberal self-optimization turned us into exhausted entrepreneurs of ourselves."},
-  "Four Quartets|T.S. Eliot": {"asin": "0156332256", "category": "books", "description": "Eliot's late masterpiece — time, memory, and the still point of the turning world."}
+  "Four Quartets|T.S. Eliot": {"asin": "0156332256", "category": "books", "description": "Eliot's late masterpiece — time, memory, and the still point of the turning world."},
+  "The Iliad|Homer": {"asin": "0140445927", "category": "books", "description": "The foundational poem of Western literature — Achilles, Hector, and the brutal poetry of war."},
+  "Songs of Innocence and Experience|William Blake": {"asin": "0192810898", "category": "books", "description": "Blake's twin visions of childhood and corruption — the divine imagination against the fallen world."}
 }


### PR DESCRIPTION
## Summary
- Added 2 new books to `content/affiliate-books.json`: The Iliad (Homer), Songs of Innocence and Experience (Blake)
- Updated affiliate_links in DB for 5 articles:
  - **Basho and the Art of the Haiku** → Meditations (curated)
  - **The Iliad for Self-Learners** → The Iliad (direct), The Peloponnesian War (curated)
  - **William Blake on the Imagination** → Songs of Innocence and Experience (direct)
  - **7 Signs of the New Renaissance** → The Beginning of Infinity (curated)
  - **The Horrifying Archaeology Of The First Wars** → Sapiens (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] `affiliate-books.json` is valid JSON
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)