### PR TITLE
refactor: deduplicate CSS between public and docs styles

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -229,8 +229,8 @@ main {
   background: var(--paper-dark);
 }
 
-/* Wikipedia card */
-.wikipedia-card .type-badge {
+/* Type badge (shared between card list + detail header) */
+.type-badge {
   display: inline-block;
   font-size: 0.7rem;
   font-weight: 600;
@@ -614,7 +614,8 @@ main {
   margin-bottom: var(--gap-lg);
 }
 
-.deep-dives h2 {
+.deep-dives h2,
+.deep-dives-label {
   font-size: var(--text-sm);
   font-weight: 600;
   color: var(--accent);
@@ -629,15 +630,8 @@ main {
   margin-bottom: 0.6rem;
 }
 
-.deep-dives-label {
-  font-size: var(--text-sm);
-  font-weight: 600;
-  color: var(--accent);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  margin-bottom: 0.6rem;
-}
-.deep-dives-list {
+.deep-dives-list,
+.deep-dive-list {
   list-style: none;
   padding: 0;
   margin: 0;
@@ -651,13 +645,6 @@ main {
 .deep-dives-list .read-time {
   font-size: var(--text-sm);
   color: var(--ink-muted);
-}
-
-
-.deep-dive-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
 }
 
 .deep-dive-item {
@@ -748,15 +735,6 @@ main {
 }
 
 .wikipedia-header .type-badge {
-  display: inline-block;
-  font-size: 0.7rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--accent);
-  background: var(--accent-bg);
-  padding: 0.15em 0.5em;
-  border-radius: 2px;
   margin-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- Merged `.deep-dives h2` and `.deep-dives-label` into a single rule (identical styles used by public and private sites respectively)
- Combined `.deep-dives-list` and `.deep-dive-list` into one rule (identical base styles)
- Extracted shared `.type-badge` base rule; `.wikipedia-header .type-badge` now only adds `margin-bottom`

Net result: 22 fewer lines of CSS, zero visual changes. `docs/styles.css` is generated by copying `public/styles.css`, so only the source file needed editing.

Closes #189

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (197 tests)
- [ ] Verify private site renders correctly (deep dives section, type badges)
- [ ] Run `npm run static:generate -- --only assets` and verify public site renders correctly

Generated with [Claude Code](https://claude.com/claude-code)