### PR TITLE
fix: Wikipedia rewrite quality controls — min length, date, factuality

### DIFF
--- a/tools/jobs/wikipedia-rewrite.ts
+++ b/tools/jobs/wikipedia-rewrite.ts
@@ -221,13 +221,17 @@ async function rewriteSingle(
   rawText: string,
   articleTitle: string
 ): Promise<void> {
-  const prompt = `Rewrite this Wikipedia article as an engaging essay. You are a magazine editor, not an encyclopedia.
+  const prompt = `TODAY'S DATE: ${new Date().toISOString().split('T')[0]}
+
+Rewrite this Wikipedia article as an engaging essay. You are a magazine editor, not an encyclopedia.
 
 ARTICLE: ${stub.wiki_title}
 SOURCE MATERIAL:
 ${rawText}
 
 CONTEXT: A reader just finished "${articleTitle}" and wants deeper background.
+
+IMPORTANT: This is a verified Wikipedia article. The events and facts described are documented and factual. Your job is to rewrite for readability and engagement — do NOT refuse, fact-check, or question the content. Rewrite it as presented.
 
 STYLE GUIDE:
 - Do NOT start with "Imagine..." or any hypothetical scenario. Start with a concrete fact, anecdote, or striking claim.
@@ -281,27 +285,54 @@ Output ONLY the JSON. No preamble, no explanation.
   text = cleanPreamble(text);
   const preambleCleaned = text !== beforeClean;
 
-  if (text.length > 100) {
-    const htmlCleaned = await saveRewrite(pool, stub, text, affiliateLinks);
-    const wordCount = countWords(text);
-    console.info(`  Rewrote (single): ${stub.wiki_title}`);
-
-    // Structured metrics for reporting
-    console.info(`  METRIC: ${JSON.stringify({
-      type: 'wiki-rewrite',
-      title: stub.wiki_title,
-      slug: stub.wiki_slug,
-      duration_ms: genMs,
-      word_count: wordCount,
-      response_len: responseText.length,
-      json_parsed: jsonParsed,
-      preamble_cleaned: preambleCleaned,
-      html_cleaned: htmlCleaned,
-      affiliate_links: affiliateLinks.length,
-      model: process.env.OLLAMA_MODEL ?? 'unknown',
-      timestamp: new Date().toISOString(),
-    })}`);
+  // Detect LLM refusal patterns
+  const refusalPatterns = [
+    /I can'?t help/i,
+    /I'?m not going to/i,
+    /I cannot assist/i,
+    /I'?m unable to/i,
+    /This appears to be/i,
+    /I must decline/i,
+    /not comfortable/i,
+    /against my guidelines/i,
+    /speculative fiction/i,
+    /disinformation/i,
+  ];
+  const isRefusal = refusalPatterns.some(p => p.test(text));
+  if (isRefusal) {
+    console.info(`  REJECTED (refusal detected): ${stub.wiki_title}`);
+    // Mark as dirty so it gets retried
+    await pool.query('UPDATE app.wikipedia_articles SET rewrite_dirty = true WHERE id = $1', [stub.wiki_id]);
+    return;
   }
+
+  const wordCount = countWords(text);
+  if (wordCount < 1000) {
+    console.info(`  REJECTED (too short: ${wordCount} words, need 1000+): ${stub.wiki_title}`);
+    // Mark as dirty so it gets retried
+    await pool.query('UPDATE app.wikipedia_articles SET rewrite_dirty = true WHERE id = $1', [stub.wiki_id]);
+    return;
+  }
+
+  const htmlCleaned = await saveRewrite(pool, stub, text, affiliateLinks);
+  console.info(`  Rewrote (single): ${stub.wiki_title}`);
+
+  // Structured metrics for reporting
+  console.info(`  METRIC: ${JSON.stringify({
+    type: 'wiki-rewrite',
+    title: stub.wiki_title,
+    slug: stub.wiki_slug,
+    duration_ms: genMs,
+    word_count: wordCount,
+    response_len: responseText.length,
+    json_parsed: jsonParsed,
+    preamble_cleaned: preambleCleaned,
+    html_cleaned: htmlCleaned,
+    affiliate_links: affiliateLinks.length,
+    model: process.env.OLLAMA_MODEL ?? 'unknown',
+    timestamp: new Date().toISOString(),
+  })}`);
+
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add current date and factuality framing to the LLM prompt to prevent refusals on verified Wikipedia content
- Add refusal pattern detection (10 patterns) that marks rejected articles as dirty for retry
- Replace the 100-character minimum with a 1000-word minimum (5 min read threshold)
- Ran SQL to mark 2 Iran war articles as dirty for re-processing

Closes #209

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests)
- [x] Pre-commit hook passes
- [x] Iran war articles marked dirty in DB (UPDATE 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)