### PR TITLE
feat: migrate affiliate books from JSON to database

### DIFF
--- a/src/db/migrations/011_affiliate_books.sql
+++ b/src/db/migrations/011_affiliate_books.sql
@@ -1,0 +1,16 @@
+-- Migration: Create affiliate_books table
+-- Moves affiliate book catalog from JSON file to database
+
+CREATE TABLE IF NOT EXISTS app.affiliate_books (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  author TEXT NOT NULL,
+  asin TEXT NOT NULL UNIQUE,
+  category TEXT NOT NULL DEFAULT 'books',
+  description TEXT,
+  gutenberg_url TEXT,
+  archive_url TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_affiliate_books_title_author ON app.affiliate_books (LOWER(title), LOWER(author));

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -9,6 +9,8 @@ import {
   Article,
   ArticleWithPublication,
   ArticleLink,
+  AffiliateBookRow,
+  UpsertAffiliateBookInput,
   CreatePublicationInput,
   CreateArticleInput,
   CreateArticleLinkInput,
@@ -335,6 +337,56 @@ export async function getArticleBacklinks(
     [articleId]
   );
   return rows;
+}
+
+// ============ Affiliate Books ============
+
+export async function getAffiliateBooks(
+  client: Pool | PoolClient
+): Promise<AffiliateBookRow[]> {
+  const { rows } = await client.query<AffiliateBookRow>(
+    'SELECT * FROM app.affiliate_books ORDER BY title'
+  );
+  return rows;
+}
+
+export async function getAffiliateBookByTitle(
+  client: Pool | PoolClient,
+  title: string
+): Promise<AffiliateBookRow | null> {
+  const { rows } = await client.query<AffiliateBookRow>(
+    'SELECT * FROM app.affiliate_books WHERE LOWER(title) = LOWER($1)',
+    [title]
+  );
+  return rows[0] ?? null;
+}
+
+export async function upsertAffiliateBook(
+  client: Pool | PoolClient,
+  book: UpsertAffiliateBookInput
+): Promise<AffiliateBookRow> {
+  const { rows } = await client.query<AffiliateBookRow>(
+    `INSERT INTO app.affiliate_books (title, author, asin, category, description, gutenberg_url, archive_url)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
+     ON CONFLICT (asin) DO UPDATE SET
+       title = EXCLUDED.title,
+       author = EXCLUDED.author,
+       category = EXCLUDED.category,
+       description = EXCLUDED.description,
+       gutenberg_url = EXCLUDED.gutenberg_url,
+       archive_url = EXCLUDED.archive_url
+     RETURNING *`,
+    [
+      book.title,
+      book.author,
+      book.asin,
+      book.category ?? 'books',
+      book.description ?? null,
+      book.gutenberg_url ?? null,
+      book.archive_url ?? null,
+    ]
+  );
+  return rows[0];
 }
 
 export async function getMostLinkedArticles(

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -75,6 +75,28 @@ export interface AffiliateLink {
   category: string;
 }
 
+export interface AffiliateBookRow {
+  id: number;
+  title: string;
+  author: string;
+  asin: string;
+  category: string;
+  description: string | null;
+  gutenberg_url: string | null;
+  archive_url: string | null;
+  created_at: Date;
+}
+
+export interface UpsertAffiliateBookInput {
+  title: string;
+  author: string;
+  asin: string;
+  category?: string;
+  description?: string;
+  gutenberg_url?: string;
+  archive_url?: string;
+}
+
 // Input types for creating records
 export interface CreatePublicationInput {
   name: string;
@@ -111,14 +133,6 @@ export interface CreateArticleLinkInput {
   target_url: string;
   link_text?: string;
   context?: string;
-}
-
-export interface AffiliateLink {
-  asin: string;
-  title: string;
-  author: string;
-  description: string;
-  category: string;
 }
 
 // Query types

--- a/src/shared/affiliate-utils.ts
+++ b/src/shared/affiliate-utils.ts
@@ -56,6 +56,42 @@ export async function loadAffiliateBooks(projectRoot: string): Promise<Map<strin
 }
 
 /**
+ * Load affiliate books from the database.
+ * Returns the same Map<string, ParsedAffiliateBook> format as loadAffiliateBooks.
+ * Use this when a database connection is available (private library, jobs).
+ * Falls back gracefully if the table doesn't exist yet.
+ */
+export async function loadAffiliateBooksFromDb(pool: import('pg').Pool): Promise<Map<string, ParsedAffiliateBook>> {
+  const map = new Map<string, ParsedAffiliateBook>();
+  try {
+    const { rows } = await pool.query<{
+      title: string;
+      author: string;
+      asin: string;
+      category: string;
+      description: string | null;
+      gutenberg_url: string | null;
+      archive_url: string | null;
+    }>('SELECT title, author, asin, category, description, gutenberg_url, archive_url FROM app.affiliate_books ORDER BY title');
+
+    for (const row of rows) {
+      map.set(row.title.toLowerCase(), {
+        asin: row.asin,
+        category: row.category,
+        description: row.description ?? '',
+        gutenberg_url: row.gutenberg_url ?? undefined,
+        archive_url: row.archive_url ?? undefined,
+        title: row.title,
+        author: row.author,
+      });
+    }
+  } catch {
+    console.warn('Warning: Could not load affiliate books from database (table may not exist yet)');
+  }
+  return map;
+}
+
+/**
  * Render purchase links footer for a Wikipedia page about a book.
  * Subtle: small text, no heading, just links.
  * Free sources first, paid second.

--- a/tools/db/seed-affiliate-books.ts
+++ b/tools/db/seed-affiliate-books.ts
@@ -1,0 +1,91 @@
+/**
+ * Seed affiliate books from content/affiliate-books.json into the database.
+ *
+ * Reads the JSON file (array of {title, author, asin, ...} objects)
+ * and upserts each entry into app.affiliate_books.
+ *
+ * Idempotent: uses ON CONFLICT (asin) DO UPDATE.
+ *
+ * Usage:
+ *   npx tsx tools/db/seed-affiliate-books.ts
+ */
+
+import 'dotenv/config';
+import { Pool } from 'pg';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+interface BookEntry {
+  title: string;
+  author: string;
+  asin: string;
+  category: string;
+  description: string;
+  gutenberg_url?: string;
+  archive_url?: string;
+}
+
+async function main(): Promise<void> {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    throw new Error('DATABASE_URL required');
+  }
+
+  const pool = new Pool({ connectionString: dbUrl });
+
+  try {
+    const filePath = join(process.cwd(), 'content', 'affiliate-books.json');
+    const raw = await readFile(filePath, 'utf-8');
+    const data = JSON.parse(raw) as BookEntry[];
+
+    console.info(`Loaded ${data.length} books from affiliate-books.json`);
+
+    let inserted = 0;
+    let updated = 0;
+
+    for (const entry of data) {
+      if (!entry.title || !entry.author) {
+        console.info(`  SKIP: missing title or author in entry`);
+        continue;
+      }
+
+      const result = await pool.query(
+        `INSERT INTO app.affiliate_books (title, author, asin, category, description, gutenberg_url, archive_url)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (asin) DO UPDATE SET
+           title = EXCLUDED.title,
+           author = EXCLUDED.author,
+           category = EXCLUDED.category,
+           description = EXCLUDED.description,
+           gutenberg_url = EXCLUDED.gutenberg_url,
+           archive_url = EXCLUDED.archive_url
+         RETURNING (xmax = 0) AS is_insert`,
+        [
+          entry.title,
+          entry.author,
+          entry.asin,
+          entry.category || 'books',
+          entry.description || null,
+          entry.gutenberg_url || null,
+          entry.archive_url || null,
+        ]
+      );
+
+      const isInsert = (result.rows[0] as { is_insert: boolean }).is_insert;
+      if (isInsert) {
+        inserted++;
+      } else {
+        updated++;
+      }
+    }
+
+    console.info(`Done: ${inserted} inserted, ${updated} updated`);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/tools/jobs/affiliate-suggest.ts
+++ b/tools/jobs/affiliate-suggest.ts
@@ -38,11 +38,39 @@ interface BookEntry {
   asin: string;
   category: string;
   description: string;
+  gutenberg_url?: string;
+  archive_url?: string;
 }
 
 type BookMap = BookEntry[];
 
-async function loadBookMap(): Promise<BookMap> {
+async function loadBookMapFromDb(pool: Pool): Promise<BookMap | null> {
+  try {
+    const { rows } = await pool.query<{
+      title: string;
+      author: string;
+      asin: string;
+      category: string;
+      description: string | null;
+      gutenberg_url: string | null;
+      archive_url: string | null;
+    }>('SELECT title, author, asin, category, description, gutenberg_url, archive_url FROM app.affiliate_books');
+
+    return rows.map(row => ({
+      title: row.title,
+      author: row.author,
+      asin: row.asin,
+      category: row.category,
+      description: row.description ?? '',
+      gutenberg_url: row.gutenberg_url ?? undefined,
+      archive_url: row.archive_url ?? undefined,
+    }));
+  } catch {
+    return null;
+  }
+}
+
+async function loadBookMapFromJson(): Promise<BookMap> {
   const mapPath = join(process.cwd(), 'content', 'affiliate-books.json');
   try {
     const raw = await readFile(mapPath, 'utf-8');
@@ -316,16 +344,19 @@ async function main(): Promise<void> {
     return;
   }
 
-  const bookMap = await loadBookMap();
+  // Try loading from DB first, fall back to JSON
+  const dbBookMap = await loadBookMapFromDb(pool);
+  const bookMap = dbBookMap ?? await loadBookMapFromJson();
   const bookCount = bookMap.length;
+  const bookSource = dbBookMap ? 'database' : 'affiliate-books.json';
 
   if (bookCount === 0) {
-    console.info('No books in content/affiliate-books.json — nothing to match against');
+    console.info(`No books in ${bookSource} — nothing to match against`);
     await pool.end();
     return;
   }
 
-  console.info(`Loaded ${bookCount} books from affiliate mapping`);
+  console.info(`Loaded ${bookCount} books from ${bookSource}`);
 
   const unresolved = await loadUnresolvedMentions();
 

--- a/tools/jobs/expand-affiliate-map.ts
+++ b/tools/jobs/expand-affiliate-map.ts
@@ -20,6 +20,7 @@
 import 'dotenv/config';
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
+import { Pool } from 'pg';
 
 // ── Load OLLAMA_API_KEY from ~/.config/.env if not already set ────
 async function loadExtraEnv(): Promise<void> {
@@ -518,10 +519,38 @@ async function main(): Promise<void> {
     await new Promise(r => setTimeout(r, 1000));
   }
 
-  // Save updated files
+  // Save updated files (JSON backup)
   if (stats.added > 0 || stats.skipped > 0) {
     await saveBookMap(bookMap);
     console.info(`\nWrote updated affiliate-books.json (${bookMap.length} total entries)`);
+  }
+
+  // Sync to database if DATABASE_URL is available
+  const dbUrl = process.env.DATABASE_URL;
+  if (dbUrl && stats.added > 0) {
+    const pool = new Pool({ connectionString: dbUrl });
+    try {
+      let dbUpserted = 0;
+      for (const entry of bookMap) {
+        if (!entry.title || !entry.author) { continue; }
+        await pool.query(
+          `INSERT INTO app.affiliate_books (title, author, asin, category, description)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (asin) DO UPDATE SET
+             title = EXCLUDED.title,
+             author = EXCLUDED.author,
+             category = EXCLUDED.category,
+             description = EXCLUDED.description`,
+          [entry.title, entry.author, entry.asin, entry.category || 'books', entry.description || null]
+        );
+        dbUpserted++;
+      }
+      console.info(`Synced ${dbUpserted} books to database`);
+    } catch (err) {
+      console.info(`Warning: Could not sync to database: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      await pool.end();
+    }
   }
 
   await saveUnresolvedMentions(unresolved);


### PR DESCRIPTION
## Summary

- Add `app.affiliate_books` table via migration `011_affiliate_books.sql` with unique ASIN constraint and case-insensitive title+author index
- Add seed script `tools/db/seed-affiliate-books.ts` that reads `content/affiliate-books.json` and upserts into DB
- Add `AffiliateBookRow` and `UpsertAffiliateBookInput` types to `src/db/types.ts` (removed duplicate `AffiliateLink` interface)
- Add `getAffiliateBooks()`, `getAffiliateBookByTitle()`, `upsertAffiliateBook()` query functions to `src/db/queries.ts`
- Add `loadAffiliateBooksFromDb(pool)` to `src/shared/affiliate-utils.ts` (JSON loader kept as fallback for static site)
- Update `expand-affiliate-map.ts` to sync resolved books to DB after JSON write
- Update `affiliate-suggest.ts` to load book map from DB first, falling back to JSON

Closes #165

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests)
- [ ] Run migration against local DB: `npx tsx src/db/migrate.ts`
- [ ] Seed books: `npx tsx tools/db/seed-affiliate-books.ts`
- [ ] Verify books in DB: `SELECT count(*) FROM app.affiliate_books`

🤖 Generated with [Claude Code](https://claude.com/claude-code)