### PR TITLE
feat: add Ferriss + Camus to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -138,5 +138,7 @@
   "Nietzsche and Philosophy|Gilles Deleuze": {"asin": "0231138776", "category": "books", "description": "Deleuze's radical reading of Nietzsche — difference over identity, joy over resentment, affirmation over negation."},
   "The Elements|Euclid": {"asin": "0486600882", "category": "books", "description": "The foundational math text — published in more editions than any book except the Bible, shaping geometry for 2,000 years."},
   "Virtue Hoarders|Catherine Liu": {"asin": "1517912253", "category": "books", "description": "The case against the professional managerial class — how liberal elites hoard virtue while abandoning solidarity."},
-  "The Fall|Albert Camus": {"asin": "0679720227", "category": "books", "description": "Camus's last novel — a judge-penitent confesses in Amsterdam, exposing the elaborate lies we tell to avoid guilt."}
+  "The Fall|Albert Camus": {"asin": "0679720227", "category": "books", "description": "Camus's last novel — a judge-penitent confesses in Amsterdam, exposing the elaborate lies we tell to avoid guilt."},
+  "Tools of Titans|Tim Ferriss": {"asin": "1328683788", "category": "books", "description": "Tactics, routines, and habits from billionaires, icons, and world-class performers — including Ferriss's own darkest chapter."},
+  "Exile and the Kingdom|Albert Camus": {"asin": "0307278581", "category": "books", "description": "Six short stories painting different images of exile — Camus's last fiction, intimate and relatable."}
 }


### PR DESCRIPTION
## Summary
- Added 2 new books: Tools of Titans (Tim Ferriss), Exile and the Kingdom (Albert Camus)
- Updated affiliate_links in DB for 5 articles:
  - **These Illusions Fool Almost Everyone** → Thinking Fast and Slow (curated)
  - **Testing the US Military's Worst Idea** → The Guns of August (curated)
  - **Tim Ferriss on Surviving Suicidal Depression** → Tools of Titans (direct), Atomic Habits (curated)
  - **Is RL + LLMs enough for AGI?** → Superintelligence (curated)
  - **Albert Camus - On Exile** → Exile and the Kingdom (direct), The Stranger (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)