### PR TITLE
fix: replace hardcoded /Users/bedwards with $HOME in scripts

### DIFF
--- a/tools/claude-loop/check-prs.sh
+++ b/tools/claude-loop/check-prs.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-cd /Users/bedwards/hex-index
+cd "$HOME/hex-index"
 
 echo "=== Open PRs ==="
 gh pr list --state open --json number,title,createdAt,statusCheckRollup --template '{{range .}}#{{.number}} {{.title}} ({{timeago .createdAt}})

--- a/tools/claude-loop/ops-prompt.md
+++ b/tools/claude-loop/ops-prompt.md
@@ -75,7 +75,7 @@ If stashes exist:
 ## 5. GPU Status Check
 
 ```bash
-/Users/bedwards/vibe/sea-gang/tools/svc ls
+$HOME/vibe/sea-gang/tools/svc ls
 ```
 
 - Verify the expected Qwen job is running (check even/odd hour schedule)

--- a/tools/claude-loop/scheduler-prompt.md
+++ b/tools/claude-loop/scheduler-prompt.md
@@ -217,7 +217,7 @@ Post dashboard to Discord if any counts are concerning.
 
 **D. GPU observation:**
 ```bash
-/Users/bedwards/vibe/sea-gang/tools/svc ls
+$HOME/vibe/sea-gang/tools/svc ls
 ```
 - Verify expected job is running for current even/odd hour
 - Note but do NOT intervene if stuck (timeout handles it)

--- a/tools/claude-loop/start-session.sh
+++ b/tools/claude-loop/start-session.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 SESSION="claude-editor"
-PROJECT_DIR="/Users/bedwards/hex-index"
+PROJECT_DIR="$HOME/hex-index"
 PROMPT_FILE="$PROJECT_DIR/tools/claude-loop/editorial-prompt.md"
 
 if [ ! -f "$PROMPT_FILE" ]; then

--- a/tools/cron/friday-publish.sh
+++ b/tools/cron/friday-publish.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/friday-publish.lock"
 LOG_FILE="$PROJECT_DIR/logs/friday-publish-$(date +%Y%m%d-%H%M%S).log"
-SVC="/Users/bedwards/vibe/sea-gang/tools/svc"
+SVC="$HOME/vibe/sea-gang/tools/svc"
 
 mkdir -p "$PROJECT_DIR/logs"
 cd "$PROJECT_DIR"


### PR DESCRIPTION
## Summary
- Replaced 5 hardcoded `/Users/bedwards` paths with `$HOME` across shell scripts and markdown prompts
- Files changed: `friday-publish.sh`, `start-session.sh`, `check-prs.sh`, `ops-prompt.md`, `scheduler-prompt.md`
- Lines using `process.env.HOME ?? '/Users/bedwards'` fallback were intentionally left unchanged

Closes #185

## Test plan
- [x] Pre-commit hooks pass (typecheck, lint, 164 tests)
- [ ] Verify `friday-publish.sh` resolves `$HOME/vibe/sea-gang/tools/svc` correctly at runtime
- [ ] Verify `start-session.sh` and `check-prs.sh` resolve `$HOME/hex-index` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)