### PR TITLE
feat: add Deleuze + Euclid to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -134,5 +134,7 @@
   "The Gambler|Fyodor Dostoevsky": {"asin": "0140455094", "category": "books", "description": "Dostoevsky wrote himself out of debt with this raw study of addiction — one more spin, always one more spin."},
   "With the Old Breed|Eugene Sledge": {"asin": "0891419195", "category": "books", "description": "The most honest account of Pacific combat ever written — Peleliu and Okinawa through a Marine's eyes."},
   "The Bomber Mafia|Malcolm Gladwell": {"asin": "0316296619", "category": "books", "description": "How a group of idealists tried to make war humane through precision bombing — and ended up burning down Japan."},
-  "Philosophical Investigations|Ludwig Wittgenstein": {"asin": "1405159286", "category": "books", "description": "Wittgenstein dismantles his own earlier work — language as use, meaning as context, philosophy as therapy."}
+  "Philosophical Investigations|Ludwig Wittgenstein": {"asin": "1405159286", "category": "books", "description": "Wittgenstein dismantles his own earlier work — language as use, meaning as context, philosophy as therapy."},
+  "Nietzsche and Philosophy|Gilles Deleuze": {"asin": "0231138776", "category": "books", "description": "Deleuze's radical reading of Nietzsche — difference over identity, joy over resentment, affirmation over negation."},
+  "The Elements|Euclid": {"asin": "0486600882", "category": "books", "description": "The foundational math text — published in more editions than any book except the Bible, shaping geometry for 2,000 years."}
 }


### PR DESCRIPTION
## Summary
- Added 2 new books: Nietzsche and Philosophy (Deleuze), The Elements (Euclid)
- Updated affiliate_links in DB for 5 articles:
  - **Deleuze Interprets Nietzsche** → Nietzsche and Philosophy (direct), Meditations (curated)
  - **One Line in the Oldest Math Text** → The Elements (direct), GEB (curated)
  - **ChatGPT Can Now Call the Cops** → Superintelligence (curated)
  - **Apple's AI Can't Reason Claim** → The Alignment Problem (curated)
  - **China digging out of crisis - Ken Rogoff** → On China (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)