### PR TITLE
feat: add Le Corbusier to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -129,5 +129,6 @@
   "Four Quartets|T.S. Eliot": {"asin": "0156332256", "category": "books", "description": "Eliot's late masterpiece — time, memory, and the still point of the turning world."},
   "The Iliad|Homer": {"asin": "0140445927", "category": "books", "description": "The foundational poem of Western literature — Achilles, Hector, and the brutal poetry of war."},
   "Songs of Innocence and Experience|William Blake": {"asin": "0192810898", "category": "books", "description": "Blake's twin visions of childhood and corruption — the divine imagination against the fallen world."},
-  "Build a Large Language Model (From Scratch)|Sebastian Raschka": {"asin": "1633437167", "category": "books", "description": "Hands-on guide to building an LLM from the ground up — attention, training, and fine-tuning explained through code."}
+  "Build a Large Language Model (From Scratch)|Sebastian Raschka": {"asin": "1633437167", "category": "books", "description": "Hands-on guide to building an LLM from the ground up — attention, training, and fine-tuning explained through code."},
+  "Towards a New Architecture|Le Corbusier": {"asin": "0486250237", "category": "books", "description": "The manifesto that redefined modern architecture — form follows function, buildings as machines for living."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book: Towards a New Architecture (Le Corbusier)
- Updated affiliate_links in DB for 5 articles:
  - **Norman Foster: Striving for Simplicity** → Towards a New Architecture (direct), How Buildings Learn (curated)
  - **Shelley's Ode to the West Wind** → Lyrical Ballads (curated)
  - **Keats's Ode to a Nightingale** → Lyrical Ballads (curated)
  - **Wordsworth's Tintern Abbey** → Lyrical Ballads, The Prelude (curated)
  - **Coleridge's Frost at Midnight** → Lyrical Ballads (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)