### PR TITLE
fix: mark BookEntry category and description as optional

### DIFF
--- a/tools/db/seed-affiliate-books.ts
+++ b/tools/db/seed-affiliate-books.ts
@@ -19,8 +19,8 @@ interface BookEntry {
   title: string;
   author: string;
   asin: string;
-  category: string;
-  description: string;
+  category?: string;
+  description?: string;
   gutenberg_url?: string;
   archive_url?: string;
 }


### PR DESCRIPTION
## Summary
- Mark `category` and `description` fields as optional (`?`) in the `BookEntry` interface in `tools/db/seed-affiliate-books.ts`
- The code already treats these fields as potentially absent (using `|| 'books'` and `|| null` fallbacks), so this aligns the type definition with actual usage

Closes #190

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (197 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)