### PR TITLE
fix: prevent empty topic_summary in article_wikipedia_links

### DIFF
--- a/src/db/migrations/016_clean_empty_topic_summaries.sql
+++ b/src/db/migrations/016_clean_empty_topic_summaries.sql
@@ -1,0 +1,13 @@
+-- Clean up: delete article_wikipedia_links with empty topic_summary values
+-- so the wiki-discover job re-processes those articles with proper descriptions.
+--
+-- The wiki-discover job finds articles with < 3 wikipedia links, so deleting
+-- these links will cause those articles to be picked up on the next run.
+-- The underlying wikipedia_articles are kept (they'll be reused via ON CONFLICT).
+
+DELETE FROM app.article_wikipedia_links
+WHERE TRIM(topic_summary) = '';
+
+-- Prevent future empty topic_summary values
+ALTER TABLE app.article_wikipedia_links
+  ADD CONSTRAINT topic_summary_not_empty CHECK (TRIM(topic_summary) <> '');

--- a/tools/jobs/wikipedia-discover.ts
+++ b/tools/jobs/wikipedia-discover.ts
@@ -295,6 +295,11 @@ ${articleLinkTopics.length > 0
             const normalized = normalizeWikipediaUrl(url);
             if (linkedUrls.has(normalized)) {continue;}
 
+            // Skip topics with empty reasons — the CHECK constraint requires non-empty topic_summary
+            if (!lt.reason || lt.reason.trim() === '') {
+              console.info(`    Skipping "${lt.topic}": LLM returned empty reason`);
+              continue;
+            }
             validatedTopics.push({ topic: lt.topic, url: normalized, reason: lt.reason });
             linkedUrls.add(normalized);
             alreadyUsed.push(lt.topic);


### PR DESCRIPTION
## Summary
- Add migration 016 that DELETEs rows with empty/whitespace-only `topic_summary` and adds a CHECK constraint to prevent future empty values
- Add validation in `wikipedia-discover.ts` to skip LLM topics with empty reasons before inserting

## Test plan
- [x] Lint passes
- [x] Typecheck passes
- [x] Unit tests pass (197/197)

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)