### PR TITLE
fix: correct Qwen model in launchctl plists

### DIFF
--- a/src/wikipedia/cli.ts
+++ b/src/wikipedia/cli.ts
@@ -71,7 +71,7 @@ async function healthcheck(): Promise<void> {
 
   // Check Ollama
   const ollamaUrl = process.env.OLLAMA_URL || 'http://127.0.0.1:11434';
-  const ollamaModel = process.env.OLLAMA_MODEL || 'mistral-large:123b';
+  const ollamaModel = process.env.OLLAMA_MODEL || 'qwen3.5:122b-a10b';
   try {
     const resp = await fetch(`${ollamaUrl}/api/tags`, { signal: AbortSignal.timeout(5000) });
     if (!resp.ok) {

--- a/tools/ops/fix-plist-model.sh
+++ b/tools/ops/fix-plist-model.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Fix Qwen model in launchctl plists
+# Run manually: bash tools/ops/fix-plist-model.sh
+set -euo pipefail
+
+WRONG_MODEL="qwen3:235b-a22b"
+RIGHT_MODEL="qwen3.5:122b-a10b"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+
+for plist in \
+  com.hex-index.wiki-rewrite.plist \
+  com.hex-index.wiki-discover.plist \
+  com.hex-index.affiliate-suggest.plist \
+  com.hex-index.article-rewrite.plist; do
+
+  file="$PLIST_DIR/$plist"
+  if [ -f "$file" ]; then
+    if grep -q "$WRONG_MODEL" "$file"; then
+      sed -i '' "s|$WRONG_MODEL|$RIGHT_MODEL|g" "$file"
+      echo "Fixed: $plist"
+      # Reload the job
+      launchctl unload "$file" 2>/dev/null || true
+      launchctl load "$file"
+      echo "  Reloaded"
+    else
+      echo "OK: $plist (already correct)"
+    fi
+  else
+    echo "SKIP: $plist (not found)"
+  fi
+done
+
+echo "Done. Verify with: launchctl list | grep hex-index"


### PR DESCRIPTION
## Summary
- Fixed stale `mistral-large:123b` fallback in `src/wikipedia/cli.ts` to use `qwen3.5:122b-a10b`
- Added `tools/ops/fix-plist-model.sh` script for the human to run — updates the 4 launchctl plists from `qwen3:235b-a22b` to `qwen3.5:122b-a10b` and reloads them

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (143 tests)
- [ ] Human runs `bash tools/ops/fix-plist-model.sh` to fix the plists

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)