### PR TITLE
fix: remove claude-quality launchctl job

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,6 @@ gantt
     Wiki Rewrite (Qwen)        :o1, 01:05, 25m
     Affiliate Suggest (Qwen)   :o2, 01:35, 25m
 
-    section Daily
-    Claude Quality Guardian     :d1, 05:00, 30m
-
     section Weekly
     Build Weekly (Thu 23:00)   :w1, 23:00, 30m
     Send Weekly (Fri 07:30)    :w2, 07:30, 5m


### PR DESCRIPTION
## Summary
- Removed Claude Quality Guardian reference from README mermaid schedule chart
- The `claude-quality.sh` script and launchctl plist were already removed in PR #168
- No `~/Library/LaunchAgents/com.hex-index.claude-quality.plist` file exists on disk

Closes #167

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)