### PR TITLE
feat: books as Wikipedia deep dives with purchase links

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -657,6 +657,33 @@ main {
   margin-top: 0.15rem;
 }
 
+.deep-dive-no-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--gap);
+}
+.deep-dive-no-link strong { color: var(--ink); }
+
+/* ── Book Purchase Links (Wikipedia pages) ───────────────────────── */
+
+.book-links {
+  margin-top: var(--gap-lg);
+  padding-top: var(--gap);
+  border-top: 1px solid var(--rule);
+  font-size: var(--text-sm);
+}
+.book-links ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+}
+.book-links li a {
+  color: var(--accent);
+}
+
 /* ── Wikipedia Page ──────────────────────────────────────────────── */
 
 .wikipedia-page { padding: 0; }

--- a/public/styles.css
+++ b/public/styles.css
@@ -620,6 +620,37 @@ main {
   margin-bottom: 0.6rem;
 }
 
+.deep-dives-label {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.6rem;
+}
+.deep-dives-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.deep-dives-list li {
+  padding: 0.25rem 0;
+}
+.deep-dives-list li a {
+  color: var(--accent);
+}
+.deep-dives-list .read-time {
+  font-size: var(--text-sm);
+  color: var(--ink-muted);
+}
+.deep-dives-list .deep-dive-no-link {
+  display: inline;
+}
+.deep-dives-list .deep-dive-no-link .read-time {
+  font-size: var(--text-sm);
+  color: var(--ink-muted);
+}
+
 .deep-dive-list {
   list-style: none;
   padding: 0;
@@ -655,6 +686,33 @@ main {
   font-size: var(--text-sm);
   color: var(--ink-soft);
   margin-top: 0.15rem;
+}
+
+.deep-dive-no-link {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--gap);
+}
+.deep-dive-no-link strong { color: var(--ink); }
+
+/* ── Book Purchase Links (Wikipedia pages) ───────────────────────── */
+
+.book-links {
+  margin-top: var(--gap-lg);
+  padding-top: var(--gap);
+  border-top: 1px solid var(--rule);
+  font-size: var(--text-sm);
+}
+.book-links ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1.5rem;
+}
+.book-links li a {
+  color: var(--accent);
 }
 
 /* ── Wikipedia Page ──────────────────────────────────────────────── */

--- a/src/api/pages.ts
+++ b/src/api/pages.ts
@@ -377,9 +377,8 @@ export function createPagesRouter(pool: Pool): Router {
       // 2. Subtitle (if present)
       // 3. Meta: author, date, reading time
       // 4. Source link to original Substack
-      // 5. Deep Dives links
+      // 5. Deep Dives links (Wikipedia articles + books)
       // 6. Article content
-      // 7. Affiliate recommendations
       const content = `
         <article class="article content-width">
           <header class="article-header">


### PR DESCRIPTION
## Summary

- Add missing CSS styles for book purchase links (`.book-links`) on Wikipedia pages, books without Wikipedia links (`.deep-dive-no-link`) in deep dives, and private library deep dives section (`.deep-dives-label`, `.deep-dives-list`)
- Clean up stale "Affiliate recommendations" comment in private library article layout
- Both static site and private library already correctly merge books into the deep dives section and show purchase links on Wikipedia book pages — this PR adds the missing CSS and cleans up documentation

## Verification

All five requirements from #126 verified:

1. **Wikipedia pages show purchase links for books** — already implemented in both sites, CSS now styled
2. **Article deep dives include books alongside Wikipedia links** — already implemented in both sites
3. **No separate affiliate/books section** — confirmed none exists
4. **Free sources shown before paid** — Gutenberg, Archive, Amazon, Kobo, BWB order confirmed
5. **Amazon link only renders when AMAZON_AFFILIATE_TAG is set** — confirmed

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)