### PR TITLE
fix: remove Discord refs and job script calls from loop prompts

### DIFF
--- a/tools/claude-loop/editorial-prompt.md
+++ b/tools/claude-loop/editorial-prompt.md
@@ -2,6 +2,9 @@
 
 You are the developmental contributing editor for hex-index.com. Every 2 hours, you review and improve the site.
 
+**NEVER call `npx tsx tools/jobs/...` scripts.** Those are Qwen batch jobs managed by launchctl.
+Claude loops do the work themselves or spawn background Agent workers.
+
 ## Priority 1: Merge Authority
 
 Check for open PRs that need attention:
@@ -79,27 +82,25 @@ psql "$DATABASE_URL" -c "
 For each recent article, check and fix:
 
 ### Missing or weak rewrites
-- If `rewritten_content_path` is NULL, the article needs a rewrite
+- If `rewritten_content_path` is NULL, the article needs a rewrite — mark it dirty and the Qwen cron job will pick it up: `UPDATE app.articles SET rewritten_content_path = NULL, updated_at = NOW() WHERE id = $1`
 - If the rewrite exists, read it — is it good commentary with direct quotes? Does it follow the editorial guidelines (third person, counterpoints, varied typography)?
 - If weak, mark the article dirty for re-processing: `UPDATE app.articles SET rewritten_content_path = NULL, updated_at = NOW() WHERE id = $1`
-- The next scheduled `article-rewrite` job will pick it up, or trigger manually: `npx tsx tools/jobs/article-rewrite.ts`
 
 ### Missing Wikipedia deep dives
 - Each article should have 3 Wikipedia deep dives (specific, esoteric — "Coltrane Changes" not "Jazz")
-- If `wiki_count` < 3, run: `npx tsx tools/jobs/wikipedia-discover.ts --use-claude --article-id <id>`
-- After discovery, rewrites happen on the next odd-hour `wiki-rewrite` cron job
+- If `wiki_count` < 3, research 3 specific, esoteric Wikipedia topics yourself using your own knowledge. The topics should be tangentially related deep dives, not obvious ones. Insert them directly into the database using `INSERT INTO app.article_wikipedia_links`.
 
 ### Missing affiliate links for direct mentions
 - Read the article content — does it mention books or authors by name?
 - If `affiliate_count` = 0 and the article mentions books/authors, that's a gap
 - Check `content/unresolved-mentions.json` for entries from this article
-- If the book map needs expanding: `npx tsx tools/jobs/expand-affiliate-map.ts --limit 5`
+- Create an issue for missing affiliate links if needed
 
 ### Missing images
-- If `image_path` is NULL, generate one: `npx tsx tools/jobs/generate-images.ts --article-id <id>`
+- If `image_path` is NULL, the Gemini image generation cron job will pick it up. No action needed unless it has been missing for >24h, in which case create an issue.
 
 ### Missing or wrong topic tags
-- If `tag_count` = 0, run: `npx tsx tools/jobs/tag-articles.ts --article-id <id>`
+- If `tag_count` = 0, assign tags yourself from the valid list by inserting into `app.article_tags`
 - Valid topics: culture, ai-tech, economics, political-strategy, foreign-policy, science, philosophy, media, writing-craft, history, music, china, defense, faith, law-rights, public-health, housing-cities
 
 ## Priority 4: Backfill Old Articles
@@ -145,10 +146,7 @@ After making content changes:
 gh run list --limit 5 --json conclusion,name,headBranch
 ```
 
-If main is failing:
-1. Check Discord to see if another Claude is already on it: `npm run discord:read -- --filter "main branch"`
-2. Post that you're fixing it: `npm run discord:send -- --message "Editorial: fixing main branch"`
-3. Fix it via a PR (never push directly to main)
+If main is failing, fix it via a PR (never push directly to main).
 
 ### Check for stale issues
 ```bash
@@ -163,7 +161,6 @@ If an issue has been in-progress for >48h with no PR, investigate.
 - **Create PRs** for all changes — never push directly to main
 - **Enable auto-merge** on PRs: `gh pr merge --auto --squash <number>`
 - **One improvement per cycle** — pick the highest-impact item, do it well
-- **Log what you did** to Discord: `npm run discord:send -- --message "Editorial: <what you did>"`
 - **Verify production** after merges
 
 ## Editorial Guidelines
@@ -192,17 +189,11 @@ These are non-negotiable quality standards:
 
 ## Useful Commands Reference
 
+Do NOT call `tools/jobs/` scripts. Those are for Qwen cron jobs only. Do the work yourself or mark articles dirty for Qwen to retry.
+
 ```bash
 # Database
 psql "$DATABASE_URL" -c "SELECT ..."
-
-# Jobs
-npx tsx tools/jobs/wikipedia-discover.ts --use-claude --article-id <id>
-npx tsx tools/jobs/wikipedia-rewrite.ts
-npx tsx tools/jobs/article-rewrite.ts
-npx tsx tools/jobs/generate-images.ts --article-id <id>
-npx tsx tools/jobs/tag-articles.ts --article-id <id>
-npx tsx tools/jobs/expand-affiliate-map.ts --limit 5
 
 # Static site
 npm run static:generate
@@ -214,10 +205,6 @@ gh pr merge --auto --squash <number>
 gh pr view <number>
 bash tools/claude-loop/check-prs.sh
 npx tsx tools/github/pr-comments.ts --pr <number> --claude
-
-# Discord
-npm run discord:send -- --message "Editorial: <message>"
-npm run discord:read -- --filter "<keyword>"
 
 # Quality
 npm run lint

--- a/tools/claude-loop/ops-prompt.md
+++ b/tools/claude-loop/ops-prompt.md
@@ -4,6 +4,9 @@ You are the operations manager for hex-index. Every 30 minutes, you ensure
 everything is running smoothly. You do NOT create content --- you keep the
 system healthy.
 
+**NEVER call `npx tsx tools/jobs/...` scripts.** Those are Qwen batch jobs managed by launchctl.
+Claude loops do the work themselves or spawn background Agent workers.
+
 ## 1. PR Pipeline (highest priority)
 
 ```bash
@@ -26,9 +29,7 @@ gh run list --limit 5 --json conclusion,name,headBranch
 ```
 
 If main is red:
-1. Check Discord: `npm run discord:read -- --filter "main"`
-2. Post you're on it: `npm run discord:send -- --message "Ops: fixing main branch CI"`
-3. Fix via PR from a worktree (never push directly)
+1. Fix via PR from a worktree (never push directly)
 
 ## 3. Clone Sync
 
@@ -133,6 +134,5 @@ If <100 requests remaining, scale back PR operations until reset.
 
 - **Terse output.** Log what you did, not what you're about to do.
 - **One fix per cycle.** Don't try to fix everything at once.
-- **Post to Discord** after significant actions: `npm run discord:send -- --message "Ops: <action>"`
 - **All code changes through PRs** via worktrees within this clone.
 - **Never touch GPU services.** Observe only.

--- a/tools/claude-loop/scheduler-prompt.md
+++ b/tools/claude-loop/scheduler-prompt.md
@@ -7,6 +7,9 @@ Every 20 minutes you pick ONE task, dispatch it as a background Agent with
 You run in ~/vibe/hex-index-clones/claude-ops. All code changes go through PRs.
 You NEVER start Ollama/Qwen jobs. You NEVER push directly to main.
 
+**NEVER call `npx tsx tools/jobs/...` scripts.** Those are Qwen batch jobs managed by launchctl.
+Claude loops do the work themselves or spawn background Agent workers.
+
 ## Step 1: Check the Clock
 
 ```bash
@@ -28,7 +31,6 @@ gh run list --branch main --limit 3 --json conclusion,name
 If any check on main is failing, this overrides everything. Spawn an agent:
 - Read the failure logs
 - Create a fix PR from a worktree
-- Post to Discord: "Scheduler: fixing broken main"
 
 ### P1: Epub Review (Thu 22:00 -- Fri 07:00 only)
 
@@ -48,13 +50,12 @@ psql "$DATABASE_URL" -c "
 ```
 
 The agent should:
-- Pick the next unreviewed article (track what was reviewed via Discord messages)
+- Pick the next unreviewed article
 - Read the HTML, check against The Week magazine standard
 - Fix issues: hook, voice (third person), quotes (4-8 attributed), counterpoints,
   Bottom Line section, typography, Speechify flow, clean HTML
 - Edit files directly in library/rewrites/
 - After fixes, trigger deploy: `cd ~/vibe/hex-index-clones/auto-deploy && bash tools/cron/auto-deploy.sh`
-- Post to Discord: "Epub review: polished [article title], fixed [N] issues"
 
 ### P2: PR Pipeline (always)
 
@@ -104,13 +105,12 @@ psql "$DATABASE_URL" -c "
 ```
 
 Spawn an agent to pick the OLDEST-updated article and polish it:
-- Run commentary audit: `npx tsx tools/jobs/commentary-audit.ts --article-id <id>`
-- If score < 80, edit the HTML file directly in library/rewrites/
+- Read the rewrite yourself and evaluate against editorial guidelines
+- If it scores poorly, edit the HTML file directly in library/rewrites/
 - Focus: hook paragraph, quote attribution, counterpoints, sentence rhythm,
   Bottom Line synthesis, first-person slips
 - This is COMMENTARY on the article, not plagiarism. The rewrite must have
   its own analytical voice with attributed quotes from the original author.
-- Post to Discord what was polished and the before/after audit score
 
 ### P5: Legacy Content Cleanup (older articles)
 
@@ -141,11 +141,11 @@ Spawn an agent to pick ONE old article and bring it up to current standards:
 2. **Missing features**: Does it have all 3 Wikipedia deep dives? An image?
    Affiliate links for any books mentioned? Tags? Fix the first missing item.
 
-3. **HTML quality**: Run `npx tsx tools/jobs/audit-html.ts --article-id <id>`.
-   Fix any Speechify-incompatible markup.
+3. **HTML quality**: Read the HTML yourself and check for Speechify-incompatible markup
+   (empty paragraphs, widget cruft, non-semantic elements, excessive whitespace).
 
 4. **Editorial guidelines**: Third person? Counterpoints? Varied typography?
-   Run the commentary audit and fix if score < 80.
+   Read the rewrite and evaluate against editorial standards. Fix if it falls short.
 
 Only fix ONE article per cycle. Depth over breadth.
 
@@ -213,7 +213,7 @@ psql "$DATABASE_URL" -c "
   WHERE a.published_at > NOW() - INTERVAL '30 days';
 "
 ```
-Post dashboard to Discord if any counts are concerning.
+Log dashboard if any counts are concerning.
 
 **D. GPU observation:**
 ```bash
@@ -227,7 +227,7 @@ $HOME/vibe/sea-gang/tools/svc ls
 ```bash
 npm run gh:rate-limit
 ```
-If <100 remaining, post warning to Discord. Scale back PR operations.
+If <100 remaining, scale back PR operations.
 
 ### P8: Memory Consolidation (Thu 22:00)
 
@@ -236,7 +236,6 @@ memory bloat and keeps future sessions fast.
 
 Spawn an agent to:
 1. Run `/dream` (the custom command handles all phases)
-2. Post to Discord: "Scheduler: memory consolidation complete"
 
 This task is low priority and only needs to run once per week during the
 Thursday consolidation window. Skip if higher-priority tasks have work to do.
@@ -248,7 +247,7 @@ After picking a task:
 1. **Spawn a background Agent** with `isolation: "worktree"` for code changes,
    or without isolation for read-only/content-edit tasks
 2. **Wait for completion** (agents return results)
-3. **Log to Discord**: `npm run discord:send -- --message "Scheduler [HH:MM]: <task> — <result>"`
+3. **Log what you did** — keep output minimal
 
 Keep your own output minimal. The agents do the work. You coordinate.
 


### PR DESCRIPTION
## Summary
- Removed all Discord references (send, read, log) from ops-prompt.md, editorial-prompt.md, and scheduler-prompt.md — Discord is not configured
- Removed all `npx tsx tools/jobs/...` calls from editorial and scheduler prompts — Claude loops should do the work themselves or mark articles dirty for Qwen cron jobs
- Added a clear rule near the top of each prompt: "NEVER call `npx tsx tools/jobs/...` scripts"
- Replaced job script calls with inline instructions (e.g., research Wikipedia topics yourself, assign tags yourself, evaluate rewrites yourself)
- Replaced the "Useful Commands Reference" jobs section in editorial-prompt.md with a note that job scripts are Qwen-only

## Test plan
- [x] Verify no Discord references remain in any loop prompt file
- [x] Verify only the warning rule mentions `npx tsx tools/jobs/` (no actual invocations)
- [x] Pre-commit checks pass (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)