### PR TITLE
fix: coerce subscriber phone to String() for numeric values

### DIFF
--- a/tools/jobs/send-weekly.ts
+++ b/tools/jobs/send-weekly.ts
@@ -65,7 +65,7 @@ async function fetchSubscribers(): Promise<Subscriber[]> {
 
   const data = await response.json() as {
     status: string;
-    subscribers?: Array<{ email: string; phone: string; carrier: string }>;
+    subscribers?: Array<{ email: string; phone: string | number; carrier: string }>;
   };
 
   if (data.status !== 'ok' || !data.subscribers) {
@@ -77,7 +77,7 @@ async function fetchSubscribers(): Promise<Subscriber[]> {
     .map(s => ({
       name: '',
       email: s.email ?? '',
-      phone: s.phone || null,
+      phone: s.phone ? String(s.phone) : null,
       carrier: (s.carrier ?? '').toLowerCase(),
     }));
 }


### PR DESCRIPTION
## Summary
- Apps Script can return phone numbers as JavaScript numbers (e.g. `2543158230`)
- `String()` coercion ensures they're handled correctly
- Updated response type to `string | number` to match actual API behavior
- Applies fix from closed #340 on top of merged #337

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)