### PR TITLE
fix: coerce subscriber phone to string (fixes #339)

### DIFF
--- a/tools/jobs/send-weekly.ts
+++ b/tools/jobs/send-weekly.ts
@@ -45,7 +45,7 @@ function loadSecrets(): Secrets {
 interface Subscriber {
   name: string;
   email: string;
-  phone: string;
+  phone: string | null;
   carrier: string;
 }
 
@@ -65,7 +65,7 @@ async function fetchSubscribers(): Promise<Subscriber[]> {
 
   const data = await response.json() as {
     status: string;
-    subscribers?: Array<{ email: string; phone: string; carrier: string }>;
+    subscribers?: Array<{ email: string; phone: string | number; carrier: string }>;
   };
 
   if (data.status !== 'ok' || !data.subscribers) {
@@ -77,7 +77,7 @@ async function fetchSubscribers(): Promise<Subscriber[]> {
     .map(s => ({
       name: '',
       email: s.email ?? '',
-      phone: s.phone ?? '',
+      phone: s.phone ? String(s.phone) : null,
       carrier: (s.carrier ?? '').toLowerCase(),
     }));
 }


### PR DESCRIPTION
## Summary
- Coerce `s.phone` to `String(s.phone)` in `fetchSubscribers()` to handle Google Apps Script returning phone numbers as JavaScript numbers (e.g., `2543158230` without quotes)
- Update the response type annotation to `string | number` to reflect the actual API behavior
- Update `Subscriber.phone` type to `string | null` for correctness

## Apps Script fix
The Apps Script source is not in this repo. A secret gist with instructions for Brian to manually fix the Apps Script has been created: https://gist.github.com/bedwards/0cbab83590f60e368694d82c58fd150e

## Relationship to PR #337
PR #337 (`fix/send-weekly-336`) also modifies `send-weekly.ts`. This PR is based on `main` and changes the same line (`phone: s.phone ?? ''` -> `phone: s.phone ? String(s.phone) : null`). PR #337 changes it to `phone: s.phone || null`. Whichever merges second will need a trivial conflict resolution — the `String()` coercion from this PR should be kept in either case.

## Test plan
- [x] TypeScript type check passes
- [x] ESLint passes (no warnings)
- [x] All 197 unit tests pass
- [ ] Manual: verify `send-weekly` handles numeric phone values without crashing

Fixes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)