### PR TITLE
chore: add CI lint check for alphabetical order of source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Check source file order
+        run: npm run lint:sources
+
       - name: Run linter
         run: npm run lint
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -75,6 +75,14 @@ if [ -n "$CONTENT_MD_FILES" ]; then
     done
 fi
 
+# Check source file alphabetical order
+echo "Checking source file order..."
+npm run lint:sources
+if [ $? -ne 0 ]; then
+    echo "❌ Source files are not sorted alphabetically. Sort them before committing."
+    exit 1
+fi
+
 # Run type checking
 echo "Running type check..."
 npm run typecheck

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start": "node dist/api/index.js",
     "lint": "eslint . --ext .ts,.tsx --max-warnings 0 --report-unused-disable-directives",
     "lint:fix": "eslint . --ext .ts,.tsx --fix --max-warnings 0 --report-unused-disable-directives",
+    "lint:sources": "node -e \"const fs=require('fs'); const files=[{f:'content/ingest-subscribed.json',k:'publications'},{f:'content/youtube-sources.json',k:'channels'}]; let ok=true; for(const {f,k} of files){const arr=JSON.parse(fs.readFileSync(f,'utf8'))[k]; const names=arr.map(x=>x.name); const sorted=[...names].sort((a,b)=>a.localeCompare(b,'en',{sensitivity:'base'})); for(let i=0;i<names.length;i++){if(names[i]!==sorted[i]){console.error(f+' is not sorted alphabetically by name: '+JSON.stringify(names[i])+' should come after '+JSON.stringify(sorted[i]));ok=false;break;}}} if(!ok)process.exit(1); console.log('Source files are sorted alphabetically.');\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- Adds `npm run lint:sources` script that checks `content/ingest-subscribed.json` and `content/youtube-sources.json` are sorted alphabetically by name
- Adds the check to the CI `lint-and-typecheck` job
- Adds the check to the pre-commit hook

Closes #297

## Test plan
- [x] `npm run lint:sources` passes on already-sorted files
- [x] `npm run lint`, `npm run typecheck`, `npm run test` all pass
- [x] Pre-commit hook runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)