### PR TITLE
refactor: convert affiliate-books.json from composite keys to array of objects

### DIFF
--- a/content/affiliate-books.json
+++ b/content/affiliate-books.json
@@ -1,582 +1,814 @@
-{
-  "1984|George Orwell": {
+[
+  {
+    "title": "1984",
+    "author": "George Orwell",
     "asin": "0451524934",
     "category": "books",
     "description": "The definitive novel of surveillance, propaganda, and totalitarian control."
   },
-  "A Beautiful Mind|Sylvia Nasar": {
+  {
+    "title": "A Beautiful Mind",
+    "author": "Sylvia Nasar",
     "asin": "1451632894",
     "category": "books",
-    "description": "The biography of John Nash \u2014 mathematical genius, Nobel laureate, and his struggle with schizophrenia."
+    "description": "The biography of John Nash — mathematical genius, Nobel laureate, and his struggle with schizophrenia."
   },
-  "A Theory of Justice|John Rawls": {
+  {
+    "title": "A Theory of Justice",
+    "author": "John Rawls",
     "asin": "0674000781",
     "category": "books",
     "description": "The most influential work of political philosophy in the twentieth century."
   },
-  "A Woman's Work|Elinor Cleghorn": {
+  {
+    "title": "A Woman's Work",
+    "author": "Elinor Cleghorn",
     "asin": "0593472705",
     "category": "books",
     "description": "A narrative history reclaiming the stories of mothers, midwives, and activists who shaped history."
   },
-  "All the President's Men|Bob Woodward": {
+  {
+    "title": "All the President's Men",
+    "author": "Bob Woodward",
     "asin": "1476770514",
     "category": "books",
-    "description": "Woodward and Bernstein's account of uncovering Watergate \u2014 investigative journalism at its finest."
+    "description": "Woodward and Bernstein's account of uncovering Watergate — investigative journalism at its finest."
   },
-  "Amusing Ourselves to Death|Neil Postman": {
+  {
+    "title": "Amusing Ourselves to Death",
+    "author": "Neil Postman",
     "asin": "014303653X",
     "category": "books",
     "description": "How television transformed public discourse from substance to entertainment."
   },
-  "Antifragile|Nassim Nicholas Taleb": {
+  {
+    "title": "Antifragile",
+    "author": "Nassim Nicholas Taleb",
     "asin": "0812979680",
     "category": "books",
-    "description": "Things that gain from disorder \u2014 a framework for thriving in uncertainty."
+    "description": "Things that gain from disorder — a framework for thriving in uncertainty."
   },
-  "Artificial Intelligence: A Modern Approach|Stuart Russell": {
+  {
+    "title": "Artificial Intelligence: A Modern Approach",
+    "author": "Stuart Russell",
     "asin": "0134610997",
     "category": "books",
-    "description": "The standard textbook on AI \u2014 comprehensive, authoritative, and used in universities worldwide."
+    "description": "The standard textbook on AI — comprehensive, authoritative, and used in universities worldwide."
   },
-  "Atlas of AI|Kate Crawford": {
+  {
+    "title": "Atlas of AI",
+    "author": "Kate Crawford",
     "asin": "0300264631",
     "category": "books",
-    "description": "How artificial intelligence is shaped by politics, labor, and the environment \u2014 not just code."
+    "description": "How artificial intelligence is shaped by politics, labor, and the environment — not just code."
   },
-  "Atomic Habits|James Clear": {
+  {
+    "title": "Atomic Habits",
+    "author": "James Clear",
     "asin": "0735211299",
     "category": "books",
-    "description": "Small changes, remarkable results \u2014 the science of habit formation."
+    "description": "Small changes, remarkable results — the science of habit formation."
   },
-  "Automating Inequality|Virginia Eubanks": {
+  {
+    "title": "Automating Inequality",
+    "author": "Virginia Eubanks",
     "asin": "1250215781",
     "category": "books",
     "description": "How high-tech tools profile, police, and punish the poor."
   },
-  "Between the World and Me|Ta-Nehisi Coates": {
+  {
+    "title": "Between the World and Me",
+    "author": "Ta-Nehisi Coates",
     "asin": "0812993543",
     "category": "books",
     "description": "Coates's searing letter to his son about being Black in America."
   },
-  "Bottle Service|Mallory Whitmore": {
+  {
+    "title": "Bottle Service",
+    "author": "Mallory Whitmore",
     "asin": "1668088762",
     "category": "books",
     "description": "A practical guide to confident, guilt-free formula feeding from the founder of The Formula Mom."
   },
-  "Bowling Alone|Robert Putnam": {
+  {
+    "title": "Bowling Alone",
+    "author": "Robert Putnam",
     "asin": "0743203046",
     "category": "books",
-    "description": "The collapse and revival of American community \u2014 why social capital matters."
+    "description": "The collapse and revival of American community — why social capital matters."
   },
-  "Brave New World|Aldous Huxley": {
+  {
+    "title": "Brave New World",
+    "author": "Aldous Huxley",
     "asin": "0060850523",
     "category": "books",
     "description": "Huxley's dystopia of pleasure, conformity, and engineered happiness."
   },
-  "Capital in the Twenty-First Century|Thomas Piketty": {
+  {
+    "title": "Capital in the Twenty-First Century",
+    "author": "Thomas Piketty",
     "asin": "0674979850",
     "category": "books",
     "description": "The landmark study of wealth inequality and its deep historical roots."
   },
-  "Caste|Isabel Wilkerson": {
+  {
+    "title": "Caste",
+    "author": "Isabel Wilkerson",
     "asin": "0593230256",
     "category": "books",
-    "description": "America's hidden caste system \u2014 connecting race in America to caste worldwide."
+    "description": "America's hidden caste system — connecting race in America to caste worldwide."
   },
-  "Clean Code|Robert Martin": {
+  {
+    "title": "Clean Code",
+    "author": "Robert Martin",
     "asin": "0132350882",
     "category": "books",
-    "description": "A handbook of agile software craftsmanship \u2014 writing code that humans can read and maintain."
+    "description": "A handbook of agile software craftsmanship — writing code that humans can read and maintain."
   },
-  "Cleaning House|Lindsay Dahl": {
+  {
+    "title": "Cleaning House",
+    "author": "Lindsay Dahl",
     "asin": "0063375591",
     "category": "books",
     "description": "An environmental health expert exposes the forces keeping toxic chemicals in consumer products."
   },
-  "Cyber for Builders|Ross Haleliuk": {
+  {
+    "title": "Cyber for Builders",
+    "author": "Ross Haleliuk",
     "asin": "173823410X",
     "category": "books",
-    "description": "The essential guide to building a cybersecurity startup \u2014 for founders, engineers, and investors."
+    "description": "The essential guide to building a cybersecurity startup — for founders, engineers, and investors."
   },
-  "Darkness at Noon|Arthur Koestler": {
+  {
+    "title": "Darkness at Noon",
+    "author": "Arthur Koestler",
     "asin": "1416540261",
     "category": "books",
     "description": "A political prisoner in a totalitarian state confronts the logic of revolution that devours its own."
   },
-  "Debt|David Graeber": {
+  {
+    "title": "Debt",
+    "author": "David Graeber",
     "asin": "1612194192",
     "category": "books",
     "description": "A 5,000-year history of debt that upends everything you thought you knew about money and markets."
   },
-  "Deep Work|Cal Newport": {
+  {
+    "title": "Deep Work",
+    "author": "Cal Newport",
     "asin": "1455586692",
     "category": "books",
     "description": "Rules for focused success in a distracted world."
   },
-  "Design Patterns|Erich Gamma": {
+  {
+    "title": "Design Patterns",
+    "author": "Erich Gamma",
     "asin": "0201633612",
     "category": "books",
-    "description": "The Gang of Four book \u2014 23 reusable design patterns that changed how software is built."
+    "description": "The Gang of Four book — 23 reusable design patterns that changed how software is built."
   },
-  "Destined for War|Graham Allison": {
+  {
+    "title": "Destined for War",
+    "author": "Graham Allison",
     "asin": "1328915387",
     "category": "books",
     "description": "Can America and China escape Thucydides's Trap? History says it's hard."
   },
-  "Everyone Is Lying to You|Jo Piazza": {
+  {
+    "title": "Everyone Is Lying to You",
+    "author": "Jo Piazza",
     "asin": "B0DJCSHC1G",
     "category": "books",
     "description": "A thriller set in the dark world of tradwife influencers and a journalist's investigation."
   },
-  "Evicted|Matthew Desmond": {
+  {
+    "title": "Evicted",
+    "author": "Matthew Desmond",
     "asin": "0553447459",
     "category": "books",
     "description": "Pulitzer-winning account of poverty, housing, and eviction in America."
   },
-  "Factfulness|Hans Rosling": {
+  {
+    "title": "Factfulness",
+    "author": "Hans Rosling",
     "asin": "1250107814",
     "category": "books",
-    "description": "Ten instincts that distort our worldview \u2014 and why the world is better than you think."
+    "description": "Ten instincts that distort our worldview — and why the world is better than you think."
   },
-  "Four Mothers|Abigail Leonard": {
+  {
+    "title": "Four Mothers",
+    "author": "Abigail Leonard",
     "asin": "1643756532",
     "category": "books",
-    "description": "Postpartum journeys across Finland, Japan, the US, and Kenya \u2014 personal stories meet policy research."
+    "description": "Postpartum journeys across Finland, Japan, the US, and Kenya — personal stories meet policy research."
   },
-  "G\u00f6del, Escher, Bach|Douglas Hofstadter": {
+  {
+    "title": "Gödel, Escher, Bach",
+    "author": "Douglas Hofstadter",
     "asin": "0465026567",
     "category": "books",
     "description": "A Pulitzer-winning exploration of consciousness, formal systems, and the strange loops connecting math, art, and music."
   },
-  "Homo Deus|Yuval Noah Harari": {
+  {
+    "title": "Homo Deus",
+    "author": "Yuval Noah Harari",
     "asin": "0062464345",
     "category": "books",
-    "description": "Where humanity is headed next \u2014 from Homo sapiens to technological gods."
+    "description": "Where humanity is headed next — from Homo sapiens to technological gods."
   },
-  "How Africa Works|Joe Studwell": {
+  {
+    "title": "How Africa Works",
+    "author": "Joe Studwell",
     "asin": "0802158439",
     "category": "books",
     "description": "Studwell's follow-up examining success and failure on the world's last developmental frontier."
   },
-  "How Asia Works|Joe Studwell": {
+  {
+    "title": "How Asia Works",
+    "author": "Joe Studwell",
     "asin": "0802121322",
     "category": "books",
     "description": "Why some Asian economies succeeded through land reform, manufacturing discipline, and financial control."
   },
-  "How Democracies Die|Steven Levitsky": {
+  {
+    "title": "How Democracies Die",
+    "author": "Steven Levitsky",
     "asin": "1524762938",
     "category": "books",
     "description": "How elected leaders can gradually subvert democracy from within."
   },
-  "Human Compatible|Stuart Russell": {
+  {
+    "title": "Human Compatible",
+    "author": "Stuart Russell",
     "asin": "0525558632",
     "category": "books",
-    "description": "How to build AI that is provably beneficial \u2014 from one of the field's founders."
+    "description": "How to build AI that is provably beneficial — from one of the field's founders."
   },
-  "Life 3.0|Max Tegmark": {
+  {
+    "title": "Life 3.0",
+    "author": "Max Tegmark",
     "asin": "1101970316",
     "category": "books",
     "description": "What it means to be human in the age of artificial intelligence."
   },
-  "Lightbreakers|Aja Gabel": {
+  {
+    "title": "Lightbreakers",
+    "author": "Aja Gabel",
     "asin": "0593329708",
     "category": "books",
     "description": "A novel about an artist and a quantum physicist whose marriage is haunted by grief and time travel."
   },
-  "MITI and the Japanese Miracle|Chalmers Johnson": {
-    "asin": "0804712069",
-    "category": "books",
-    "description": "Landmark study of Japan's industrial policy and the ministry that engineered postwar economic growth."
-  },
-  "Manufacturing Consent|Noam Chomsky": {
+  {
+    "title": "Manufacturing Consent",
+    "author": "Noam Chomsky",
     "asin": "0375714499",
     "category": "books",
     "description": "The propaganda model of mass media and how institutional filters shape the news."
   },
-  "Meditations|Marcus Aurelius": {
+  {
+    "title": "Meditations",
+    "author": "Marcus Aurelius",
     "asin": "0812968255",
     "category": "books",
-    "description": "The private journal of a Roman emperor \u2014 Stoic philosophy at its most personal."
+    "description": "The private journal of a Roman emperor — Stoic philosophy at its most personal."
   },
-  "Nothing Is True and Everything Is Possible|Peter Pomerantsev": {
+  {
+    "title": "MITI and the Japanese Miracle",
+    "author": "Chalmers Johnson",
+    "asin": "0804712069",
+    "category": "books",
+    "description": "Landmark study of Japan's industrial policy and the ministry that engineered postwar economic growth."
+  },
+  {
+    "title": "Nothing Is True and Everything Is Possible",
+    "author": "Peter Pomerantsev",
     "asin": "1610394550",
     "category": "books",
     "description": "A firsthand account of modern Russia's surreal media landscape, propaganda, and Kremlin power."
   },
-  "Nudge|Richard Thaler": {
+  {
+    "title": "Nudge",
+    "author": "Richard Thaler",
     "asin": "014311526X",
     "category": "books",
     "description": "How small design choices in how options are presented can dramatically improve decisions."
   },
-  "On China|Henry Kissinger": {
+  {
+    "title": "On China",
+    "author": "Henry Kissinger",
     "asin": "0143121316",
     "category": "books",
     "description": "Kissinger's insider account of Chinese strategic thinking from Mao to the present."
   },
-  "On Tyranny|Timothy Snyder": {
+  {
+    "title": "On Tyranny",
+    "author": "Timothy Snyder",
     "asin": "0804190119",
     "category": "books",
     "description": "Twenty lessons from the twentieth century on resisting authoritarianism."
   },
-  "On Writing|Stephen King": {
+  {
+    "title": "On Writing",
+    "author": "Stephen King",
     "asin": "1982159375",
     "category": "books",
     "description": "Part memoir, part master class on the craft of writing from one of America's most prolific authors."
   },
-  "Orientalism|Edward Said": {
+  {
+    "title": "Orientalism",
+    "author": "Edward Said",
     "asin": "039474067X",
     "category": "books",
-    "description": "How the West constructed 'the Orient' as exotic other \u2014 and used that construction to justify domination."
+    "description": "How the West constructed 'the Orient' as exotic other — and used that construction to justify domination."
   },
-  "Prisoners of Geography|Tim Marshall": {
+  {
+    "title": "Prisoners of Geography",
+    "author": "Tim Marshall",
     "asin": "1501121472",
     "category": "books",
-    "description": "How physical geography shapes geopolitics \u2014 why maps explain more than ideology."
+    "description": "How physical geography shapes geopolitics — why maps explain more than ideology."
   },
-  "Quietly Wild|Alix Klingenberg": {
+  {
+    "title": "Quietly Wild",
+    "author": "Alix Klingenberg",
     "asin": "B0DV4N9N7S",
     "category": "books",
     "description": "Poetry, photography, and earth-centered rituals guiding readers through nature's seasonal cycles."
   },
-  "Race After Technology|Ruha Benjamin": {
+  {
+    "title": "Race After Technology",
+    "author": "Ruha Benjamin",
     "asin": "1509526404",
     "category": "books",
     "description": "How social inequality is embedded in digital design and the 'New Jim Code.'"
   },
-  "Sapiens|Yuval Noah Harari": {
+  {
+    "title": "Sapiens",
+    "author": "Yuval Noah Harari",
     "asin": "0062316095",
     "category": "books",
     "description": "A sweeping history of humankind from the Stone Age to Silicon Valley."
   },
-  "Spillover|David Quammen": {
+  {
+    "title": "Spillover",
+    "author": "David Quammen",
     "asin": "0393346617",
     "category": "books",
-    "description": "How animal infections jump to humans \u2014 the science of the next pandemic, written before COVID."
+    "description": "How animal infections jump to humans — the science of the next pandemic, written before COVID."
   },
-  "Superintelligence|Nick Bostrom": {
+  {
+    "title": "Superintelligence",
+    "author": "Nick Bostrom",
     "asin": "0199678111",
     "category": "books",
     "description": "The canonical argument for why advanced AI poses existential risk."
   },
-  "Technopoly|Neil Postman": {
+  {
+    "title": "Technopoly",
+    "author": "Neil Postman",
     "asin": "0679745408",
     "category": "books",
     "description": "How technology became a totalitarian force that surrenders culture to its own imperatives."
   },
-  "The Age of AI|Henry Kissinger": {
+  {
+    "title": "The Age of AI",
+    "author": "Henry Kissinger",
     "asin": "0316273805",
     "category": "books",
     "description": "How artificial intelligence will reshape security, politics, and human identity."
   },
-  "The Age of Surveillance Capitalism|Shoshana Zuboff": {
+  {
+    "title": "The Age of Surveillance Capitalism",
+    "author": "Shoshana Zuboff",
     "asin": "1610395697",
     "category": "books",
     "description": "How tech companies turned human experience into raw material for prediction and control."
   },
-  "The Alignment Problem|Brian Christian": {
+  {
+    "title": "The Alignment Problem",
+    "author": "Brian Christian",
     "asin": "0393635821",
     "category": "books",
-    "description": "How machine learning reflects and amplifies human values \u2014 and where it goes wrong."
+    "description": "How machine learning reflects and amplifies human values — and where it goes wrong."
   },
-  "The Argonauts|Maggie Nelson": {
+  {
+    "title": "The Argonauts",
+    "author": "Maggie Nelson",
     "asin": "1555977359",
     "category": "books",
     "description": "A genre-bending memoir blending personal narrative with critical theory on queer family-making and identity."
   },
-  "The Art of War|Sun Tzu": {
+  {
+    "title": "The Art of War",
+    "author": "Sun Tzu",
     "asin": "1599869772",
     "category": "books",
     "description": "The ancient Chinese treatise on strategy, still applied in business and conflict."
   },
-  "The Ascent of Money|Niall Ferguson": {
+  {
+    "title": "The Ascent of Money",
+    "author": "Niall Ferguson",
     "asin": "0143116177",
     "category": "books",
-    "description": "A financial history of the world \u2014 how money, credit, and banking shaped civilization."
+    "description": "A financial history of the world — how money, credit, and banking shaped civilization."
   },
-  "The Beatles|Bob Spitz": {
+  {
+    "title": "The Beatles",
+    "author": "Bob Spitz",
     "asin": "0316013315",
     "category": "books",
-    "description": "The definitive biography of the Beatles \u2014 exhaustive, intimate, and authoritative."
+    "description": "The definitive biography of the Beatles — exhaustive, intimate, and authoritative."
   },
-  "The Beginning of Infinity|David Deutsch": {
+  {
+    "title": "The Beginning of Infinity",
+    "author": "David Deutsch",
     "asin": "0143121359",
     "category": "books",
-    "description": "A physicist's argument that explanations are the key to progress \u2014 and that progress is infinite."
+    "description": "A physicist's argument that explanations are the key to progress — and that progress is infinite."
   },
-  "The Big Short|Michael Lewis": {
+  {
+    "title": "The Big Short",
+    "author": "Michael Lewis",
     "asin": "0393338827",
     "category": "books",
     "description": "How a handful of investors saw the housing bubble and bet against Wall Street."
   },
-  "The Black Swan|Nassim Nicholas Taleb": {
+  {
+    "title": "The Black Swan",
+    "author": "Nassim Nicholas Taleb",
     "asin": "081297381X",
     "category": "books",
     "description": "Why highly improbable events dominate history and how we systematically underestimate them."
   },
-  "The Book of Why|Judea Pearl": {
+  {
+    "title": "The Book of Why",
+    "author": "Judea Pearl",
     "asin": "046509760X",
     "category": "books",
-    "description": "The new science of cause and effect \u2014 why correlation is not causation and what to do about it."
+    "description": "The new science of cause and effect — why correlation is not causation and what to do about it."
   },
-  "The Circle|Dave Eggers": {
+  {
+    "title": "The Circle",
+    "author": "Dave Eggers",
     "asin": "0345807294",
     "category": "books",
-    "description": "A novel about a powerful tech company that demands total transparency \u2014 and the cost of giving it."
+    "description": "A novel about a powerful tech company that demands total transparency — and the cost of giving it."
   },
-  "The Clash of Civilizations|Samuel Huntington": {
+  {
+    "title": "The Clash of Civilizations",
+    "author": "Samuel Huntington",
     "asin": "1451628978",
     "category": "books",
     "description": "The controversial thesis that cultural identity drives post-Cold War conflict."
   },
-  "The Color of Law|Richard Rothstein": {
+  {
+    "title": "The Color of Law",
+    "author": "Richard Rothstein",
     "asin": "1631494538",
     "category": "books",
     "description": "How government policy created residential segregation in America."
   },
-  "The Consumer Society|Jean Baudrillard": {
+  {
+    "title": "The Consumer Society",
+    "author": "Jean Baudrillard",
     "asin": "0761956921",
     "category": "books",
     "description": "Baudrillard's seminal critique arguing modern society is organized around consumption rather than production."
   },
-  "The Correspondent|Virginia Evans": {
+  {
+    "title": "The Correspondent",
+    "author": "Virginia Evans",
     "asin": "0593798430",
     "category": "books",
     "description": "An epistolary novel about a prickly septuagenarian who must confront a painful chapter of her past."
   },
-  "The Death and Life of Great American Cities|Jane Jacobs": {
+  {
+    "title": "The Death and Life of Great American Cities",
+    "author": "Jane Jacobs",
     "asin": "067974195X",
     "category": "books",
-    "description": "The classic that transformed urban planning \u2014 why cities need density, mixed use, and organic complexity."
+    "description": "The classic that transformed urban planning — why cities need density, mixed use, and organic complexity."
   },
-  "The Design of Everyday Things|Don Norman": {
+  {
+    "title": "The Design of Everyday Things",
+    "author": "Don Norman",
     "asin": "0465050654",
     "category": "books",
-    "description": "Why some designs work and others don't \u2014 the psychology of good design."
+    "description": "Why some designs work and others don't — the psychology of good design."
   },
-  "The Diary of a Young Girl|Anne Frank": {
+  {
+    "title": "The Diary of a Young Girl",
+    "author": "Anne Frank",
     "asin": "0553296981",
     "category": "books",
-    "description": "The intimate journal of a Jewish girl hiding from the Nazis \u2014 humanity's most personal Holocaust testimony."
+    "description": "The intimate journal of a Jewish girl hiding from the Nazis — humanity's most personal Holocaust testimony."
   },
-  "The Emerging Democratic Majority|John Judis": {
+  {
+    "title": "The Emerging Democratic Majority",
+    "author": "John Judis",
     "asin": "0743254783",
     "category": "books",
     "description": "Data-driven forecast of demographic and geographic shifts favoring a new progressive political coalition."
   },
-  "The End of Alchemy|Mervyn King": {
+  {
+    "title": "The End of Alchemy",
+    "author": "Mervyn King",
     "asin": "0393353575",
     "category": "books",
     "description": "A former central banker explains why the global financial system remains dangerously fragile."
   },
-  "The End of History and the Last Man|Francis Fukuyama": {
+  {
+    "title": "The End of History and the Last Man",
+    "author": "Francis Fukuyama",
     "asin": "0743284550",
     "category": "books",
     "description": "Fukuyama's famous thesis that liberal democracy is the final form of government."
   },
-  "The Fire Next Time|James Baldwin": {
+  {
+    "title": "The Fire Next Time",
+    "author": "James Baldwin",
     "asin": "067974472X",
     "category": "books",
     "description": "Baldwin's searing essays on race, religion, and identity in America."
   },
-  "The Fourth Turning|William Strauss": {
+  {
+    "title": "The Fourth Turning",
+    "author": "William Strauss",
     "asin": "0767900464",
     "category": "books",
-    "description": "The cyclical theory of American history \u2014 crisis, renewal, and generational patterns."
+    "description": "The cyclical theory of American history — crisis, renewal, and generational patterns."
   },
-  "The Great Influenza|John M. Barry": {
+  {
+    "title": "The Great Influenza",
+    "author": "John M. Barry",
     "asin": "0143036491",
     "category": "books",
-    "description": "The epic story of the 1918 pandemic \u2014 the deadliest plague in history and the scientists who fought it."
+    "description": "The epic story of the 1918 pandemic — the deadliest plague in history and the scientists who fought it."
   },
-  "The Great War for Civilisation|Robert Fisk": {
+  {
+    "title": "The Great War for Civilisation",
+    "author": "Robert Fisk",
     "asin": "1400075173",
     "category": "books",
     "description": "Fisk's magisterial account of the Middle East's wars from the perspective of those who lived through them."
   },
-  "The Guns of August|Barbara Tuchman": {
+  {
+    "title": "The Guns of August",
+    "author": "Barbara Tuchman",
     "asin": "0345476093",
     "category": "books",
     "description": "The definitive account of the first month of World War I and the failures of diplomacy."
   },
-  "The Hot Zone|Richard Preston": {
+  {
+    "title": "The Hot Zone",
+    "author": "Richard Preston",
     "asin": "0385495226",
     "category": "books",
-    "description": "The terrifying true story of Ebola's emergence \u2014 a thriller that reads like fiction but isn't."
+    "description": "The terrifying true story of Ebola's emergence — a thriller that reads like fiction but isn't."
   },
-  "The Innovator's Dilemma|Clayton Christensen": {
+  {
+    "title": "The Innovator's Dilemma",
+    "author": "Clayton Christensen",
     "asin": "0062060244",
     "category": "books",
     "description": "Why great companies fail when disruptive technologies emerge."
   },
-  "The Lean Startup|Eric Ries": {
+  {
+    "title": "The Lean Startup",
+    "author": "Eric Ries",
     "asin": "0307887898",
     "category": "books",
-    "description": "Build-measure-learn \u2014 the methodology that changed how startups operate."
+    "description": "Build-measure-learn — the methodology that changed how startups operate."
   },
-  "The Looming Tower|Lawrence Wright": {
+  {
+    "title": "The Looming Tower",
+    "author": "Lawrence Wright",
     "asin": "1400030846",
     "category": "books",
-    "description": "Pulitzer-winning account of the road to 9/11 \u2014 al-Qaeda, the FBI, and the intelligence failures."
+    "description": "Pulitzer-winning account of the road to 9/11 — al-Qaeda, the FBI, and the intelligence failures."
   },
-  "The Master Algorithm|Pedro Domingos": {
+  {
+    "title": "The Master Algorithm",
+    "author": "Pedro Domingos",
     "asin": "0465065708",
     "category": "books",
     "description": "The quest for the universal learning algorithm that will reshape civilization."
   },
-  "The Myth of the Perfect Mom|Erin Schlozman": {
+  {
+    "title": "The Myth of the Perfect Mom",
+    "author": "Erin Schlozman",
     "asin": "B0FH1D67NR",
     "category": "books",
     "description": "A therapist breaks down ten harmful myths weighing new mothers down in postpartum."
   },
-  "The Narrow Corridor|Daron Acemoglu": {
+  {
+    "title": "The Narrow Corridor",
+    "author": "Daron Acemoglu",
     "asin": "0735224382",
     "category": "books",
-    "description": "How the constant struggle between state and society creates \u2014 or destroys \u2014 liberty."
+    "description": "How the constant struggle between state and society creates — or destroys — liberty."
   },
-  "The New Jim Crow|Michelle Alexander": {
+  {
+    "title": "The New Jim Crow",
+    "author": "Michelle Alexander",
     "asin": "1620971933",
     "category": "books",
     "description": "Mass incarceration as the modern successor to Jim Crow racial control."
   },
-  "The Origins of Totalitarianism|Hannah Arendt": {
+  {
+    "title": "The Origins of Totalitarianism",
+    "author": "Hannah Arendt",
     "asin": "0156701537",
     "category": "books",
     "description": "Arendt's analysis of how totalitarian movements arise from loneliness and terror."
   },
-  "The Orthodox Church|Timothy Ware": {
+  {
+    "title": "The Orthodox Church",
+    "author": "Timothy Ware",
     "asin": "014198063X",
     "category": "books",
-    "description": "The standard introduction to Eastern Orthodox Christianity \u2014 history, theology, and worship."
+    "description": "The standard introduction to Eastern Orthodox Christianity — history, theology, and worship."
   },
-  "The Peloponnesian War|Thucydides": {
+  {
+    "title": "The Peloponnesian War",
+    "author": "Thucydides",
     "asin": "0140440399",
     "category": "books",
-    "description": "The original work of political realism \u2014 Athens versus Sparta, and why democracies go to war."
+    "description": "The original work of political realism — Athens versus Sparta, and why democracies go to war."
   },
-  "The Pilgrimage|Paulo Coelho": {
+  {
+    "title": "The Pilgrimage",
+    "author": "Paulo Coelho",
     "asin": "0061687456",
     "category": "books",
     "description": "Coelho's autobiographical account of his mystical walk along the Santiago de Compostela route."
   },
-  "The Power Broker|Robert Caro": {
+  {
+    "title": "The Power Broker",
+    "author": "Robert Caro",
     "asin": "0394720245",
     "category": "books",
     "description": "The epic biography of Robert Moses and the making of modern New York."
   },
-  "The Prince|Niccol\u00f2 Machiavelli": {
+  {
+    "title": "The Prince",
+    "author": "Niccolò Machiavelli",
     "asin": "0140449159",
     "category": "books",
-    "description": "The original handbook on political power \u2014 ruthlessly practical, endlessly debated."
+    "description": "The original handbook on political power — ruthlessly practical, endlessly debated."
   },
-  "The Prize|Daniel Yergin": {
+  {
+    "title": "The Prize",
+    "author": "Daniel Yergin",
     "asin": "1439110123",
     "category": "books",
-    "description": "The epic history of oil, money, and power \u2014 from the first wells to the Gulf War."
+    "description": "The epic history of oil, money, and power — from the first wells to the Gulf War."
   },
-  "The Righteous Mind|Jonathan Haidt": {
+  {
+    "title": "The Righteous Mind",
+    "author": "Jonathan Haidt",
     "asin": "0307455777",
     "category": "books",
-    "description": "Why good people are divided by politics and religion \u2014 moral psychology explained."
+    "description": "Why good people are divided by politics and religion — moral psychology explained."
   },
-  "The Rise and Fall of the Great Powers|Paul Kennedy": {
+  {
+    "title": "The Rise and Fall of the Great Powers",
+    "author": "Paul Kennedy",
     "asin": "0679720197",
     "category": "books",
     "description": "How economic strength and military overstretch determine the fate of empires."
   },
-  "The Road to Serfdom|Friedrich Hayek": {
+  {
+    "title": "The Road to Serfdom",
+    "author": "Friedrich Hayek",
     "asin": "0226320553",
     "category": "books",
     "description": "Hayek's warning that central planning leads inevitably to authoritarianism."
   },
-  "The Second Machine Age|Erik Brynjolfsson": {
+  {
+    "title": "The Second Machine Age",
+    "author": "Erik Brynjolfsson",
     "asin": "0393350649",
     "category": "books",
     "description": "How digital technology is transforming the economy, work, and prosperity."
   },
-  "The Shock Doctrine|Naomi Klein": {
+  {
+    "title": "The Shock Doctrine",
+    "author": "Naomi Klein",
     "asin": "0312427999",
     "category": "books",
     "description": "How crises are exploited to push through radical free-market policies."
   },
-  "The Size of Your Joy|Elise Powers": {
+  {
+    "title": "The Size of Your Joy",
+    "author": "Elise Powers",
     "asin": "1771684402",
     "category": "books",
     "description": "A debut poetry collection exploring modern womanhood, motherhood, and the hunger for belonging."
   },
-  "The Strategy of Denial|Elbridge Colby": {
+  {
+    "title": "The Strategy of Denial",
+    "author": "Elbridge Colby",
     "asin": "0300256434",
     "category": "books",
     "description": "The case for American defense strategy focused on denying China regional hegemony in Asia."
   },
-  "The Structure of Scientific Revolutions|Thomas Kuhn": {
+  {
+    "title": "The Structure of Scientific Revolutions",
+    "author": "Thomas Kuhn",
     "asin": "0226458121",
     "category": "books",
-    "description": "The book that gave us 'paradigm shift' \u2014 how science actually changes."
+    "description": "The book that gave us 'paradigm shift' — how science actually changes."
   },
-  "The Tyranny of Merit|Michael Sandel": {
+  {
+    "title": "The Tyranny of Merit",
+    "author": "Michael Sandel",
     "asin": "0374289980",
     "category": "books",
     "description": "Why meritocracy breeds resentment and what a more humane politics might look like."
   },
-  "The Wealth of Nations|Adam Smith": {
+  {
+    "title": "The Wealth of Nations",
+    "author": "Adam Smith",
     "asin": "0679783369",
     "category": "books",
     "description": "The foundational text of modern economics and free market theory."
   },
-  "The Wretched of the Earth|Frantz Fanon": {
+  {
+    "title": "The Wretched of the Earth",
+    "author": "Frantz Fanon",
     "asin": "0802158633",
     "category": "books",
     "description": "Fanon's landmark analysis of colonialism, violence, and national liberation."
   },
-  "Thinking in Systems|Donella Meadows": {
+  {
+    "title": "Thinking in Systems",
+    "author": "Donella Meadows",
     "asin": "1603580557",
     "category": "books",
-    "description": "A primer on systems thinking \u2014 how to see the interconnections that drive complex behavior."
+    "description": "A primer on systems thinking — how to see the interconnections that drive complex behavior."
   },
-  "Thinking, Fast and Slow|Daniel Kahneman": {
+  {
+    "title": "Thinking, Fast and Slow",
+    "author": "Daniel Kahneman",
     "asin": "0374533555",
     "category": "books",
     "description": "The foundational work on cognitive biases and dual-process theory."
   },
-  "Too Big to Fail|Andrew Ross Sorkin": {
+  {
+    "title": "Too Big to Fail",
+    "author": "Andrew Ross Sorkin",
     "asin": "0143118242",
     "category": "books",
     "description": "The definitive inside account of the 2008 financial crisis and the people who caused it."
   },
-  "Utopia|Thomas More": {
+  {
+    "title": "Utopia",
+    "author": "Thomas More",
     "asin": "0140449108",
     "category": "books",
-    "description": "The foundational 1516 work imagining an ideal society \u2014 exploring property, governance, and social justice."
+    "description": "The foundational 1516 work imagining an ideal society — exploring property, governance, and social justice."
   },
-  "We Have Never Been Middle Class|Hadas Weiss": {
+  {
+    "title": "We Have Never Been Middle Class",
+    "author": "Hadas Weiss",
     "asin": "1788733916",
     "category": "books",
     "description": "Anthropological argument that 'middle class' is an ideology of social mobility that misleads us about economies."
   },
-  "Weapons of Math Destruction|Cathy O'Neil": {
+  {
+    "title": "Weapons of Math Destruction",
+    "author": "Cathy O'Neil",
     "asin": "0553418831",
     "category": "books",
     "description": "How big data algorithms reinforce inequality and threaten democracy."
   },
-  "Why Nations Fail|Daron Acemoglu": {
+  {
+    "title": "Why Nations Fail",
+    "author": "Daron Acemoglu",
     "asin": "0307719227",
     "category": "books",
     "description": "How political and economic institutions determine why some countries thrive and others don't."
   },
-  "Witness to Hope|George Weigel": {
+  {
+    "title": "Witness to Hope",
+    "author": "George Weigel",
     "asin": "0060732032",
     "category": "books",
-    "description": "Definitive biography of Pope John Paul II \u2014 his role in the fall of communism and his theological vision."
+    "description": "Definitive biography of Pope John Paul II — his role in the fall of communism and his theological vision."
   },
-  "Yesteryear|Caro Claire Burke": {
+  {
+    "title": "Yesteryear",
+    "author": "Caro Claire Burke",
     "asin": "059380421X",
     "category": "books",
     "description": "A tradwife influencer wakes up in the brutal reality of 1855."
   },
-  "Zero to One|Peter Thiel": {
+  {
+    "title": "Zero to One",
+    "author": "Peter Thiel",
     "asin": "0804139296",
     "category": "books",
     "description": "Thiel's contrarian guide to building startups that create something genuinely new."
   }
-}
+]

--- a/src/shared/affiliate-utils.ts
+++ b/src/shared/affiliate-utils.ts
@@ -13,9 +13,11 @@ export function buildAmazonUrl(asin: string, tag: string): string {
 }
 
 /**
- * Affiliate book entry from content/affiliate-books.json
+ * Affiliate book entry from content/affiliate-books.json (array format)
  */
 export interface AffiliateBook {
+  title: string;
+  author: string;
   asin: string;
   category: string;
   description: string;
@@ -24,15 +26,12 @@ export interface AffiliateBook {
 }
 
 /**
- * Parsed affiliate book with title and author extracted from the key
+ * Alias kept for backward compatibility — AffiliateBook now includes title/author directly.
  */
-export interface ParsedAffiliateBook extends AffiliateBook {
-  title: string;
-  author: string;
-}
+export type ParsedAffiliateBook = AffiliateBook;
 
 /**
- * Load and parse the affiliate books map from content/affiliate-books.json.
+ * Load and parse the affiliate books array from content/affiliate-books.json.
  * Call once at the top of a generation run, not per-page.
  * Returns a Map keyed by lowercase book title for fast lookup.
  */
@@ -42,12 +41,11 @@ export async function loadAffiliateBooks(projectRoot: string): Promise<Map<strin
   const filePath = join(projectRoot, 'content', 'affiliate-books.json');
   try {
     const raw = await readFile(filePath, 'utf-8');
-    const data = JSON.parse(raw) as Record<string, AffiliateBook>;
+    const data = JSON.parse(raw) as AffiliateBook[];
     const map = new Map<string, ParsedAffiliateBook>();
-    for (const [key, value] of Object.entries(data)) {
-      const [title, author] = key.split('|');
-      if (title && author) {
-        map.set(title.toLowerCase(), { ...value, title, author });
+    for (const entry of data) {
+      if (entry.title && entry.author) {
+        map.set(entry.title.toLowerCase(), entry);
       }
     }
     return map;

--- a/tools/jobs/affiliate-suggest.ts
+++ b/tools/jobs/affiliate-suggest.ts
@@ -33,12 +33,14 @@ const resetMode = args.includes('--reset');
 // ── Book mapping ────────────────────────────────────────────────────
 
 interface BookEntry {
+  title: string;
+  author: string;
   asin: string;
   category: string;
   description: string;
 }
 
-type BookMap = Record<string, BookEntry>;
+type BookMap = BookEntry[];
 
 async function loadBookMap(): Promise<BookMap> {
   const mapPath = join(process.cwd(), 'content', 'affiliate-books.json');
@@ -47,7 +49,7 @@ async function loadBookMap(): Promise<BookMap> {
     return JSON.parse(raw) as BookMap;
   } catch {
     console.info('Warning: content/affiliate-books.json not found or invalid');
-    return {};
+    return [];
   }
 }
 
@@ -59,21 +61,21 @@ function lookupBook(
   bookMap: BookMap,
   title: string,
   author: string
-): (BookEntry & { title: string; author: string }) | null {
-  // Exact match: "Title|Author"
-  const exactKey = `${title}|${author}`;
-  if (bookMap[exactKey]) {
-    return { ...bookMap[exactKey], title, author };
+): BookEntry | null {
+  // Exact match on title + author
+  const titleLower = title.toLowerCase().trim();
+  const authorLower = author.toLowerCase().trim();
+  const exact = bookMap.find(
+    b => b.title.toLowerCase().trim() === titleLower && b.author.toLowerCase().trim() === authorLower
+  );
+  if (exact) {
+    return exact;
   }
 
-  // Fuzzy: case-insensitive match on title portion of key
-  const titleLower = title.toLowerCase().trim();
-  for (const [key, entry] of Object.entries(bookMap)) {
-    const [mapTitle] = key.split('|');
-    if (mapTitle.toLowerCase().trim() === titleLower) {
-      const [, mapAuthor] = key.split('|');
-      return { ...entry, title: mapTitle, author: mapAuthor ?? author };
-    }
+  // Fuzzy: case-insensitive match on title only
+  const byTitle = bookMap.find(b => b.title.toLowerCase().trim() === titleLower);
+  if (byTitle) {
+    return byTitle;
   }
 
   return null;
@@ -86,15 +88,9 @@ function lookupBook(
 function lookupAuthor(
   bookMap: BookMap,
   author: string
-): (BookEntry & { title: string; author: string }) | null {
+): BookEntry | null {
   const authorLower = author.toLowerCase().trim();
-  for (const [key, entry] of Object.entries(bookMap)) {
-    const [mapTitle, mapAuthor] = key.split('|');
-    if (mapAuthor && mapAuthor.toLowerCase().trim() === authorLower) {
-      return { ...entry, title: mapTitle, author: mapAuthor };
-    }
-  }
-  return null;
+  return bookMap.find(b => b.author.toLowerCase().trim() === authorLower) ?? null;
 }
 
 // ── Unresolved mentions tracking ────────────────────────────────────
@@ -321,7 +317,7 @@ async function main(): Promise<void> {
   }
 
   const bookMap = await loadBookMap();
-  const bookCount = Object.keys(bookMap).length;
+  const bookCount = bookMap.length;
 
   if (bookCount === 0) {
     console.info('No books in content/affiliate-books.json — nothing to match against');

--- a/tools/jobs/expand-affiliate-map.ts
+++ b/tools/jobs/expand-affiliate-map.ts
@@ -60,12 +60,14 @@ const OLLAMA_CLOUD_BASE = 'https://ollama.com/api';
 // ── Types ───────────────────────────────────────────────────────────
 
 interface BookEntry {
+  title: string;
+  author: string;
   asin: string;
   category: string;
   description: string;
 }
 
-type BookMap = Record<string, BookEntry>;
+type BookMap = BookEntry[];
 
 interface UnresolvedEntry {
   type: 'book_mention' | 'author_mention';
@@ -115,15 +117,12 @@ async function loadBookMap(): Promise<BookMap> {
     return JSON.parse(raw) as BookMap;
   } catch {
     console.info('Warning: content/affiliate-books.json not found, starting fresh');
-    return {};
+    return [];
   }
 }
 
 async function saveBookMap(bookMap: BookMap): Promise<void> {
-  const sorted: BookMap = {};
-  for (const key of Object.keys(bookMap).sort((a, b) => a.localeCompare(b))) {
-    sorted[key] = bookMap[key];
-  }
+  const sorted = [...bookMap].sort((a, b) => a.title.localeCompare(b.title));
   await writeFile(MAP_PATH, JSON.stringify(sorted, null, 2) + '\n', 'utf-8');
 }
 
@@ -154,23 +153,12 @@ function isValidAsin(asin: string): boolean {
 }
 
 function bookExistsByAsin(bookMap: BookMap, asin: string): boolean {
-  for (const entry of Object.values(bookMap)) {
-    if (entry.asin === asin) {
-      return true;
-    }
-  }
-  return false;
+  return bookMap.some(entry => entry.asin === asin);
 }
 
 function bookExistsByTitle(bookMap: BookMap, title: string): boolean {
   const titleLower = title.toLowerCase().trim();
-  for (const key of Object.keys(bookMap)) {
-    const [mapTitle] = key.split('|');
-    if (mapTitle.toLowerCase().trim() === titleLower) {
-      return true;
-    }
-  }
-  return false;
+  return bookMap.some(entry => entry.title.toLowerCase().trim() === titleLower);
 }
 
 // ── Ollama tool calling ─────────────────────────────────────────────
@@ -420,7 +408,7 @@ async function main(): Promise<void> {
 
   const bookMap = await loadBookMap();
   const unresolved = await loadUnresolvedMentions();
-  const initialMapCount = Object.keys(bookMap).length;
+  const initialMapCount = bookMap.length;
   const unresolvedKeys = Object.keys(unresolved);
 
   console.info(`Loaded ${initialMapCount} books from affiliate-books.json`);
@@ -507,19 +495,20 @@ async function main(): Promise<void> {
       }
 
       // Add to book map
-      const mapKey = `${result.title}|${result.author}`;
-      bookMap[mapKey] = {
+      bookMap.push({
+        title: result.title,
+        author: result.author,
         asin,
         category: result.category || 'books',
         description: result.description,
-      };
+      });
 
       // Remove from unresolved
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- cleaning resolved entries from map
       delete unresolved[key];
 
       stats.added++;
-      console.info(`  ADDED: ${mapKey} → ${asin}`);
+      console.info(`  ADDED: ${result.title} by ${result.author} → ${asin}`);
     } catch (err) {
       console.info(`  ERROR: ${err instanceof Error ? err.message : String(err)}`);
       stats.failed++;
@@ -532,7 +521,7 @@ async function main(): Promise<void> {
   // Save updated files
   if (stats.added > 0 || stats.skipped > 0) {
     await saveBookMap(bookMap);
-    console.info(`\nWrote updated affiliate-books.json (${Object.keys(bookMap).length} total entries)`);
+    console.info(`\nWrote updated affiliate-books.json (${bookMap.length} total entries)`);
   }
 
   await saveUnresolvedMentions(unresolved);
@@ -546,7 +535,7 @@ async function main(): Promise<void> {
   console.info(`  Skipped (dupes):    ${stats.skipped}`);
   console.info(`  Failed:             ${stats.failed}`);
   console.info(`  Web searches used:  ${stats.searchesUsed} / 100 daily budget`);
-  console.info(`  Map size:           ${initialMapCount} → ${Object.keys(bookMap).length}`);
+  console.info(`  Map size:           ${initialMapCount} → ${bookMap.length}`);
   console.info(`  Unresolved:         ${unresolvedKeys.length} → ${remainingUnresolved}`);
 }
 


### PR DESCRIPTION
## Summary
- Converted `content/affiliate-books.json` from `{"Title|Author": {asin, category, description}}` object format to `[{title, author, asin, category, description}]` array format
- Updated `src/shared/affiliate-utils.ts`: `AffiliateBook` interface now includes `title`/`author` directly; `ParsedAffiliateBook` is a type alias; `loadAffiliateBooks()` reads from array
- Updated `tools/jobs/affiliate-suggest.ts`: `BookMap` is now `BookEntry[]`; `lookupBook()` and `lookupAuthor()` use array search instead of key splitting
- Updated `tools/jobs/expand-affiliate-map.ts`: `BookMap` is `BookEntry[]`; `saveBookMap()` sorts by title; new entries are pushed to the array

Closes #172

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests, 9 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)