### PR TITLE
feat: revamp Deep Dives — books first, drop read times, view on Amazon

### DIFF
--- a/src/api/pages.ts
+++ b/src/api/pages.ts
@@ -352,11 +352,11 @@ export function createPagesRouter(pool: Pool): Router {
         const affiliateTag = process.env.AMAZON_AFFILIATE_TAG ?? '';
         let inner: string;
         if (wikiSlug) {
-          inner = `<a href="/wikipedia/${escapeHtml(wikiSlug)}">${escapeHtml(link.title)}</a>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`;
+          inner = `<a href="/wikipedia/${escapeHtml(wikiSlug)}">${escapeHtml(link.title)}${link.author ? ` by ${escapeHtml(link.author)}` : ''}</a>`;
         } else if (link.asin && affiliateTag) {
-          inner = `<a href="${buildAmazonUrl(link.asin, affiliateTag)}" target="_blank" rel="noopener">${escapeHtml(link.title)}</a>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`;
+          inner = `<a href="${buildAmazonUrl(link.asin, affiliateTag)}" target="_blank" rel="noopener">${escapeHtml(link.title)}${link.author ? ` by ${escapeHtml(link.author)}` : ''}</a> <span class="read-time">view on Amazon</span>`;
         } else {
-          inner = `<span>${escapeHtml(link.title)}</span>${link.author ? ` <span class="read-time">by ${escapeHtml(link.author)}</span>` : ''}`;
+          inner = `<span>${escapeHtml(link.title)}${link.author ? ` by ${escapeHtml(link.author)}` : ''}</span>`;
         }
         bookItems.push(`<li>${inner}</li>`);
       }
@@ -364,10 +364,10 @@ export function createPagesRouter(pool: Pool): Router {
       // Render Wikipedia deep dives section - compact list before content
       // Includes both Wikipedia articles and books (merged into one list)
       const allDeepDiveItems = [
-        ...wikiLinks.map(w => `
-              <li><a href="/wikipedia/${escapeHtml(w.slug)}">${escapeHtml(w.title)}</a>${w.read_time ? ` <span class="read-time">${w.read_time} min</span>` : ''}</li>
-            `),
         ...bookItems,
+        ...wikiLinks.map(w => `
+              <li><a href="/wikipedia/${escapeHtml(w.slug)}">${escapeHtml(w.title)}</a></li>
+            `),
       ];
       const wikiSection = allDeepDiveItems.length > 0 ? `
         <nav class="deep-dives" aria-label="Related Wikipedia articles">

--- a/tools/static-site/pages/article.ts
+++ b/tools/static-site/pages/article.ts
@@ -152,7 +152,6 @@ function generateArticlePage(
       <li class="deep-dive-item">
         <a href="${pathToRoot}wikipedia/${w.slug}/index.html">
           <strong>${escapeHtml(w.title)}</strong>
-          <span class="read-time">${w.estimated_read_time_minutes} min read</span>
         </a>
         <p class="topic-summary">${escapeHtml(w.topic_summary)}</p>
       </li>`
@@ -166,18 +165,16 @@ function generateArticlePage(
       let inner: string;
       if (b.wikiSlug) {
         inner = `<a href="${pathToRoot}wikipedia/${b.wikiSlug}/index.html">
-          <strong>${escapeHtml(b.title)}</strong>
-          <span class="read-time">by ${escapeHtml(b.author)}</span>
+          <strong>${escapeHtml(b.title)}</strong> by ${escapeHtml(b.author)}
         </a>`;
       } else if (b.asin && affiliateTag) {
         inner = `<a href="${buildAmazonUrl(b.asin, affiliateTag)}" target="_blank" rel="noopener">
-          <strong>${escapeHtml(b.title)}</strong>
-          <span class="read-time">by ${escapeHtml(b.author)}</span>
-        </a>`;
+          <strong>${escapeHtml(b.title)}</strong> by ${escapeHtml(b.author)}
+        </a>
+        <span class="read-time">view on Amazon</span>`;
       } else {
         inner = `<span>
-          <strong>${escapeHtml(b.title)}</strong>
-          <span class="read-time">by ${escapeHtml(b.author)}</span>
+          <strong>${escapeHtml(b.title)}</strong> by ${escapeHtml(b.author)}
         </span>`;
       }
       return `
@@ -188,13 +185,13 @@ function generateArticlePage(
     })
     .join('\n');
 
-  const allItems = wikiItems + bookItems;
+  const allItems = bookItems + wikiItems;
   let deepDivesHtml = '';
   if (allItems.trim()) {
     deepDivesHtml = `
       <section id="deep-dives" class="deep-dives">
         <h2>Deep Dives</h2>
-        <p class="deep-dives-intro">Explore related topics with these Wikipedia articles, rewritten for enjoyable reading:</p>
+        <p class="deep-dives-intro">Explore these related deep dives:</p>
         <ul class="deep-dive-list">
           ${allItems}
         </ul>


### PR DESCRIPTION
## Summary
- Order books before Wikipedia items in the Deep Dives section (both static site and server-side renderer)
- Remove read time badges from Wikipedia deep dive items
- Move "by Author" into the link text for books instead of a separate `<span>`
- Add "view on Amazon" badge for Amazon-linked books (not wiki-linked ones)
- Update intro text to "Explore these related deep dives:"

Closes #205

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)