### PR TITLE
feat: full Claude loop infrastructure — 5 roles with clones and commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ library
 
 # Secrets file (for recording remote secrets set)
 .secrets
+
+# Claude loop tracking files
+tools/claude-loop/.epub-reviewed

--- a/tools/claude-loop/consolidate-memory-prompt.md
+++ b/tools/claude-loop/consolidate-memory-prompt.md
@@ -1,0 +1,11 @@
+# Memory Consolidation Loop
+
+Run `/consolidate-memory` to consolidate memory files.
+
+This performs a 4-phase pass:
+1. Orient --- read existing memory files
+2. Gather --- find new signal from git history and recent work
+3. Consolidate --- merge duplicates, fix stale dates, resolve contradictions
+4. Prune --- keep MEMORY.md under 200 lines
+
+After consolidation, report what changed.

--- a/tools/claude-loop/epub-review-prompt.md
+++ b/tools/claude-loop/epub-review-prompt.md
@@ -1,0 +1,71 @@
+# Epub Review Loop
+
+You monitor for newly generated weekly Reader epubs and perform editorial review when one appears.
+
+## Check for new epub
+
+```bash
+# Get the latest epub file
+LATEST_EPUB=$(ls -t docs/weekly/*.epub 2>/dev/null | head -1)
+echo "Latest epub: $LATEST_EPUB"
+
+# Check if we already reviewed it
+TRACKING_FILE="tools/claude-loop/.epub-reviewed"
+if [ -f "$TRACKING_FILE" ] && grep -q "$(basename "$LATEST_EPUB")" "$TRACKING_FILE"; then
+  echo "Already reviewed. Nothing to do."
+  exit 0
+fi
+
+echo "Current date: $(date)"
+```
+
+If the latest epub has already been reviewed (its filename appears in the tracking file), print "Already reviewed" and stop. Do nothing else.
+
+If there IS a new unreviewed epub:
+
+## Review process
+
+1. **Read the epub content**: The epub is generated from articles in the database. Query for the articles in this week's consolidation:
+```sql
+SELECT a.title, a.rewritten_content_path, t.name as tag
+FROM app.weekly_consolidated wc
+JOIN app.articles a ON a.id = ANY(wc.article_ids)
+LEFT JOIN app.article_tags at ON at.article_id = a.id
+LEFT JOIN app.tags t ON t.slug = at.tag_slug
+WHERE wc.epub_filename = '<latest epub filename>'
+ORDER BY at.score DESC
+```
+
+2. **Check each article's rewritten content** for:
+   - LLM artifacts (think tags, preamble, refusals)
+   - Garbled text or encoding issues
+   - Missing section headings
+   - Very short content
+   - Duplicate paragraphs
+
+3. **Fix problems** by marking articles dirty:
+```sql
+UPDATE app.articles SET rewrite_dirty = true WHERE id = '<id>';
+```
+
+4. **Regenerate the epub**: After fixing, regenerate:
+```bash
+npm run static:generate
+```
+
+5. **Deploy**: Commit and push docs/ changes so the improved epub goes live. Use a worktree + PR:
+```bash
+# Create a worktree, commit docs/ changes, push, create PR
+```
+Do not push directly to main. All changes go through PRs.
+
+6. **Mark as reviewed**:
+```bash
+echo "$(basename "$LATEST_EPUB")" >> tools/claude-loop/.epub-reviewed
+```
+
+## Important
+- The first draft epub goes live immediately when build-weekly runs Thursday night
+- Your improved version replaces it on the live site
+- Always regenerate and deploy after making changes
+- Track what you've reviewed so you don't repeat work

--- a/tools/ops/claude-editorial-hex-index.sh
+++ b/tools/ops/claude-editorial-hex-index.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eux
+cd ~/vibe/hex-index-clones/claude-editorial
+git checkout main
+git pull --ff-only origin main
+npm ci --silent
+tmux new-session -d -s claude-editorial -c ~/vibe/hex-index-clones/claude-editorial
+tmux send-keys -t claude-editorial "claude --dangerously-skip-permissions" Enter
+sleep 5
+tmux send-keys -t claude-editorial "/loop 2h tools/claude-loop/editorial-prompt.md" Enter
+tmux attach -t claude-editorial

--- a/tools/ops/claude-epub-hex-index.sh
+++ b/tools/ops/claude-epub-hex-index.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eux
+cd ~/vibe/hex-index-clones/claude-epub
+git checkout main
+git pull --ff-only origin main
+npm ci --silent
+tmux new-session -d -s claude-epub -c ~/vibe/hex-index-clones/claude-epub
+tmux send-keys -t claude-epub "claude --dangerously-skip-permissions" Enter
+sleep 5
+tmux send-keys -t claude-epub "/loop 30m tools/claude-loop/epub-review-prompt.md" Enter
+tmux attach -t claude-epub

--- a/tools/ops/claude-memory-hex-index.sh
+++ b/tools/ops/claude-memory-hex-index.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eux
+cd ~/vibe/hex-index-clones/claude-memory
+git checkout main
+git pull --ff-only origin main
+npm ci --silent
+tmux new-session -d -s claude-memory -c ~/vibe/hex-index-clones/claude-memory
+tmux send-keys -t claude-memory "claude --dangerously-skip-permissions" Enter
+sleep 5
+tmux send-keys -t claude-memory "/loop 24h tools/claude-loop/consolidate-memory-prompt.md" Enter
+tmux attach -t claude-memory

--- a/tools/ops/claude-ops-hex-index.sh
+++ b/tools/ops/claude-ops-hex-index.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eux
+cd ~/vibe/hex-index-clones/claude-ops
+git checkout main
+git pull --ff-only origin main
+npm ci --silent
+tmux new-session -d -s claude-ops -c ~/vibe/hex-index-clones/claude-ops
+tmux send-keys -t claude-ops "claude --dangerously-skip-permissions" Enter
+sleep 5
+tmux send-keys -t claude-ops "/loop 30m tools/claude-loop/ops-prompt.md" Enter
+tmux attach -t claude-ops

--- a/tools/ops/claude-quality-hex-index.sh
+++ b/tools/ops/claude-quality-hex-index.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eux
+cd ~/vibe/hex-index-clones/claude-quality
+git checkout main
+git pull --ff-only origin main
+npm ci --silent
+tmux new-session -d -s claude-quality -c ~/vibe/hex-index-clones/claude-quality
+tmux send-keys -t claude-quality "claude --dangerously-skip-permissions" Enter
+sleep 5
+tmux send-keys -t claude-quality "/loop 2h tools/claude-loop/quality-audit-prompt.md" Enter
+tmux attach -t claude-quality

--- a/tools/ops/setup-clones.sh
+++ b/tools/ops/setup-clones.sh
@@ -9,7 +9,7 @@ BASE="$HOME/vibe/hex-index-clones"
 
 mkdir -p "$BASE"
 
-for name in qwen-batch auto-deploy claude-ops; do
+for name in qwen-batch auto-deploy claude-ops claude-editorial claude-quality claude-epub claude-memory; do
   if [ ! -d "$BASE/$name" ]; then
     echo "Cloning $name..."
     git clone "$REPO" "$BASE/$name"

--- a/tools/ops/start-all-loops.sh
+++ b/tools/ops/start-all-loops.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Start all Claude loops in separate tmux sessions
+# Usage: bash tools/ops/start-all-loops.sh
+set -eu
+
+CLONES="$HOME/vibe/hex-index-clones"
+
+start_loop() {
+  local name=$1
+  local clone=$2
+  local interval=$3
+  local prompt=$4
+
+  echo "=== Starting $name ==="
+
+  # Kill existing session
+  tmux kill-session -t "$name" 2>/dev/null || true
+
+  # Update clone
+  cd "$CLONES/$clone"
+  git checkout main 2>/dev/null
+  git pull --ff-only origin main
+  npm ci --silent 2>/dev/null
+
+  # Start session
+  tmux new-session -d -s "$name" -c "$CLONES/$clone"
+  tmux send-keys -t "$name" "claude --dangerously-skip-permissions" Enter
+  sleep 5
+  tmux send-keys -t "$name" "/loop $interval $prompt" Enter
+
+  echo "  Started: /loop $interval $prompt"
+}
+
+start_loop "claude-ops"       "claude-ops"       "30m" "tools/claude-loop/ops-prompt.md"
+start_loop "claude-editorial" "claude-editorial"  "2h"  "tools/claude-loop/editorial-prompt.md"
+start_loop "claude-quality"   "claude-quality"    "2h"  "tools/claude-loop/quality-audit-prompt.md"
+start_loop "claude-epub"      "claude-epub"       "30m" "tools/claude-loop/epub-review-prompt.md"
+start_loop "claude-memory"    "claude-memory"     "24h" "tools/claude-loop/consolidate-memory-prompt.md"
+
+echo ""
+echo "All loops started. Sessions:"
+tmux ls
+echo ""
+echo "Attach: tmux attach -t <name>"
+echo "Refresh all (after 3-7 days): bash tools/ops/start-all-loops.sh"


### PR DESCRIPTION
## Summary

- Add 5 individual loop launcher scripts (`tools/ops/claude-{ops,editorial,quality,epub,memory}-hex-index.sh`) that each start a tmux session with the correct clone, interval, and prompt
- Add `tools/ops/start-all-loops.sh` master script to launch all 5 loops without blocking
- Create 2 new prompt files: `epub-review-prompt.md` (weekly epub editorial review) and `consolidate-memory-prompt.md` (memory file consolidation via `/consolidate-memory`)
- Update `setup-clones.sh` to include all 7 clones (added `claude-editorial`, `claude-quality`, `claude-epub`, `claude-memory`)
- Add `tools/claude-loop/.epub-reviewed` to `.gitignore`

## Loop roles

| Clone | Interval | Purpose |
|-------|----------|---------|
| claude-ops | 30m | PR pipeline, main health, clone sync, GPU status |
| claude-editorial | 2h | Content quality, epub review, site verification |
| claude-quality | 2h | Qwen content audit for LLM artifacts |
| claude-epub | 30m | Weekly epub editorial review and deploy |
| claude-memory | 24h | Memory file consolidation |

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (156 tests)
- [x] All `.sh` files are executable
- [x] Pre-commit hook passes

Generated with [Claude Code](https://claude.com/claude-code)