### PR TITLE
fix: update missed qwen model reference in wikipedia-discover.ts

### DIFF
--- a/tools/jobs/wikipedia-discover.ts
+++ b/tools/jobs/wikipedia-discover.ts
@@ -47,7 +47,7 @@ if (USE_CLAUDE) {
 }
 const DISCOVER_MODEL = USE_CLAUDE
   ? (process.env.CLAUDE_MODEL || 'claude-sonnet-4-6')
-  : (process.env.OLLAMA_MODEL || 'qwen3.5:122b-a10b');
+  : (process.env.OLLAMA_MODEL || 'qwen3.5:122b-a10b-q8');
 
 const articleIdIdx = args.indexOf('--article-id');
 const ARTICLE_IDS: string[] = [];


### PR DESCRIPTION
## Summary
- One hardcoded fallback in `tools/jobs/wikipedia-discover.ts:50` still referenced `qwen3.5:122b-a10b` instead of `qwen3.5:122b-a10b-q8`
- Without this fix, running wiki-discover without `OLLAMA_MODEL` env var would attempt to load the old model

🤖 Generated with [Claude Code](https://claude.com/claude-code)