### PR TITLE
chore: upgrade model to qwen3.5:122b-a10b-q8 (Q8 quantization)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ NEON_DATABASE_URL=
 
 # Ollama (for Wikipedia topic analysis and rewriting)
 OLLAMA_URL=http://127.0.0.1:11434
-OLLAMA_MODEL=qwen3.5:122b-a10b
+OLLAMA_MODEL=qwen3.5:122b-a10b-q8
 
 # Substack (for Weekly Vibe newsletter automation)
 SUBSTACK_EMAIL=brian.mabry.edwards@gmail.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ If you notice something broken or improvable unrelated to your current task, pre
 
 Automated jobs run on a schedule via launchctl, managed by `svc` tool.
 
-### LLM: Qwen 3.5 122B-A10B
-All scheduled LLM tasks use `qwen3.5:122b-a10b` via Ollama. The model stays loaded forever on GPU. Only one Qwen job runs at a time.
+### LLM: Qwen 3.5 122B-A10B-Q8
+All scheduled LLM tasks use `qwen3.5:122b-a10b-q8` via Ollama. The model stays loaded forever on GPU. Only one Qwen job runs at a time.
 
 Job schedule (even/odd hour pattern):
 ```
@@ -163,7 +163,7 @@ Always use latest stable versions. Listen to Dependabot.
 - **API**: Express.js with TypeScript
 - **Frontend**: Vite with TypeScript
 - **Testing**: Vitest (not Jest), Playwright for E2E
-- **Local LLM**: Qwen 3.5 122B-A10B via Ollama on Mac Studio M2 Ultra
+- **Local LLM**: Qwen 3.5 122B-A10B-Q8 via Ollama on Mac Studio M2 Ultra
 - **Cloud LLM**: Claude Opus 4.6 via Max subscription (`claude -p`)
 - **Image Generation**: Gemini 2.5 Flash Image API
 - **Deployment**: GitHub Pages (static site), local (private library)

--- a/src/wikipedia/cli.ts
+++ b/src/wikipedia/cli.ts
@@ -71,7 +71,7 @@ async function healthcheck(): Promise<void> {
 
   // Check Ollama
   const ollamaUrl = process.env.OLLAMA_URL || 'http://127.0.0.1:11434';
-  const ollamaModel = process.env.OLLAMA_MODEL || 'qwen3.5:122b-a10b';
+  const ollamaModel = process.env.OLLAMA_MODEL || 'qwen3.5:122b-a10b-q8';
   try {
     const resp = await fetch(`${ollamaUrl}/api/tags`, { signal: AbortSignal.timeout(5000) });
     if (!resp.ok) {

--- a/src/wikipedia/ollama.ts
+++ b/src/wikipedia/ollama.ts
@@ -9,7 +9,7 @@
  */
 
 const OLLAMA_URL = process.env.OLLAMA_URL || 'http://127.0.0.1:11434';
-const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'qwen3.5:122b-a10b';
+const OLLAMA_MODEL = process.env.OLLAMA_MODEL || 'qwen3.5:122b-a10b-q8';
 const DEFAULT_TIMEOUT = parseInt(process.env.HEX_TASK_TIMEOUT_MS || '900000', 10);
 
 interface GenerateOptions {

--- a/tools/cron/affiliate-suggest.sh
+++ b/tools/cron/affiliate-suggest.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/affiliate-suggest.lock"
 LOG_FILE="$PROJECT_DIR/logs/affiliate-suggest-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b-q8}"
 
 TIME_BUDGET=600         # 10 minutes — fast job, runs first at :05, done by :15
 SECS_PER_ITEM=7

--- a/tools/cron/article-rewrite.sh
+++ b/tools/cron/article-rewrite.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/article-rewrite.lock"
 LOG_FILE="$PROJECT_DIR/logs/article-rewrite-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b-q8}"
 
 TIME_BUDGET=2700        # 45 minutes — starts at :15 after wiki-discover finishes
 SECS_PER_ITEM=65

--- a/tools/cron/ingest-and-publish.sh
+++ b/tools/cron/ingest-and-publish.sh
@@ -19,7 +19,7 @@ LOG_FILE="$PROJECT_DIR/logs/ingest-$(date +%Y%m%d-%H%M%S).log"
 LATEST_LOG="$PROJECT_DIR/logs/ingestion-latest.log"
 ENRICHMENT_TIMEOUT=18000  # 5 hours
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b-q8}"
 
 mkdir -p "$PROJECT_DIR/logs"
 cd "$PROJECT_DIR"

--- a/tools/cron/tag-articles.sh
+++ b/tools/cron/tag-articles.sh
@@ -12,7 +12,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/tag-articles.lock"
 LOG_FILE="$PROJECT_DIR/logs/tag-articles-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b-q8}"
 
 TIME_BUDGET=1500        # 25 minutes — fits even-hour Qwen slot
 SECS_PER_ITEM=15

--- a/tools/cron/title-cleanup.sh
+++ b/tools/cron/title-cleanup.sh
@@ -10,7 +10,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/title-cleanup.lock"
 LOG_FILE="$PROJECT_DIR/logs/title-cleanup-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b-q8}"
 
 TIME_BUDGET=1500        # 25 minutes — fits Qwen slot
 SECS_PER_ITEM=10

--- a/tools/cron/wikipedia-discover.sh
+++ b/tools/cron/wikipedia-discover.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/wiki-discover.lock"
 LOG_FILE="$PROJECT_DIR/logs/wiki-discover-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b-q8}"
 
 # Tuning constants
 TIME_BUDGET=600         # 10 minutes — fast job, runs first at :05, done by :15

--- a/tools/cron/wikipedia-rewrite.sh
+++ b/tools/cron/wikipedia-rewrite.sh
@@ -9,7 +9,7 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOCK_FILE="$PROJECT_DIR/logs/wiki-rewrite.lock"
 LOG_FILE="$PROJECT_DIR/logs/wiki-rewrite-$(date +%Y%m%d-%H%M%S).log"
 OLLAMA_URL="${OLLAMA_URL:-http://127.0.0.1:11434}"
-OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen3.5:122b-a10b-q8}"
 
 TIME_BUDGET=2700        # 45 minutes — starts at :15 after affiliate-suggest finishes
 SECS_PER_ITEM=140

--- a/tools/ops/fix-plist-model.sh
+++ b/tools/ops/fix-plist-model.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 WRONG_MODEL="qwen3.5:122b-a10b"
-RIGHT_MODEL="qwen3.5:122b-a10b"
+RIGHT_MODEL="qwen3.5:122b-a10b-q8"
 PLIST_DIR="$HOME/Library/LaunchAgents"
 
 for plist in \


### PR DESCRIPTION
## Summary
- 141 GB on GPU, full Q8 precision
- Updated all code defaults and cron scripts
- Launchd plists already updated separately

## Changes
- `src/wikipedia/ollama.ts` and `src/wikipedia/cli.ts` -- default model fallback
- `.env.example` -- example config
- `CLAUDE.md` -- documentation (backtick model name and human-readable references)
- All 7 cron scripts in `tools/cron/`
- `tools/ops/fix-plist-model.sh` -- RIGHT_MODEL target

## Test plan
- [x] Verified no `qwen3.5:122b-a10b` without `-q8` suffix remains (negative lookahead grep)
- [x] All 12 occurrences updated to `qwen3.5:122b-a10b-q8`
- [x] Pre-commit checks pass (lint, typecheck, 197 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)