### PR TITLE
fix: lowercase 'AI' topic to 'ai' for consistency

### DIFF
--- a/content/ingest-subscribed.json
+++ b/content/ingest-subscribed.json
@@ -10,7 +10,7 @@
         "rationality",
         "science",
         "philosophy",
-        "AI"
+        "ai"
       ],
       "category": "philosophy"
     },


### PR DESCRIPTION
## Summary
- Lowercase 'AI' to 'ai' in Astral Codex Ten topics in `ingest-subscribed.json`
- All other 48 topics use lowercase kebab-case; this was the only outlier

Closes #298

🤖 Generated with [Claude Code](https://claude.com/claude-code)