### PR TITLE
feat: implement /dream memory consolidation

### DIFF
--- a/.claude/commands/dream.md
+++ b/.claude/commands/dream.md
@@ -1,0 +1,36 @@
+# Dream: Memory Consolidation
+
+You are performing a dream — a reflective pass over your memory files. Synthesize what you've learned recently into durable, well-organized memories so that future sessions can orient quickly.
+
+## Phase 1 — Orient
+
+- Run `ls` on the memory directory at `$HOME/.claude/projects/-Users-bedwards-hex-index/memory/`
+- Read `MEMORY.md` (the index file) to understand the current state
+- Skim each existing topic file so you improve them rather than creating duplicates
+- Check `.claude/worktrees/*/` for any leftover worktree memory files that should be consolidated
+
+## Phase 2 — Gather recent signal
+
+Look for new information worth persisting:
+1. Review existing memories that may have drifted — facts that contradict the current codebase
+2. Check `CLAUDE.md` for anything that changed recently but isn't reflected in memory
+3. Check `git log --oneline -20` for recent work patterns worth remembering
+4. Look for repeated patterns in recent sessions — feedback the user gave, workflows that worked well
+
+## Phase 3 — Consolidate
+
+- Merge new signal into existing topic files (never create near-duplicates)
+- Convert any relative dates ("yesterday", "next week") to absolute dates
+- Delete contradicted facts at the source — if a memory says "we use Jest" but CLAUDE.md says "Vitest", fix the memory
+- Update descriptions in frontmatter to accurately reflect current content
+- Combine memories that cover the same topic into single files
+
+## Phase 4 — Prune and index
+
+Update `MEMORY.md` so it stays under 200 lines:
+- Remove stale, wrong, or superseded pointers
+- Demote verbose entries: keep the gist in the index, detail in the topic file
+- Add pointers to newly important memories
+- Resolve contradictions between files
+- Verify every file referenced in MEMORY.md actually exists
+- Remove any MEMORY.md entries pointing to deleted files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,9 @@ while true:
 
 **Limit interactions with the human prompter.** Work autonomously. Only stop for things you absolutely cannot do.
 
+### Memory Hygiene
+Run `/dream` at the end of long sessions or when you notice memory files growing stale. This is automatic on Thursdays during consolidation, but can be run anytime.
+
 ## What You Cannot Do
 
 If a tool isn't authenticated or you lack permissions, **stop immediately**. Do not use alternative approaches. Report back to the human prompter with:

--- a/tools/claude-loop/scheduler-prompt.md
+++ b/tools/claude-loop/scheduler-prompt.md
@@ -229,6 +229,18 @@ npm run gh:rate-limit
 ```
 If <100 remaining, post warning to Discord. Scale back PR operations.
 
+### P8: Memory Consolidation (Thu 22:00)
+
+Run `/dream` to consolidate memory files across all worktrees. This prevents
+memory bloat and keeps future sessions fast.
+
+Spawn an agent to:
+1. Run `/dream` (the custom command handles all phases)
+2. Post to Discord: "Scheduler: memory consolidation complete"
+
+This task is low priority and only needs to run once per week during the
+Thursday consolidation window. Skip if higher-priority tasks have work to do.
+
 ## Step 3: Dispatch and Report
 
 After picking a task:

--- a/tools/cron/dream.sh
+++ b/tools/cron/dream.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Memory consolidation — runs during Thursday consolidation window
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+echo "=== Dream: Memory Consolidation ==="
+echo "Started: $(date)"
+
+# Run dream via claude CLI
+claude -p "Run /dream — consolidate all memory files, prune stale entries, resolve contradictions. Be thorough but fast." --no-input
+
+echo "Completed: $(date)"


### PR DESCRIPTION
## Summary
- Add custom `/dream` slash command (`.claude/commands/dream.md`) that performs four-phase memory consolidation: orient, gather signal, consolidate, prune
- Wire dream into the Thursday 22:00 consolidation window as P8 in the scheduler prompt
- Add `tools/cron/dream.sh` wrapper for cron-based execution
- Add Memory Hygiene note to CLAUDE.md Development Loop section

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] All 143 tests pass (`npm run test`)
- [x] Pre-commit hook passes
- [x] `/dream` command file is valid markdown
- [x] `dream.sh` is executable

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)