### PR TITLE
fix: books in deep dives link to Amazon when no Wikipedia page exists

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -657,14 +657,6 @@ main {
   margin-top: 0.15rem;
 }
 
-.deep-dive-no-link {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: var(--gap);
-}
-.deep-dive-no-link strong { color: var(--ink); }
-
 /* ── Book Purchase Links (Wikipedia pages) ───────────────────────── */
 
 .book-links {

--- a/public/styles.css
+++ b/public/styles.css
@@ -643,13 +643,7 @@ main {
   font-size: var(--text-sm);
   color: var(--ink-muted);
 }
-.deep-dives-list .deep-dive-no-link {
-  display: inline;
-}
-.deep-dives-list .deep-dive-no-link .read-time {
-  font-size: var(--text-sm);
-  color: var(--ink-muted);
-}
+
 
 .deep-dive-list {
   list-style: none;
@@ -687,14 +681,6 @@ main {
   color: var(--ink-soft);
   margin-top: 0.15rem;
 }
-
-.deep-dive-no-link {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: var(--gap);
-}
-.deep-dive-no-link strong { color: var(--ink); }
 
 /* ── Book Purchase Links (Wikipedia pages) ───────────────────────── */
 

--- a/src/api/pages.ts
+++ b/src/api/pages.ts
@@ -12,7 +12,7 @@ import { Router, Request, Response } from 'express';
 import { Pool } from 'pg';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { loadAffiliateBooks, renderBookPurchaseLinks } from '../shared/affiliate-utils.js';
+import { loadAffiliateBooks, renderBookPurchaseLinks, buildAmazonUrl } from '../shared/affiliate-utils.js';
 import type { ParsedAffiliateBook } from '../shared/affiliate-utils.js';
 
 interface Article {
@@ -349,9 +349,15 @@ export function createPagesRouter(pool: Pool): Router {
           [link.title]
         );
         const wikiSlug = wikiResult2.rows[0]?.slug ?? null;
-        const inner = wikiSlug
-          ? `<a href="/wikipedia/${escapeHtml(wikiSlug)}">${escapeHtml(link.title)}</a>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`
-          : `<span class="deep-dive-no-link">${escapeHtml(link.title)}</span>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`;
+        const affiliateTag = process.env.AMAZON_AFFILIATE_TAG ?? '';
+        let inner: string;
+        if (wikiSlug) {
+          inner = `<a href="/wikipedia/${escapeHtml(wikiSlug)}">${escapeHtml(link.title)}</a>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`;
+        } else if (link.asin && affiliateTag) {
+          inner = `<a href="${buildAmazonUrl(link.asin, affiliateTag)}" target="_blank" rel="noopener">${escapeHtml(link.title)}</a>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`;
+        } else {
+          inner = `<span>${escapeHtml(link.title)}</span>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`;
+        }
         bookItems.push(`<li>${inner}</li>`);
       }
 

--- a/tools/static-site/pages/article.ts
+++ b/tools/static-site/pages/article.ts
@@ -5,7 +5,7 @@
 
 import type { Pool } from 'pg';
 import { staticReadingLayout } from '../templates.js';
-import { writeFile, extractHtmlExcerpt, escapeHtml, formatDate, loadAffiliateBooks } from '../utils.js';
+import { writeFile, extractHtmlExcerpt, escapeHtml, formatDate, loadAffiliateBooks, buildAmazonUrl } from '../utils.js';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
 
@@ -127,6 +127,7 @@ interface BookDeepDive {
   author: string;
   description: string;
   wikiSlug: string | null;
+  asin: string | null;
 }
 
 /**
@@ -158,17 +159,27 @@ function generateArticlePage(
     )
     .join('\n');
 
+  const affiliateTag = process.env.AMAZON_AFFILIATE_TAG ?? '';
+
   const bookItems = bookDeepDives
     .map((b) => {
-      const inner = b.wikiSlug
-        ? `<a href="${pathToRoot}wikipedia/${b.wikiSlug}/index.html">
+      let inner: string;
+      if (b.wikiSlug) {
+        inner = `<a href="${pathToRoot}wikipedia/${b.wikiSlug}/index.html">
           <strong>${escapeHtml(b.title)}</strong>
           <span class="read-time">by ${escapeHtml(b.author)}</span>
-        </a>`
-        : `<span class="deep-dive-no-link">
+        </a>`;
+      } else if (b.asin && affiliateTag) {
+        inner = `<a href="${buildAmazonUrl(b.asin, affiliateTag)}" target="_blank" rel="noopener">
+          <strong>${escapeHtml(b.title)}</strong>
+          <span class="read-time">by ${escapeHtml(b.author)}</span>
+        </a>`;
+      } else {
+        inner = `<span>
           <strong>${escapeHtml(b.title)}</strong>
           <span class="read-time">by ${escapeHtml(b.author)}</span>
         </span>`;
+      }
       return `
       <li class="deep-dive-item">
         ${inner}
@@ -331,6 +342,7 @@ export async function generateArticlePages(
         author: link.author,
         description: mapEntry?.description ?? link.description,
         wikiSlug,
+        asin: link.asin ?? mapEntry?.asin ?? null,
       });
     }
 


### PR DESCRIPTION
## Summary
- Books in the Deep Dives section that lack a Wikipedia page now fall back to Amazon affiliate links (opens in new tab) instead of rendering as plain text
- Added `asin` to the `BookDeepDive` interface in the static site generator and passed it through from `affiliate_links`
- Applied the same Amazon fallback in the private library (`src/api/pages.ts`)
- Removed dead `.deep-dive-no-link` CSS from both `public/styles.css` and `docs/styles.css`
- Safe fallback: if neither wiki slug nor ASIN exists, the title stays as plain text

## Test plan
- [x] Lint passes
- [x] TypeScript compiles cleanly
- [x] All 143 unit tests pass
- [ ] Verify on static site that books without Wikipedia pages render as Amazon links
- [ ] Verify on private library that books without Wikipedia pages render as Amazon links

🤖 Generated with [Claude Code](https://claude.com/claude-code)