### PR TITLE
docs: update all references to use incremental static generation

### DIFF
--- a/.claude/commands/audit-site.md
+++ b/.claude/commands/audit-site.md
@@ -1,0 +1,51 @@
+You are auditing and improving the production site at hex-index.com.
+
+## Your tracking file
+Read `tmp/site-audit-tracker.json` first. It tracks what you've already reviewed so you don't repeat work. Update it after every run.
+
+## What to audit
+1. Start with the home page, then first page of each topic, then spider into articles
+2. For each page, check via the generated HTML in `docs/`:
+   - Bold wrapping quotes (`<strong>&quot;` or `<strong>"`)
+   - Blockquotes immediately after images (`</figure>` then `<blockquote>`)
+   - Missing deep dives (articles with no wiki links and no book recs)
+   - Missing topic summaries on wiki links
+   - Empty or broken content
+   - Typography issues (smart quotes, em dashes, encoding problems)
+   - Image issues (missing images, broken paths)
+   - Deep dive quality (are the wiki topics specific and relevant, not generic?)
+3. New content is always coming in from the pipeline — check recently published articles first
+
+## How to fix
+- For content issues (bold quotes, blockquotes): fix the source in `library/rewritten/` or the DB
+- For template/CSS issues: fix in `tools/static-site/` or `public/styles.css`
+- **Always use incremental generation** — never full regen for small changes:
+  - Single article: `npm run static:generate -- --article <id>` (0.4s)
+  - Template change: `npm run static:generate -- --only weekly` (0.5s)
+  - Tag/listing changes: `npm run static:generate -- --only home,tags` (15s)
+  - CSS: `npm run static:generate -- --only assets`
+  - Full regen only for DB-wide changes affecting many pages
+- Create a PR branch, commit, push, create PR
+- Never push directly to main — always PRs with `strict: false`
+
+## What to track
+Update `tmp/site-audit-tracker.json` with:
+- Pages you reviewed (add to `pages_reviewed`)
+- Issues found (add to `issues_found` with page, issue type, status)
+- Issues fixed (move from found to fixed with PR number)
+- Next pages to review (update `queue`)
+
+## Gist report
+After every run, update the gist at https://gist.github.com/bedwards/05a7f17c04b643359ee0fed4e24ddc56 with:
+- Current summary counts (pages reviewed, issues found/fixed, PRs created)
+- Check/uncheck the audit queue items as you complete them
+- Add entries to the Run Log with date, what was reviewed, what was fixed
+- Add entries to Issues Found / Issues Fixed sections
+
+Use: `gh gist edit 05a7f17c04b643359ee0fed4e24ddc56 -f "site-audit-report.md" - <<'EOF' ... EOF`
+
+## Priority
+1. First page of home and all 17 topics — visible to every visitor
+2. Most recent articles (last 7 days) — freshest content
+3. Articles with book recommendations — revenue pages
+4. Spider deeper into older content

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,21 @@ Gemini 2.5 Flash API. Key in `~/.config/.env` (GEMINI_API_KEY). ImageMagick post
 | Database | Postgres | None (static HTML) |
 
 ### Regenerating the Static Site
+
+**Always use incremental generation** — never full regen for small changes.
+
 ```bash
-npm run static:generate   # Generate from current DB state
-npm run static:clean      # Clean and regenerate
+# Incremental (use these)
+npm run static:generate -- --article <id>      # Single article (0.4s)
+npm run static:generate -- --only weekly       # Just weekly page (0.5s)
+npm run static:generate -- --only home,tags    # Home + tag pages (15s)
+npm run static:generate -- --only assets       # CSS + images (2s)
+
+# Options: home, articles, wikipedia, publications, tags, weekly, about, search, assets
+
+# Full (only when needed)
+npm run static:generate   # Full generation (~3 min)
+npm run static:clean      # Clean and full regenerate
 npm run static:preview    # Preview at localhost:3000
 ```
 
@@ -179,10 +191,13 @@ npm run test               # Unit tests
 npm run gh:rate-limit      # Check API limits
 npm run gh:issue -- --title "..." --labels "..."
 
-# Static Site
-npm run static:generate    # Generate docs/ from DB
-npm run static:clean       # Clean and regenerate
-npm run static:preview     # Preview at localhost:3000
+# Static Site (always use incremental flags)
+npm run static:generate -- --article <id>      # Single article (0.4s)
+npm run static:generate -- --only weekly       # One section (0.5s)
+npm run static:generate -- --only home,tags    # Multiple sections (15s)
+npm run static:generate                        # Full regen (~3 min, rare)
+npm run static:clean                           # Clean + full regen
+npm run static:preview                         # Preview at localhost:3000
 
 # Jobs (manual)
 npm run job:model-report   # LLM performance report (last 24h)

--- a/tools/claude-loop/editorial-prompt.md
+++ b/tools/claude-loop/editorial-prompt.md
@@ -57,7 +57,7 @@ For each article in the current week's epub:
 3. If issues found:
    - Edit the rewrite file directly in `library/rewrites/<id>.html`
    - Update the database timestamp: `UPDATE app.articles SET updated_at = NOW() WHERE id = '<id>'`
-   - After all fixes: `npm run static:generate` then deploy via `bash tools/cron/deploy.sh "fix: epub editorial polish"`
+   - After all fixes: `npm run static:generate -- --only articles,weekly` then deploy via `bash tools/cron/deploy.sh "fix: epub editorial polish"`
    - Verify at https://hex-index.com/weekly/
 4. Log what was reviewed and what was fixed
 
@@ -195,8 +195,10 @@ Do NOT call `tools/jobs/` scripts. Those are for Qwen cron jobs only. Do the wor
 # Database
 psql "$DATABASE_URL" -c "SELECT ..."
 
-# Static site
-npm run static:generate
+# Static site (always use incremental flags)
+npm run static:generate -- --article <id>      # Single article (0.4s)
+npm run static:generate -- --only weekly       # Just weekly page (0.5s)
+npm run static:generate -- --only articles,weekly  # Articles + weekly
 npm run static:clean
 
 # GitHub

--- a/tools/claude-loop/epub-review-prompt.md
+++ b/tools/claude-loop/epub-review-prompt.md
@@ -48,9 +48,10 @@ ORDER BY at.score DESC
 UPDATE app.articles SET rewrite_dirty = true WHERE id = '<id>';
 ```
 
-4. **Regenerate the epub**: After fixing, regenerate:
+4. **Regenerate affected pages**: After fixing, regenerate only what changed:
 ```bash
-npm run static:generate
+npm run static:generate -- --only articles,weekly   # If fixing article content
+npm run static:generate -- --article <id>           # If fixing a single article
 ```
 
 5. **Deploy**: Commit and push docs/ changes so the improved epub goes live. Use a worktree + PR:


### PR DESCRIPTION
## Summary
All docs and tools now reference incremental generation flags:
- CLAUDE.md quick reference
- /audit-site command
- Editorial loop prompt
- Epub review loop prompt

Cron deploy scripts intentionally keep full regen (they pick up all pipeline changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)