### PR TITLE
feat: add The Second Sex to catalog + link 5 articles

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -141,5 +141,6 @@
   "The Fall|Albert Camus": {"asin": "0679720227", "category": "books", "description": "Camus's last novel — a judge-penitent confesses in Amsterdam, exposing the elaborate lies we tell to avoid guilt."},
   "Tools of Titans|Tim Ferriss": {"asin": "1328683788", "category": "books", "description": "Tactics, routines, and habits from billionaires, icons, and world-class performers — including Ferriss's own darkest chapter."},
   "Exile and the Kingdom|Albert Camus": {"asin": "0307278581", "category": "books", "description": "Six short stories painting different images of exile — Camus's last fiction, intimate and relatable."},
-  "The Three-Body Problem|Liu Cixin": {"asin": "0765377063", "category": "books", "description": "The dark forest of the universe — Liu Cixin's Hugo-winning first contact novel where silence means survival."}
+  "The Three-Body Problem|Liu Cixin": {"asin": "0765377063", "category": "books", "description": "The dark forest of the universe — Liu Cixin's Hugo-winning first contact novel where silence means survival."},
+  "The Second Sex|Simone de Beauvoir": {"asin": "030727778X", "category": "books", "description": "The foundational text of modern feminism — one is not born, but rather becomes, a woman."}
 }


### PR DESCRIPTION
## Summary
- Added 1 new book: The Second Sex (Simone de Beauvoir)
- Updated affiliate_links in DB for 5 articles:
  - **The Expert Myth** → Thinking Fast and Slow (curated)
  - **Simone de Beauvoir Her Life and Philosophy** → The Second Sex (direct), Origins of Totalitarianism (curated)
  - **Vivek Chibber: How the Left Got Lost** → The Righteous Mind (curated)
  - **Emma Vigeland: Epstein, Conspiracy & Right-wing Media** → Manufacturing Consent (curated)
  - **David Adler: Inside an Israeli Prison** → The Origins of Totalitarianism (curated)

## Test plan
- [x] Pre-commit checks pass (typecheck, lint, 143 tests)
- [x] DB updates confirmed (UPDATE 1 x 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)