### PR TITLE
feat: add Virtue Hoarders + The Fall to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -136,5 +136,7 @@
   "The Bomber Mafia|Malcolm Gladwell": {"asin": "0316296619", "category": "books", "description": "How a group of idealists tried to make war humane through precision bombing — and ended up burning down Japan."},
   "Philosophical Investigations|Ludwig Wittgenstein": {"asin": "1405159286", "category": "books", "description": "Wittgenstein dismantles his own earlier work — language as use, meaning as context, philosophy as therapy."},
   "Nietzsche and Philosophy|Gilles Deleuze": {"asin": "0231138776", "category": "books", "description": "Deleuze's radical reading of Nietzsche — difference over identity, joy over resentment, affirmation over negation."},
-  "The Elements|Euclid": {"asin": "0486600882", "category": "books", "description": "The foundational math text — published in more editions than any book except the Bible, shaping geometry for 2,000 years."}
+  "The Elements|Euclid": {"asin": "0486600882", "category": "books", "description": "The foundational math text — published in more editions than any book except the Bible, shaping geometry for 2,000 years."},
+  "Virtue Hoarders|Catherine Liu": {"asin": "1517912253", "category": "books", "description": "The case against the professional managerial class — how liberal elites hoard virtue while abandoning solidarity."},
+  "The Fall|Albert Camus": {"asin": "0679720227", "category": "books", "description": "Camus's last novel — a judge-penitent confesses in Amsterdam, exposing the elaborate lies we tell to avoid guilt."}
 }


### PR DESCRIPTION
## Summary
- Added 2 new books: Virtue Hoarders (Catherine Liu), The Fall (Albert Camus)
- Updated affiliate_links in DB for 5 articles:
  - **Catherine Liu: the Psychology of Liberalism** → Virtue Hoarders (direct), The Tyranny of Merit (curated)
  - **Observing Words (Step 2)** → Meditations (curated)
  - **AI Improves at Self-improving** → Superintelligence (curated)
  - **Albert Camus - Kafka and The Fall** → The Fall (direct), The Rebel (curated)
  - **What Everyone Gets Wrong About Planes** → Structure of Scientific Revolutions (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)