### PR TITLE
feat: recommend Readest epub reader on weekly page

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1225,3 +1225,11 @@ main {
   margin: 0.25rem 0 0 0;
   line-height: 1.5;
 }
+.reader-recommendation {
+  font-size: var(--text-sm);
+  color: var(--ink-light);
+  margin-bottom: var(--gap-lg);
+}
+.reader-recommendation a {
+  color: var(--accent);
+}

--- a/tools/static-site/pages/weekly.ts
+++ b/tools/static-site/pages/weekly.ts
@@ -1024,6 +1024,7 @@ function generateWeeklyListingPage(weeks: WeekListItem[]): string {
 
   const content = `
     <h1 class="section-title">Hex Index Reader</h1>
+    <p class="reader-recommendation">For the best reading experience, we recommend <a href="https://readest.com/" target="_blank" rel="noopener">Readest</a> — a free, open-source epub reader.</p>
     ${subscribeSection}
     <div class="weekly-list">
       ${weeks.length > 0 ? weekItems : '<p style="color:var(--ink-muted)">No weekly editions available yet.</p>'}


### PR DESCRIPTION
## Summary
- Add a Readest epub reader recommendation at the top of the weekly Reader listing page (after the title, before the subscribe card)
- Add minimal CSS styling for `.reader-recommendation` using existing design tokens

Closes #221

## Test plan
- [x] Lint passes
- [x] Typecheck passes
- [x] All 143 unit tests pass
- [ ] Verify recommendation appears on weekly listing page after next `static:generate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)