### PR TITLE
fix: stop swallowing npm ci failures in start-loops.sh

### DIFF
--- a/tools/ops/start-loops.sh
+++ b/tools/ops/start-loops.sh
@@ -6,9 +6,9 @@ CLONE="$HOME/vibe/hex-index-clones/claude-ops"
 
 # Sync clone before starting
 cd "$CLONE"
-git checkout main 2>/dev/null
-git pull --ff-only 2>/dev/null || git pull
-npm ci --silent 2>/dev/null || true
+git checkout main 2>&1 | grep -v "Already on"
+git pull --ff-only || git pull
+npm ci --silent
 
 # Kill existing session
 tmux kill-session -t "$SESSION" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Remove `|| true` from `npm ci` so install failures fail fast (script uses `set -e`)
- Remove `2>/dev/null` from `git pull` so errors are visible while keeping `--ff-only || git pull` fallback
- Filter only the harmless "Already on main" message from `git checkout` while preserving real errors

Closes #186

## Test plan
- [ ] Verify `start-loops.sh` exits non-zero when `npm ci` fails (e.g., corrupt lockfile)
- [ ] Verify git pull errors are visible in output
- [ ] Verify "Already on main" noise is still suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)