### PR TITLE
fix: optimize pre-commit hook to skip docs generation for unrelated changes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -117,8 +117,20 @@ NEED_FULL_REGEN=false
 NEED_REGEN=false
 
 if [ -n "$STAGED_ALL" ]; then
-    # Any static-site TypeScript file → full regen (resilient to new files)
-    if echo "$STAGED_ALL" | grep -qE '^tools/static-site/.*\.ts$'; then
+    # Any static-site TypeScript source file → full regen (excludes test files)
+    if echo "$STAGED_ALL" | grep -E '^tools/static-site/.*\.ts$' | grep -qvE '\.test\.ts$'; then
+        NEED_FULL_REGEN=true
+        NEED_REGEN=true
+    fi
+
+    # DB queries file affects static site output
+    if echo "$STAGED_ALL" | grep -qE '^src/db/queries\.ts$'; then
+        NEED_FULL_REGEN=true
+        NEED_REGEN=true
+    fi
+
+    # package.json version is read by templates at generation time
+    if echo "$STAGED_ALL" | grep -qE '^package\.json$'; then
         NEED_FULL_REGEN=true
         NEED_REGEN=true
     fi


### PR DESCRIPTION
## Summary
- Exclude test files (`.test.ts`) under `tools/static-site/` from triggering full static site regeneration
- Add `src/db/queries.ts` as a trigger for full regen (DB queries affect static site output)
- Add `package.json` as a trigger for full regen (version is read by templates)

Closes #261

## Test plan
- [x] Lint, typecheck, and tests pass
- [x] Pre-commit hook correctly skipped regeneration for this commit (only `.husky/pre-commit` changed)
- [ ] Verify that committing only a test file under `tools/static-site/` skips regen
- [ ] Verify that committing a source file under `tools/static-site/` triggers full regen

🤖 Generated with [Claude Code](https://claude.com/claude-code)