### PR TITLE
fix: log errors in send-weekly affiliate book fetch catch block

### DIFF
--- a/tools/jobs/send-weekly.ts
+++ b/tools/jobs/send-weekly.ts
@@ -232,7 +232,8 @@ async function getWeeklyAffiliateBooks(weekLabel: string): Promise<AffiliateBook
     }
 
     return results;
-  } catch {
+  } catch (err) {
+    console.error(`Failed to fetch affiliate books for week ${weekLabel}: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   } finally {
     await pool.end();


### PR DESCRIPTION
## Summary
- Added `console.error` logging to the silent catch block in `getWeeklyAffiliateBooks()` in `tools/jobs/send-weekly.ts`
- Errors now log the week label and error message, making affiliate book fetch failures visible in job logs

Closes #347

## Test plan
- [x] Lint passes
- [x] TypeScript type check passes
- [x] All 197 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)