### PR TITLE
fix: only swallow ENOENT in CNAME catch block

### DIFF
--- a/tools/static-site/generate.ts
+++ b/tools/static-site/generate.ts
@@ -57,7 +57,10 @@ async function main(): Promise<void> {
       let cnameContent: string | null = null;
       try {
         cnameContent = await readFile(cnameFile, 'utf-8');
-      } catch {
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw err;
+        }
         // CNAME doesn't exist, nothing to preserve
       }
       await rm(OUTPUT_DIR, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Narrows the CNAME catch block in `tools/static-site/generate.ts` to only swallow `ENOENT` errors (file not found), re-throwing unexpected errors like permission issues

Closes #193

## Test plan
- [x] Pre-commit hooks pass (typecheck, lint, 164 tests)
- [ ] Verify `static:clean` still works when CNAME exists
- [ ] Verify `static:clean` still works when CNAME does not exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)