### PR TITLE
perf: deduplicate git diff call in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,13 +6,16 @@
 
 echo "🔍 Running pre-commit checks..."
 
+# Capture staged file list once and reuse throughout the hook
+CACHED_DIFF=$(git diff --cached --name-only || true)
+
 # Check for secrets in staged files (excluding workflow files and examples)
 echo "Checking for secrets..."
 # Pattern matches actual secret values, not just variable names
 SECRETS_PATTERNS='(sk-[a-zA-Z0-9]{20,}|AKIA[A-Z0-9]{16}|ghp_[a-zA-Z0-9]{36}|password\s*=\s*["\x27][^"\x27]{8,}["\x27])'
 
 # Use || true because grep returns 1 when no match (and sh -e would exit)
-STAGED_FILES=$(git diff --cached --name-only | grep -v '\.yml$' | grep -v '\.example$' | grep -v 'CLAUDE\.md$' | grep -v 'README\.md$' || true)
+STAGED_FILES=$(echo "$CACHED_DIFF" | grep -v '\.yml$' | grep -v '\.example$' | grep -v 'CLAUDE\.md$' | grep -v 'README\.md$' || true)
 if [ -n "$STAGED_FILES" ]; then
     if echo "$STAGED_FILES" | xargs grep -E -l "$SECRETS_PATTERNS" 2>/dev/null; then
         echo "❌ ERROR: Possible secrets detected in staged files!"
@@ -23,7 +26,7 @@ if [ -n "$STAGED_FILES" ]; then
 fi
 
 # Check for .env or .secrets files
-if git diff --cached --name-only | grep -qE '^\.env$|^\.secrets$'; then
+if echo "$CACHED_DIFF" | grep -qE '^\.env$|^\.secrets$'; then
     echo "❌ ERROR: Attempting to commit .env or .secrets!"
     echo "These files contain sensitive data and must not be committed."
     echo "Use .env.example and .secrets.example for templates."
@@ -32,7 +35,7 @@ fi
 
 # Validate YAML frontmatter in markdown files
 echo "Checking YAML frontmatter..."
-CONTENT_MD_FILES=$(git diff --cached --name-only | grep -E '^content/.*\.md$' || true)
+CONTENT_MD_FILES=$(echo "$CACHED_DIFF" | grep -E '^content/.*\.md$' || true)
 if [ -n "$CONTENT_MD_FILES" ]; then
     for file in $CONTENT_MD_FILES; do
         if [ -f "$file" ]; then
@@ -111,7 +114,7 @@ fi
 echo "Checking if static site needs regeneration..."
 
 # Determine which --only flags are needed based on staged file changes
-STAGED_ALL=$(git diff --cached --name-only || true)
+STAGED_ALL="$CACHED_DIFF"
 STATIC_ONLY_FLAGS=""
 NEED_FULL_REGEN=false
 NEED_REGEN=false


### PR DESCRIPTION
## Summary
- Captures `git diff --cached --name-only` once at the top of the pre-commit hook into `CACHED_DIFF`
- Replaces all 4 subsequent `git diff --cached --name-only` calls with reuse of the cached variable
- Reduces subprocess spawns on every commit with no behavior change

Closes #194

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (197 tests)
- [x] Pre-commit hook ran successfully during commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)