### PR TITLE
fix: use polling instead of fixed sleep in start-loops.sh

### DIFF
--- a/tools/ops/start-loops.sh
+++ b/tools/ops/start-loops.sh
@@ -7,7 +7,7 @@ CLONE="$HOME/vibe/hex-index-clones/claude-ops"
 # Sync clone before starting
 cd "$CLONE"
 git checkout main 2>&1 | grep -v "Already on"
-git pull --ff-only || git pull
+git pull --ff-only
 npm ci --silent
 
 # Kill existing session
@@ -15,9 +15,23 @@ tmux kill-session -t "$SESSION" 2>/dev/null || true
 
 # Start fresh
 tmux new-session -d -s "$SESSION" -c "$CLONE"
-sleep 2
+
+# Poll until tmux session is ready (up to 10s)
+for i in $(seq 1 20); do
+  tmux has-session -t "$SESSION" 2>/dev/null && break
+  sleep 0.5
+done
+tmux has-session -t "$SESSION" 2>/dev/null || { echo "ERROR: tmux session failed to start"; exit 1; }
+
 tmux send-keys -t "$SESSION" "claude --dangerously-skip-permissions" Enter
-sleep 5
+
+# Poll until claude process is running in the session (up to 30s)
+for i in $(seq 1 60); do
+  tmux list-panes -t "$SESSION" -F '#{pane_current_command}' 2>/dev/null | grep -q claude && break
+  sleep 0.5
+done
+tmux list-panes -t "$SESSION" -F '#{pane_current_command}' 2>/dev/null | grep -q claude || { echo "ERROR: claude failed to start"; exit 1; }
+
 tmux send-keys -t "$SESSION" "/loop 20m tools/claude-loop/scheduler-prompt.md" Enter
 
 echo "Claude loops session started: $SESSION"


### PR DESCRIPTION
## Summary
- Replace fixed `sleep 2` and `sleep 5` with polling loops that check for tmux session readiness and claude process startup, with timeouts and error messages on failure
- Use strict `git pull --ff-only` instead of falling back to `git pull` to avoid accidental merge commits

## Test plan
- [ ] Run `bash tools/ops/start-loops.sh` and verify tmux session starts correctly
- [ ] Verify claude process launches and `/loop` command is sent

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)