### PR TITLE
feat: title editorial rules + version bump v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hex-index",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "hex-index - built on claude-base",
   "type": "module",
   "bin": {

--- a/src/shared/title-normalizer.test.ts
+++ b/src/shared/title-normalizer.test.ts
@@ -58,6 +58,43 @@ describe('normalizeTitle', () => {
       .toBe('The Great Gatsby and American Dreams');
   });
 
+  it('strips trailing periods', () => {
+    expect(normalizeTitle('The End of History.')).toBe('The End of History');
+  });
+
+  it('strips trailing period with whitespace', () => {
+    expect(normalizeTitle('The End of History.  ')).toBe('The End of History');
+  });
+
+  it('strips multiple trailing periods', () => {
+    expect(normalizeTitle('The End of History..')).toBe('The End of History');
+  });
+
+  it('strips parenthetical asides at end', () => {
+    expect(normalizeTitle('Trump Fires FBI Director (Full Interview)'))
+      .toBe('Trump Fires FBI Director');
+  });
+
+  it('keeps parenthetical in middle of title', () => {
+    expect(normalizeTitle('The (Real) Story Behind AI'))
+      .toBe('The (Real) Story Behind AI');
+  });
+
+  it('fixes individual ALL CAPS words in mixed-case titles', () => {
+    expect(normalizeTitle('How MASSIVELY Powerful AI Will Change Everything'))
+      .toBe('How Massively Powerful AI Will Change Everything');
+  });
+
+  it('preserves known acronyms in mixed-case titles', () => {
+    expect(normalizeTitle('The DOGE Movement and NASA Plans'))
+      .toBe('The DOGE Movement and NASA Plans');
+  });
+
+  it('does not touch short uppercase words (3 or fewer letters)', () => {
+    expect(normalizeTitle('The FBI and CIA Work Together'))
+      .toBe('The FBI and CIA Work Together');
+  });
+
   it('handles empty string', () => {
     expect(normalizeTitle('')).toBe('');
   });

--- a/src/shared/title-normalizer.ts
+++ b/src/shared/title-normalizer.ts
@@ -31,6 +31,21 @@ export function normalizeTitle(title: string): string {
     );
   }
 
+  // Strip trailing periods
+  t = t.replace(/\.+\s*$/, '');
+
+  // Strip parenthetical asides at end
+  t = t.replace(/\s*\([^)]{0,40}\)\s*$/, '').trim();
+
+  // Fix individual ALL CAPS words (4+ letters) in mixed-case titles
+  const knownAcronyms = new Set(['AIDS','API','BBC','CEO','CIA','CTO','DOGE','DOJ','EPA','EU','FBI','FEMA','FTC','GDP','GOP','GPT','ICE','IMF','IRAN','IRS','ISIS','LLM','NASA','NATO','NBA','NFL','NSA','OPEC','SEC','UK','UN','US','USA','WHO','CLAUDE']);
+  if (/[a-z]/.test(t)) {
+    t = t.replace(/\b([A-Z]{4,})\b/g, (match) => {
+      if (knownAcronyms.has(match)) { return match; }
+      return match.charAt(0) + match.slice(1).toLowerCase();
+    });
+  }
+
   // Collapse excessive punctuation
   t = t.replace(/!{2,}/g, '!').replace(/\?{2,}/g, '?');
 

--- a/tools/claude-loop/editorial-prompt.md
+++ b/tools/claude-loop/editorial-prompt.md
@@ -181,6 +181,14 @@ These are non-negotiable quality standards:
 - **Never use --no-verify** on commits — the pre-commit hook catches real bugs
 - **Never push directly to main** — all changes go through PRs
 
+### Title Standards
+- **Title case** — capitalize major words, lowercase articles/prepositions
+- **No trailing punctuation** — titles don't end with periods
+- **No parenthetical asides** — remove (w/ One Exception), (Full Interview)
+- **No individual ALL CAPS words** for emphasis — MASSIVELY → Massively
+- **Preserve real acronyms** — AI, ICE, FBI, DOGE, NATO stay uppercase
+- **60 chars ideal, 80 max**
+
 ## Useful Commands Reference
 
 ```bash

--- a/tools/jobs/title-backfill.ts
+++ b/tools/jobs/title-backfill.ts
@@ -1,0 +1,47 @@
+/**
+ * One-time backfill: apply normalizeTitle() to all articles.
+ * Updates any titles that change. Run after adding new normalizer rules.
+ */
+
+import 'dotenv/config';
+import { Pool } from 'pg';
+import { normalizeTitle } from '../../src/shared/title-normalizer.js';
+
+async function main(): Promise<void> {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    throw new Error('DATABASE_URL required');
+  }
+
+  const pool = new Pool({ connectionString: dbUrl });
+
+  try {
+    const { rows } = await pool.query<{ id: string; title: string }>(
+      'SELECT id, title FROM app.articles',
+    );
+
+    console.info(`Checking ${rows.length} articles...`);
+
+    let updated = 0;
+    for (const row of rows) {
+      const normalized = normalizeTitle(row.title);
+      if (normalized !== row.title) {
+        await pool.query('UPDATE app.articles SET title = $1 WHERE id = $2', [
+          normalized,
+          row.id,
+        ]);
+        console.info(`  "${row.title}" -> "${normalized}"`);
+        updated++;
+      }
+    }
+
+    console.info(`\nDone: ${updated} titles updated out of ${rows.length}`);
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/tools/jobs/title-cleanup.ts
+++ b/tools/jobs/title-cleanup.ts
@@ -75,8 +75,7 @@ CURRENT TITLE: "${article.title}"
 EXCERPT: ${excerpt}
 
 Requirements:
-- 60 characters ideal, 80 max
-- Sentence case (not Title Case, not ALL CAPS)
+- Title case. No trailing punctuation. No parenthetical asides. Keep acronyms (AI, ICE, FBI, DOGE) uppercase. 60 chars ideal, 80 max.
 - Descriptive and specific
 - No clickbait
 - No pipe separators or channel names


### PR DESCRIPTION
## Summary
- **New normalizer rules**: strip trailing periods, strip parenthetical asides at end, fix individual ALL CAPS words (4+ letters) while preserving known acronyms (AIDS, NASA, DOGE, FBI, etc.)
- **Updated all three layers**: deterministic normalizer, Qwen LLM prompt, and editorial loop guidelines
- **Backfill applied**: 38 titles updated out of 4987 articles
- **Version bump**: 0.5.0 → 0.6.0

## Files changed
- `src/shared/title-normalizer.ts` — three new rules
- `src/shared/title-normalizer.test.ts` — seven new test cases (164 total)
- `tools/jobs/title-cleanup.ts` — updated Qwen prompt
- `tools/claude-loop/editorial-prompt.md` — Title Standards section
- `tools/jobs/title-backfill.ts` — reusable backfill script
- `package.json` — version 0.6.0

## Test plan
- [x] All 164 unit tests pass
- [x] Lint clean (zero warnings)
- [x] TypeScript compiles
- [x] Backfill ran successfully against production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)