### PR TITLE
fix: add rel=sponsored to Better World Books affiliate links

### DIFF
--- a/src/shared/affiliate-utils.ts
+++ b/src/shared/affiliate-utils.ts
@@ -95,7 +95,7 @@ export function renderBookPurchaseLinks(book: ParsedAffiliateBook, affiliateTag:
     items.push(`<li><a href="${buildAmazonUrl(book.isbn10, affiliateTag)}" target="_blank" rel="noopener sponsored">Amazon <small class="affiliate-disclosure">affiliate</small></a></li>`);
   }
   if (book.isbn13) {
-    items.push(`<li><a href="${buildBWBUrl(book.isbn13)}" target="_blank" rel="noopener">Better World Books</a></li>`);
+    items.push(`<li><a href="${buildBWBUrl(book.isbn13)}" target="_blank" rel="noopener sponsored">Better World Books</a></li>`);
   }
 
   return `

--- a/tools/static-site/pages/article.ts
+++ b/tools/static-site/pages/article.ts
@@ -203,7 +203,7 @@ function generateArticlePage(
         buyLinks.push(`<a href="${buildAmazonUrl(b.isbn10, affiliateTag)}" target="_blank" rel="noopener sponsored" class="buy-link">Amazon</a>`);
       }
       if (b.isbn13) {
-        buyLinks.push(`<a href="${buildBWBUrl(b.isbn13)}" target="_blank" rel="noopener" class="buy-link">Better World Books</a>`);
+        buyLinks.push(`<a href="${buildBWBUrl(b.isbn13)}" target="_blank" rel="noopener sponsored" class="buy-link">Better World Books</a>`);
       }
       const buyHtml = buyLinks.length > 0
         ? `<span class="read-time">${buyLinks.join(' · ')}</span>`

--- a/tools/static-site/pages/wikipedia.ts
+++ b/tools/static-site/pages/wikipedia.ts
@@ -123,7 +123,7 @@ function generateWikipediaPage(
           links.push(`<a href="${buildAmazonUrl(book.isbn10, affiliateTag)}" target="_blank" rel="noopener sponsored">Amazon</a>`);
         }
         if (book.isbn13) {
-          links.push(`<a href="${buildBWBUrl(book.isbn13)}" target="_blank" rel="noopener">Better World Books</a>`);
+          links.push(`<a href="${buildBWBUrl(book.isbn13)}" target="_blank" rel="noopener sponsored">Better World Books</a>`);
         }
         const buyText = links.length > 0 ? ` — ${links.join(' · ')}` : '';
         return `<li>${escapeHtml(book.title)}${buyText} — ${escapeHtml(book.description)}</li>`;


### PR DESCRIPTION
## Summary
- Added `rel="noopener sponsored"` to all Better World Books affiliate links across 3 files
- BWB links now match the same `rel` attribute pattern as Amazon affiliate links

Closes #317

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (197 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)