### PR TITLE
feat: add Three-Body Problem to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -140,5 +140,6 @@
   "Virtue Hoarders|Catherine Liu": {"asin": "1517912253", "category": "books", "description": "The case against the professional managerial class — how liberal elites hoard virtue while abandoning solidarity."},
   "The Fall|Albert Camus": {"asin": "0679720227", "category": "books", "description": "Camus's last novel — a judge-penitent confesses in Amsterdam, exposing the elaborate lies we tell to avoid guilt."},
   "Tools of Titans|Tim Ferriss": {"asin": "1328683788", "category": "books", "description": "Tactics, routines, and habits from billionaires, icons, and world-class performers — including Ferriss's own darkest chapter."},
-  "Exile and the Kingdom|Albert Camus": {"asin": "0307278581", "category": "books", "description": "Six short stories painting different images of exile — Camus's last fiction, intimate and relatable."}
+  "Exile and the Kingdom|Albert Camus": {"asin": "0307278581", "category": "books", "description": "Six short stories painting different images of exile — Camus's last fiction, intimate and relatable."},
+  "The Three-Body Problem|Liu Cixin": {"asin": "0765377063", "category": "books", "description": "The dark forest of the universe — Liu Cixin's Hugo-winning first contact novel where silence means survival."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book: The Three-Body Problem (Liu Cixin)
- Updated affiliate_links in DB for 5 articles:
  - **Dark Forest Theory of the Internet** → The Three-Body Problem (direct), Age of Surveillance Capitalism (curated)
  - **The Rarest Wooden Artefacts Ever Found** → Sapiens (curated)
  - **Humane Arts: Conclusion** → Amusing Ourselves to Death (curated)
  - **The humans that roamed Australia 50,000 years ago** → Sapiens (curated)
  - **My response to Graham Hancock** → Sapiens (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)