### PR TITLE
feat: author Wikipedia pages show purchase links for their books

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -682,6 +682,23 @@ main {
   margin-top: 0.15rem;
 }
 
+/* ── Author Books (Wikipedia pages about authors) ────────────────── */
+
+.author-books {
+  margin-bottom: var(--gap-lg);
+  padding: var(--gap);
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  font-size: var(--text-sm);
+}
+.author-books ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+}
+.author-books li { margin-bottom: 0.5rem; }
+.author-books li a { color: var(--accent); }
+
 /* ── Book Purchase Links (Wikipedia pages) ───────────────────────── */
 
 .book-links {

--- a/src/api/pages.ts
+++ b/src/api/pages.ts
@@ -534,6 +534,37 @@ export function createPagesRouter(pool: Pool): Router {
         ? renderBookPurchaseLinks(matchedBook, affiliateTag)
         : '';
 
+      // Check if this Wikipedia article is about an author who has books
+      const authorBooks: ParsedAffiliateBook[] = [];
+      if (!matchedBook) {
+        for (const [, book] of affiliateBooksMap) {
+          if (wiki.title.toLowerCase().includes(book.author.toLowerCase())) {
+            authorBooks.push(book);
+          }
+        }
+      }
+
+      let authorBooksHtml = '';
+      if (authorBooks.length > 0) {
+        const bookItems = authorBooks
+          .map((book) => {
+            const amazonUrl = affiliateTag ? buildAmazonUrl(book.asin, affiliateTag) : '';
+            const link = amazonUrl
+              ? `<a href="${amazonUrl}" target="_blank" rel="noopener">${escapeHtml(book.title)}</a>`
+              : escapeHtml(book.title);
+            return `<li>${link} &mdash; ${escapeHtml(book.description)} <small>Affiliate link</small></li>`;
+          })
+          .join('\n            ');
+
+        authorBooksHtml = `
+        <div class="author-books">
+          <p>Books by this author:</p>
+          <ul>
+            ${bookItems}
+          </ul>
+        </div>`;
+      }
+
       // Optimized Wikipedia layout for Speechify:
       // 1. Type badge + Title
       // 2. Meta: read time, source link
@@ -550,6 +581,7 @@ export function createPagesRouter(pool: Pool): Router {
             </p>
           </header>
           ${relatedSection}
+          ${authorBooksHtml}
           <div class="article-content">
             ${wikiContent}
           </div>

--- a/tools/static-site/pages/wikipedia.ts
+++ b/tools/static-site/pages/wikipedia.ts
@@ -8,6 +8,7 @@ import { writeFile, escapeHtml, renderBookPurchaseLinks, loadAffiliateBooks } fr
 import type { ParsedAffiliateBook } from '../utils.js';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
+import { buildAmazonUrl } from '../utils.js';
 
 interface WikipediaRow {
   id: string;
@@ -104,6 +105,37 @@ function generateWikipediaPage(
     ? renderBookPurchaseLinks(matchedBook, affiliateTag)
     : '';
 
+  // Check if this Wikipedia article is about an author who has books
+  const authorBooks: ParsedAffiliateBook[] = [];
+  if (!matchedBook) {
+    for (const [, book] of affiliateBooksMap) {
+      if (wiki.title.toLowerCase().includes(book.author.toLowerCase())) {
+        authorBooks.push(book);
+      }
+    }
+  }
+
+  let authorBooksHtml = '';
+  if (authorBooks.length > 0) {
+    const bookItems = authorBooks
+      .map((book) => {
+        const amazonUrl = affiliateTag ? buildAmazonUrl(book.asin, affiliateTag) : '';
+        const link = amazonUrl
+          ? `<a href="${amazonUrl}" target="_blank" rel="noopener">${escapeHtml(book.title)}</a>`
+          : escapeHtml(book.title);
+        return `<li>${link} &mdash; ${escapeHtml(book.description)} <small>Affiliate link</small></li>`;
+      })
+      .join('\n          ');
+
+    authorBooksHtml = `
+      <div class="author-books">
+        <p>Books by this author:</p>
+        <ul>
+          ${bookItems}
+        </ul>
+      </div>`;
+  }
+
   // Related articles section
   let relatedHtml = '';
   if (relatedArticles.length > 0) {
@@ -159,6 +191,8 @@ function generateWikipediaPage(
           <span class="read-time">${wiki.estimated_read_time_minutes} min read</span>
         </div>
       </header>
+
+      ${authorBooksHtml}
 
       ${contentBlock}
 


### PR DESCRIPTION
## Summary
- When a Wikipedia page is about an author who has books in the affiliate catalog, show purchase links at the **top** of the page (before article content)
- Applies to both the public static site (`tools/static-site/pages/wikipedia.ts`) and the private library (`src/api/pages.ts`)
- Added `.author-books` CSS styles to `public/styles.css`
- Book title matches continue showing purchase links at the bottom (existing behavior unchanged)

## How it works
After the existing book-title lookup (`affiliateBooksMap.get(wiki.title.toLowerCase())`), if no book match is found, iterate the affiliate map and check if `wiki.title.toLowerCase()` contains `book.author.toLowerCase()`. This catches pages like "Bill Bishop (author)" matching author "Bill Bishop".

Closes #202

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)