### PR TITLE
chore: use glob pattern for static generator files in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -117,46 +117,14 @@ NEED_FULL_REGEN=false
 NEED_REGEN=false
 
 if [ -n "$STAGED_ALL" ]; then
-    # Files that affect everything → full regen
-    if echo "$STAGED_ALL" | grep -qE '^tools/static-site/templates\.ts$|^tools/static-site/utils\.ts$|^tools/static-site/generate\.ts$'; then
+    # Any static-site TypeScript file → full regen (resilient to new files)
+    if echo "$STAGED_ALL" | grep -qE '^tools/static-site/.*\.ts$'; then
         NEED_FULL_REGEN=true
         NEED_REGEN=true
     fi
 
     if [ "$NEED_FULL_REGEN" = false ]; then
-        # Map specific files to --only sections
-        if echo "$STAGED_ALL" | grep -qE '^tools/static-site/pages/article\.ts$'; then
-            STATIC_ONLY_FLAGS="${STATIC_ONLY_FLAGS},articles"
-            NEED_REGEN=true
-        fi
-        if echo "$STAGED_ALL" | grep -qE '^tools/static-site/pages/wikipedia\.ts$'; then
-            STATIC_ONLY_FLAGS="${STATIC_ONLY_FLAGS},wikipedia"
-            NEED_REGEN=true
-        fi
-        if echo "$STAGED_ALL" | grep -qE '^tools/static-site/pages/home\.ts$'; then
-            STATIC_ONLY_FLAGS="${STATIC_ONLY_FLAGS},home"
-            NEED_REGEN=true
-        fi
-        if echo "$STAGED_ALL" | grep -qE '^tools/static-site/pages/tag\.ts$'; then
-            STATIC_ONLY_FLAGS="${STATIC_ONLY_FLAGS},tags"
-            NEED_REGEN=true
-        fi
-        if echo "$STAGED_ALL" | grep -qE '^tools/static-site/pages/weekly\.ts$'; then
-            STATIC_ONLY_FLAGS="${STATIC_ONLY_FLAGS},weekly"
-            NEED_REGEN=true
-        fi
-        if echo "$STAGED_ALL" | grep -qE '^tools/static-site/pages/about\.ts$'; then
-            STATIC_ONLY_FLAGS="${STATIC_ONLY_FLAGS},about"
-            NEED_REGEN=true
-        fi
-        if echo "$STAGED_ALL" | grep -qE '^tools/static-site/pages/publication\.ts$'; then
-            STATIC_ONLY_FLAGS="${STATIC_ONLY_FLAGS},publications"
-            NEED_REGEN=true
-        fi
-        if echo "$STAGED_ALL" | grep -qE '^tools/static-site/pages/search-index\.ts$'; then
-            STATIC_ONLY_FLAGS="${STATIC_ONLY_FLAGS},search"
-            NEED_REGEN=true
-        fi
+        # Non-generator files that affect specific sections
         if echo "$STAGED_ALL" | grep -qE '^src/shared/affiliate-utils\.ts$'; then
             STATIC_ONLY_FLAGS="${STATIC_ONLY_FLAGS},articles,wikipedia"
             NEED_REGEN=true


### PR DESCRIPTION
Closes #299

## Summary
- Replace 8 individual file checks for `tools/static-site/pages/*.ts` and 3 for `tools/static-site/*.ts` with a single regex pattern `^tools/static-site/.*\.ts$`
- Any change to static-site TypeScript files now triggers full regeneration, making the hook resilient to new files being added
- Keep specific checks for non-static-site files (CSS, `src/shared/affiliate-utils.ts`)

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (197 tests)
- [x] `bash .husky/pre-commit` runs successfully
- [x] Pre-commit hook runs successfully during actual commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)