### PR TITLE
fix: fall back to Better World Books link when Amazon link missing

### DIFF
--- a/tools/static-site/pages/article.ts
+++ b/tools/static-site/pages/article.ts
@@ -192,6 +192,10 @@ function generateArticlePage(
         titleLink = `<a href="${buildAmazonUrl(b.isbn10, affiliateTag)}" target="_blank" rel="noopener">
           <strong>${escapeHtml(b.title)}</strong>
         </a>`;
+      } else if (b.isbn13) {
+        titleLink = `<a href="${buildBWBUrl(b.isbn13)}" target="_blank" rel="noopener">
+          <strong>${escapeHtml(b.title)}</strong>
+        </a>`;
       } else {
         titleLink = `<strong>${escapeHtml(b.title)}</strong>`;
       }


### PR DESCRIPTION
## Summary

- When a book lacks a valid Amazon link (no isbn10 or no affiliate tag), the book title now falls back to linking to Better World Books via isbn13, instead of rendering as plain unlinked text
- Updated the fallback chain in `tools/static-site/pages/article.ts`: Wikipedia page -> Amazon -> **Better World Books** -> plain text
- Checked `tools/static-site/pages/wikipedia.ts` — uses a different pattern (separate buy links, not linked titles) so no fix needed there

Closes #380

## Test plan

- [ ] Verify lint, typecheck, and tests pass in CI
- [ ] Find a book with isbn13 but no isbn10 in the static site and confirm the title links to BWB

🤖 Generated with [Claude Code](https://claude.com/claude-code)