### PR TITLE
fix: add descriptive alt attributes to generated article images

### DIFF
--- a/tools/static-site/pages/article.ts
+++ b/tools/static-site/pages/article.ts
@@ -98,9 +98,9 @@ async function getLinkedWikipedia(
  * Insert a generated image into the middle of article text
  * Places it after the 2nd paragraph as a floating illustration
  */
-function injectImageIntoText(html: string, imageSrc: string): string {
+function injectImageIntoText(html: string, imageSrc: string, altText: string): string {
   const imgTag = `<figure class="inline-illustration">
-    <img src="${imageSrc}" alt="" loading="lazy" width="600" height="315">
+    <img src="${imageSrc}" alt="${escapeHtml(altText)}" loading="lazy" width="600" height="315">
   </figure>`;
 
   // Find the end of the 2nd </p> tag and insert after it,
@@ -293,7 +293,7 @@ function generateArticlePage(
 
       ${isFullRewrite ? `
       <div class="article-content">
-        ${article.image_path ? injectImageIntoText(mainContent, `${pathToRoot}${article.image_path}`) : mainContent}
+        ${article.image_path ? injectImageIntoText(mainContent, `${pathToRoot}${article.image_path}`, article.title) : mainContent}
       </div>
 
       ${deepDivesHtml}

--- a/tools/static-site/pages/weekly.ts
+++ b/tools/static-site/pages/weekly.ts
@@ -582,7 +582,7 @@ ${navTocHtml}    </ol>
           archive.append(article.imageData, { name: `OEBPS/${imgFile}` });
           const mediaType = article.imageExt === 'webp' ? 'image/webp' : `image/${article.imageExt}`;
           manifestItems.push(`<item id="${imgId}" href="${imgFile}" media-type="${mediaType}"/>`);
-          imageHtml = `<img src="../images/${imgId}.${article.imageExt}" alt="" />`;
+          imageHtml = `<img src="../images/${imgId}.${article.imageExt}" alt="${escapeXml(article.row.title)}" />`;
         }
 
         // Deep dives

--- a/tools/static-site/templates.ts
+++ b/tools/static-site/templates.ts
@@ -226,7 +226,7 @@ export function renderStaticArticleCard(
   const articleUrl = `${pathToRoot}article/${article.id}/index.html${fromTag ? `?from=${fromTag}` : ''}`;
 
   const thumbHtml = article.imagePath
-    ? `<a href="${articleUrl}" class="article-thumb-link"><img class="article-thumb" src="${pathToRoot}${article.imagePath}" alt="" loading="lazy" width="180" height="94"></a>`
+    ? `<a href="${articleUrl}" class="article-thumb-link"><img class="article-thumb" src="${pathToRoot}${article.imagePath}" alt="${escapeHtml(article.title)}" loading="lazy" width="180" height="94"></a>`
     : '';
 
   return `<article class="article-card">


### PR DESCRIPTION
## Summary
- Add article title as `alt` attribute to all generated article `<img>` tags
- Covers static site article pages, home page thumbnail cards, and weekly epub images
- All alt text is properly HTML/XML-escaped using existing `escapeHtml()`/`escapeXml()` utilities

Closes #318

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (197 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)