### PR TITLE
feat: add Dostoevsky + Sledge to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -130,5 +130,7 @@
   "The Iliad|Homer": {"asin": "0140445927", "category": "books", "description": "The foundational poem of Western literature — Achilles, Hector, and the brutal poetry of war."},
   "Songs of Innocence and Experience|William Blake": {"asin": "0192810898", "category": "books", "description": "Blake's twin visions of childhood and corruption — the divine imagination against the fallen world."},
   "Build a Large Language Model (From Scratch)|Sebastian Raschka": {"asin": "1633437167", "category": "books", "description": "Hands-on guide to building an LLM from the ground up — attention, training, and fine-tuning explained through code."},
-  "Towards a New Architecture|Le Corbusier": {"asin": "0486250237", "category": "books", "description": "The manifesto that redefined modern architecture — form follows function, buildings as machines for living."}
+  "Towards a New Architecture|Le Corbusier": {"asin": "0486250237", "category": "books", "description": "The manifesto that redefined modern architecture — form follows function, buildings as machines for living."},
+  "The Gambler|Fyodor Dostoevsky": {"asin": "0140455094", "category": "books", "description": "Dostoevsky wrote himself out of debt with this raw study of addiction — one more spin, always one more spin."},
+  "With the Old Breed|Eugene Sledge": {"asin": "0891419195", "category": "books", "description": "The most honest account of Pacific combat ever written — Peleliu and Okinawa through a Marine's eyes."}
 }


### PR DESCRIPTION
## Summary
- Added 2 new books: The Gambler (Dostoevsky), With the Old Breed (Sledge)
- Updated affiliate_links in DB for 5 articles:
  - **How are holograms possible?** → The Beginning of Infinity (curated)
  - **Attention in transformers** → The Master Algorithm (curated)
  - **Novara REACTS To Tory Leadership** → How Democracies Die (curated)
  - **A philosophy of self-destruction (Dostoevsky, Bataille)** → The Gambler (direct), Notes from Underground (curated)
  - **Sledgehammer and Big Shot** → With the Old Breed (direct), The Guns of August (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)