### PR TITLE
refactor: extract LlmResponse interface in wikipedia-discover.ts

### DIFF
--- a/tools/jobs/wikipedia-discover.ts
+++ b/tools/jobs/wikipedia-discover.ts
@@ -64,6 +64,12 @@ interface TopicResult {
   reason: string;
 }
 
+interface LlmResponse {
+  topics?: TopicResult[];
+  existing_topic_reasons?: TopicResult[];
+  additional_topics?: TopicResult[];
+}
+
 // ── Main ────────────────────────────────────────────────────────────
 async function main(): Promise<void> {
   const dbUrl = process.env.DATABASE_URL;
@@ -245,11 +251,7 @@ ${articleLinkTopics.length > 0
           // Try to extract JSON object from the text
           const jsonMatch = cleaned.match(/\{[\s\S]*\}/);
           if (jsonMatch) {
-            const parsed = JSON.parse(jsonMatch[0]) as {
-              topics?: TopicResult[];
-              existing_topic_reasons?: TopicResult[];
-              additional_topics?: TopicResult[];
-            };
+            const parsed = JSON.parse(jsonMatch[0]) as LlmResponse;
             // Handle both response formats
             if (parsed.existing_topic_reasons) {
               for (const r of parsed.existing_topic_reasons) {


### PR DESCRIPTION
## Summary
- Extracted the inline type cast on the parsed LLM JSON response into a named `LlmResponse` interface
- Placed the interface in the Types section alongside the existing `TopicResult` interface
- Replaced the inline `as { ... }` cast with `as LlmResponse`

Closes #287

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (197 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)