### PR TITLE
fix: prevent blockquotes from rendering directly after images

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -450,6 +450,15 @@ main {
   border-radius: 2px;
 }
 
+/* Prevent blockquotes from appearing to caption images */
+.article-content img + blockquote,
+.article-content figure + blockquote,
+.article-content .inline-illustration + blockquote,
+.wikipedia-content img + blockquote,
+.wikipedia-content figure + blockquote {
+  margin-top: 2rem;
+}
+
 /* Excerpt-specific — previews should read as prose, not full articles */
 .article-excerpt {
   position: relative;


### PR DESCRIPTION
## Summary
- Add CSS sibling selector guard (`img + blockquote`, `figure + blockquote`, `.inline-illustration + blockquote`) with `margin-top: 2rem` to create visual separation when blockquotes follow images
- The `injectImageIntoText` function already avoids placing images before blockquotes in generated HTML; this CSS rule handles cases in raw article content

## Test plan
- [ ] Verify articles with images followed by blockquotes now have proper spacing
- [ ] Confirm no visual regression on articles without the image+blockquote pattern

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)