### PR TITLE
feat: add Bomber Mafia (Gladwell) to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -132,5 +132,6 @@
   "Build a Large Language Model (From Scratch)|Sebastian Raschka": {"asin": "1633437167", "category": "books", "description": "Hands-on guide to building an LLM from the ground up — attention, training, and fine-tuning explained through code."},
   "Towards a New Architecture|Le Corbusier": {"asin": "0486250237", "category": "books", "description": "The manifesto that redefined modern architecture — form follows function, buildings as machines for living."},
   "The Gambler|Fyodor Dostoevsky": {"asin": "0140455094", "category": "books", "description": "Dostoevsky wrote himself out of debt with this raw study of addiction — one more spin, always one more spin."},
-  "With the Old Breed|Eugene Sledge": {"asin": "0891419195", "category": "books", "description": "The most honest account of Pacific combat ever written — Peleliu and Okinawa through a Marine's eyes."}
+  "With the Old Breed|Eugene Sledge": {"asin": "0891419195", "category": "books", "description": "The most honest account of Pacific combat ever written — Peleliu and Okinawa through a Marine's eyes."},
+  "The Bomber Mafia|Malcolm Gladwell": {"asin": "0316296619", "category": "books", "description": "How a group of idealists tried to make war humane through precision bombing — and ended up burning down Japan."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book: The Bomber Mafia (Malcolm Gladwell)
- Updated affiliate_links in DB for 5 articles:
  - **Five Biggest Insider Trading Scandals** → The Big Short (curated)
  - **Gladwell and the Bomber Mafia** → The Bomber Mafia (direct), The Guns of August (curated)
  - **This Unstoppable Robot Could Save Your Life** → The Design of Everyday Things (curated)
  - **The Two Best AI Models Just Got Released** → Superintelligence (curated)
  - **Anthropic: automate all white collar work** → The Second Machine Age (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)