### PR TITLE
fix: clean YouTube transcript excerpts

### DIFF
--- a/tools/static-site/pages/article.ts
+++ b/tools/static-site/pages/article.ts
@@ -346,9 +346,10 @@ export async function generateArticlePages(
     const hasRewrite = !!article.rewritten_content_path;
     const rawContent = await loadArticleContent(article.content_path);
     const isYouTube = article.original_url.includes('youtube.com') || article.original_url.includes('youtu.be');
-    const rawExcerpt = extractHtmlExcerpt(rawContent, 400);
-    // Clean speech artifacts from YouTube transcript excerpts
-    const excerpt = isYouTube ? cleanTranscript(rawExcerpt) : rawExcerpt;
+    // Clean speech artifacts from YouTube transcripts before excerpting,
+    // so cleaning operates on plain text and excerpt boundary is computed on cleaned result
+    const contentForExcerpt = isYouTube ? cleanTranscript(rawContent) : rawContent;
+    const excerpt = extractHtmlExcerpt(contentForExcerpt, 400);
 
     let displayContent: string;
     if (hasRewrite) {

--- a/tools/static-site/utils.test.ts
+++ b/tools/static-site/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { cleanTranscript } from './utils.js';
+import { cleanTranscript, escapeHtml, formatDate, extractExcerpt, extractHtmlExcerpt, relativePath, estimateReadTime, slugify } from './utils.js';
 
 describe('cleanTranscript', () => {
   it('removes >> speaker change markers', () => {
@@ -33,6 +33,8 @@ describe('cleanTranscript', () => {
     expect(cleanTranscript('Hello [Music] world')).toBe('Hello world');
     expect(cleanTranscript('[Laughter] That was funny')).toBe('That was funny');
     expect(cleanTranscript('And then [Applause] thank you')).toBe('And then thank you');
+    expect(cleanTranscript('[FOREIGN] Some text')).toBe('Some text');
+    expect(cleanTranscript('Text [Background noise] more')).toBe('Text more');
   });
 
   it('normalizes whitespace', () => {
@@ -63,6 +65,126 @@ describe('cleanTranscript', () => {
   it('preserves HTML tags', () => {
     const input = '<p>Um, this is <strong>important</strong></p>';
     const result = cleanTranscript(input);
-    expect(result).toContain('<strong>important</strong>');
+    expect(result).toBe('<p>this is <strong>important</strong></p>');
+  });
+
+  it('does not corrupt long bracket spans', () => {
+    // Brackets over 40 chars should be preserved (not transcript annotations)
+    const longBracket = '[This is a very long bracket span that exceeds forty characters and should stay]';
+    expect(cleanTranscript(longBracket)).toBe(longBracket);
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes all special characters', () => {
+    expect(escapeHtml('<div class="test">&\'value\'')).toBe(
+      '&lt;div class=&quot;test&quot;&gt;&amp;&#039;value&#039;'
+    );
+  });
+
+  it('returns plain text unchanged', () => {
+    expect(escapeHtml('hello world')).toBe('hello world');
+  });
+});
+
+describe('formatDate', () => {
+  it('formats a date string', () => {
+    const result = formatDate('2026-03-15T00:00:00Z');
+    expect(result).toContain('Mar');
+    expect(result).toContain('2026');
+  });
+
+  it('returns empty string for null', () => {
+    expect(formatDate(null)).toBe('');
+  });
+});
+
+describe('extractExcerpt', () => {
+  it('returns full text when under word limit', () => {
+    expect(extractExcerpt('<p>Hello world</p>', 10)).toBe('Hello world');
+  });
+
+  it('strips HTML tags and decodes entities', () => {
+    expect(extractExcerpt('<p>A &amp; B</p>')).toBe('A & B');
+  });
+
+  it('truncates at sentence boundary when possible', () => {
+    const long = '<p>' + Array(300).fill('word').join(' ') + '. More words here.</p>';
+    const result = extractExcerpt(long, 200);
+    expect(result.length).toBeLessThan(long.length);
+  });
+
+  it('strips script and style tags', () => {
+    expect(extractExcerpt('<script>alert("x")</script><p>Hello</p>')).toBe('Hello');
+  });
+});
+
+describe('extractHtmlExcerpt', () => {
+  it('preserves HTML structure within word limit', () => {
+    const html = '<p>Hello <strong>bold</strong> world</p>';
+    const result = extractHtmlExcerpt(html, 100);
+    expect(result).toContain('<strong>bold</strong>');
+  });
+
+  it('closes unclosed tags after truncation', () => {
+    const words = Array(20).fill('word').join(' ');
+    const html = `<p><strong>${words}</strong></p>`;
+    const result = extractHtmlExcerpt(html, 5);
+    expect(result).toContain('</strong>');
+    expect(result).toContain('</p>');
+  });
+
+  it('strips scripts, styles, and nav elements', () => {
+    const html = '<nav>Nav</nav><script>x</script><p>Content</p>';
+    const result = extractHtmlExcerpt(html, 100);
+    expect(result).not.toContain('Nav');
+    expect(result).toContain('Content');
+  });
+
+  it('adds ellipsis when truncated', () => {
+    const words = Array(20).fill('word').join(' ');
+    const html = `<p>${words}</p>`;
+    const result = extractHtmlExcerpt(html, 5);
+    expect(result).toContain('...');
+  });
+});
+
+describe('relativePath', () => {
+  it('computes relative path between sibling directories', () => {
+    expect(relativePath('article/index.html', 'about/index.html')).toBe('../about/index.html');
+  });
+
+  it('returns ./ for same directory', () => {
+    expect(relativePath('index.html', '')).toBe('./');
+  });
+});
+
+describe('estimateReadTime', () => {
+  it('returns at least 1 minute', () => {
+    expect(estimateReadTime('short')).toBe(1);
+  });
+
+  it('estimates based on 200 words per minute', () => {
+    const text = Array(400).fill('word').join(' ');
+    expect(estimateReadTime(text)).toBe(2);
+  });
+
+  it('strips HTML tags before counting', () => {
+    const text = '<p>' + Array(400).fill('word').join(' ') + '</p>';
+    expect(estimateReadTime(text)).toBe(2);
+  });
+});
+
+describe('slugify', () => {
+  it('converts to lowercase kebab-case', () => {
+    expect(slugify('Hello World')).toBe('hello-world');
+  });
+
+  it('strips special characters', () => {
+    expect(slugify('Hello! @World#')).toBe('hello-world');
+  });
+
+  it('collapses multiple hyphens', () => {
+    expect(slugify('a  --  b')).toBe('a-b');
   });
 });

--- a/tools/static-site/utils.ts
+++ b/tools/static-site/utils.ts
@@ -256,8 +256,9 @@ export function cleanTranscript(text: string): string {
   return text
     // Remove >> speaker change markers
     .replace(/>>/g, '')
-    // Remove bracketed annotations like [Music], [Laughter], [Applause]
-    .replace(/\[(?:Music|Laughter|Applause|Inaudible|Crosstalk)\]/gi, '')
+    // Remove bracketed annotations like [Music], [Laughter], [Speaking in foreign language]
+    // Cap at 40 chars to avoid swallowing long bracket spans in non-transcript content
+    .replace(/\[[^\]]{1,40}\]/g, '')
     // Remove standalone filler words (case-insensitive, word boundaries)
     // Multi-word fillers first (uh huh before uh)
     .replace(/\buh huh,?\s*/gi, '')


### PR DESCRIPTION
## Summary
- Add `cleanTranscript()` utility that strips speech artifacts from YouTube transcript text: filler words (um, uh, ah, er, uh huh, you know, I mean), `>>` speaker markers, bracketed annotations ([Music], [Laughter], etc.), and stuttered/repeated words
- Apply cleaning to YouTube article excerpts during static site generation, identified by `original_url` containing youtube.com or youtu.be
- Add 12 unit tests covering all artifact types, edge cases, and HTML preservation

Closes #249

## Test plan
- [x] All 176 unit tests pass including 12 new cleanTranscript tests
- [x] Lint and typecheck pass with zero warnings
- [ ] Verify YouTube article excerpts on hex-index.com after next static site regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)