### PR TITLE
fix: harden lazy-summary migration with TRIM/LOWER

### DIFF
--- a/src/db/migrations/014_backfill_lazy_summaries.sql
+++ b/src/db/migrations/014_backfill_lazy_summaries.sql
@@ -6,10 +6,10 @@
 -- The underlying wikipedia_articles are kept (they'll be reused via ON CONFLICT).
 
 DELETE FROM app.article_wikipedia_links
-WHERE topic_summary IN (
-  'Referenced in the article',
-  'Referenced in the article.',
-  'Mentioned in the article',
-  'Mentioned in the article.',
-  'Related topic'
+WHERE TRIM(LOWER(topic_summary)) IN (
+  'referenced in the article',
+  'referenced in the article.',
+  'mentioned in the article',
+  'mentioned in the article.',
+  'related topic'
 );


### PR DESCRIPTION
## Summary
- Wrap `topic_summary` matches in `TRIM(LOWER(...))` so the migration catches variations with different casing or whitespace

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)