### PR TITLE
refactor: unify model metadata column naming convention

### DIFF
--- a/src/db/migrations/019_unify_model_column_names.sql
+++ b/src/db/migrations/019_unify_model_column_names.sql
@@ -1,0 +1,9 @@
+-- Unify model metadata column naming convention
+-- Rename tagged_by → tag_model and discovered_by → discover_model
+-- to match the established rewrite_model pattern
+
+ALTER TABLE app.article_tags
+  RENAME COLUMN tagged_by TO tag_model;
+
+ALTER TABLE app.article_wikipedia_links
+  RENAME COLUMN discovered_by TO discover_model;

--- a/tools/jobs/article-rewrite.ts
+++ b/tools/jobs/article-rewrite.ts
@@ -391,9 +391,9 @@ Return ONLY tags scoring 30+. Output valid JSON, no explanation:
               if (!validSlugs.has(ts.slug)) {continue;}
               if (ts.score < 30 || ts.score > 100) {continue;}
               await pool.query(
-                `INSERT INTO app.article_tags (article_id, tag_slug, score, tagged_by)
+                `INSERT INTO app.article_tags (article_id, tag_slug, score, tag_model)
                  VALUES ($1, $2, $3, $4)
-                 ON CONFLICT (article_id, tag_slug) DO UPDATE SET score = EXCLUDED.score, tagged_by = EXCLUDED.tagged_by`,
+                 ON CONFLICT (article_id, tag_slug) DO UPDATE SET score = EXCLUDED.score, tag_model = EXCLUDED.tag_model`,
                 [article.id, ts.slug, ts.score, modelName]
               );
             }

--- a/tools/jobs/tag-articles.ts
+++ b/tools/jobs/tag-articles.ts
@@ -128,9 +128,9 @@ Return ONLY tags scoring 30+. Output valid JSON, no explanation:
 
           try {
             await pool.query(
-              `INSERT INTO app.article_tags (article_id, tag_slug, score, tagged_by)
+              `INSERT INTO app.article_tags (article_id, tag_slug, score, tag_model)
                VALUES ($1, $2, $3, $4)
-               ON CONFLICT (article_id, tag_slug) DO UPDATE SET score = EXCLUDED.score, tagged_by = EXCLUDED.tagged_by`,
+               ON CONFLICT (article_id, tag_slug) DO UPDATE SET score = EXCLUDED.score, tag_model = EXCLUDED.tag_model`,
               [article.id, ts.slug, ts.score, modelName]
             );
             inserted++;

--- a/tools/jobs/wikipedia-discover.ts
+++ b/tools/jobs/wikipedia-discover.ts
@@ -378,12 +378,12 @@ ${articleLinkTopics.length > 0
             // Link to article
             await pool.query(`
               INSERT INTO app.article_wikipedia_links (
-                article_id, wikipedia_id, relevance_rank, topic_summary, discovered_by
+                article_id, wikipedia_id, relevance_rank, topic_summary, discover_model
               ) VALUES ($1, $2, $3, $4, $5)
               ON CONFLICT (article_id, relevance_rank) DO UPDATE SET
                 wikipedia_id = EXCLUDED.wikipedia_id,
                 topic_summary = EXCLUDED.topic_summary,
-                discovered_by = EXCLUDED.discovered_by
+                discover_model = EXCLUDED.discover_model
             `, [article.id, wikiId, rank, vt.reason, DISCOVER_MODEL]);
             rank++;
           } catch (err) {


### PR DESCRIPTION
## Summary
- Renames `article_tags.tagged_by` to `tag_model` and `article_wikipedia_links.discovered_by` to `discover_model` to match the established `rewrite_model` pattern
- Adds migration `019_unify_model_column_names.sql`
- Updates all SQL references in `article-rewrite.ts`, `tag-articles.ts`, and `wikipedia-discover.ts`

Closes #290

## Test plan
- [x] Lint passes with zero warnings
- [x] TypeScript compiles cleanly
- [x] All 197 unit tests pass
- [ ] Run migration on local Postgres and verify column renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)