### PR TITLE
fix: stronger error handling for git pull --ff-only failures

### DIFF
--- a/.claude/commands/work-issues.md
+++ b/.claude/commands/work-issues.md
@@ -9,7 +9,7 @@ You do NOT write code yourself. You spawn background Agent workers with `isolati
 ## Step 0: Prepare
 
 ```bash
-git checkout main && git pull --ff-only
+git checkout main && git pull --ff-only || git reset --hard origin/main
 git status --short
 ```
 

--- a/operations-plan.md
+++ b/operations-plan.md
@@ -202,7 +202,11 @@ for clone in qwen-batch auto-deploy claude-editorial claude-ops claude-epub; do
       git status --short
     else
       git checkout main 2>/dev/null
-      git pull --ff-only 2>/dev/null || echo "WARN: $clone cannot fast-forward"
+      if ! git pull --ff-only 2>/dev/null; then
+        echo "ERROR: $clone cannot fast-forward — attempting reset to origin/main"
+        git fetch origin main
+        git reset --hard origin/main || echo "FATAL: reset failed for $clone — create a priority:high issue"
+      fi
     fi
     # Check for stale worktrees
     git worktree list
@@ -255,7 +259,7 @@ psql "$DATABASE_URL" -c "
 If content has changed since last deploy:
 ```bash
 cd ~/vibe/hex-index-clones/auto-deploy
-git checkout main && git pull --ff-only
+git checkout main && git pull --ff-only || git reset --hard origin/main
 bash tools/cron/auto-deploy.sh
 ```
 

--- a/tools/claude-loop/ops-prompt.md
+++ b/tools/claude-loop/ops-prompt.md
@@ -48,7 +48,11 @@ for clone in qwen-batch auto-deploy claude-editorial claude-ops claude-quality c
       git status --short
     else
       git checkout main 2>/dev/null
-      git pull --ff-only 2>/dev/null || echo "WARN: $clone cannot fast-forward"
+      if ! git pull --ff-only 2>/dev/null; then
+        echo "ERROR: $clone cannot fast-forward — attempting reset to origin/main"
+        git fetch origin main
+        git reset --hard origin/main || echo "FATAL: reset failed for $clone — create a priority:high issue"
+      fi
     fi
     # Check for stale worktrees
     git worktree list
@@ -101,7 +105,7 @@ psql "$DATABASE_URL" -c "
 If content has changed since last deploy:
 ```bash
 cd ~/vibe/hex-index-clones/auto-deploy
-git checkout main && git pull --ff-only
+git checkout main && git pull --ff-only || git reset --hard origin/main
 bash tools/cron/auto-deploy.sh
 ```
 

--- a/tools/claude-loop/scheduler-prompt.md
+++ b/tools/claude-loop/scheduler-prompt.md
@@ -186,13 +186,13 @@ for clone in qwen-batch auto-deploy claude-editorial claude-ops claude-epub; do
   git status --short
   git stash list
   git worktree list
-  git checkout main 2>/dev/null && git pull --ff-only 2>/dev/null
+  git checkout main 2>/dev/null && { git pull --ff-only 2>/dev/null || git reset --hard origin/main; }
 done
 ```
 - Uncommitted changes → commit to branch, push, create PR
 - Stashes → apply to branch, push, drop stash
 - Stale worktrees → remove if PR is merged
-- Failed pull → investigate
+- Failed pull → reset to origin/main (clones must not have local main changes); if reset fails, create a priority:high issue
 
 **B. Deploy check:**
 ```bash

--- a/tools/ops/claude-all-hex-index
+++ b/tools/ops/claude-all-hex-index
@@ -3,7 +3,11 @@
 # Usage: bash tools/ops/claude-all-hex-index
 set -eu
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLONES="$HOME/vibe/hex-index-clones"
+
+# shellcheck source=tools/ops/sync-clone.sh
+. "$SCRIPT_DIR/sync-clone.sh"
 
 start_loop() {
   local name=$1
@@ -17,9 +21,10 @@ start_loop() {
   tmux kill-session -t "$name" 2>/dev/null || true
 
   # Update clone
-  cd "$CLONES/$clone"
-  git checkout main 2>/dev/null
-  git pull --ff-only origin main
+  if ! sync_clone "$CLONES/$clone"; then
+    echo "SKIPPING $name — clone sync failed"
+    return 1
+  fi
   npm ci --silent 2>/dev/null
 
   # Start session

--- a/tools/ops/claude-editorial-hex-index
+++ b/tools/ops/claude-editorial-hex-index
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eux
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-editorial
 cd ~/vibe/hex-index-clones/claude-editorial
-git checkout main
-git pull --ff-only origin main
 npm ci --silent
 tmux new-session -d -s claude-editorial -c ~/vibe/hex-index-clones/claude-editorial
 tmux send-keys -t claude-editorial "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/claude-epub-hex-index
+++ b/tools/ops/claude-epub-hex-index
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eux
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-epub
 cd ~/vibe/hex-index-clones/claude-epub
-git checkout main
-git pull --ff-only origin main
 npm ci --silent
 tmux new-session -d -s claude-epub -c ~/vibe/hex-index-clones/claude-epub
 tmux send-keys -t claude-epub "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/claude-memory-hex-index
+++ b/tools/ops/claude-memory-hex-index
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eux
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-memory
 cd ~/vibe/hex-index-clones/claude-memory
-git checkout main
-git pull --ff-only origin main
 npm ci --silent
 tmux new-session -d -s claude-memory -c ~/vibe/hex-index-clones/claude-memory
 tmux send-keys -t claude-memory "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/claude-ops-hex-index
+++ b/tools/ops/claude-ops-hex-index
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eux
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-ops
 cd ~/vibe/hex-index-clones/claude-ops
-git checkout main
-git pull --ff-only origin main
 npm ci --silent
 tmux new-session -d -s claude-ops -c ~/vibe/hex-index-clones/claude-ops
 tmux send-keys -t claude-ops "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/claude-quality-hex-index
+++ b/tools/ops/claude-quality-hex-index
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eux
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-quality
 cd ~/vibe/hex-index-clones/claude-quality
-git checkout main
-git pull --ff-only origin main
 npm ci --silent
 tmux new-session -d -s claude-quality -c ~/vibe/hex-index-clones/claude-quality
 tmux send-keys -t claude-quality "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/start-loops.sh
+++ b/tools/ops/start-loops.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SESSION="claude-loops"
 CLONE="$HOME/vibe/hex-index-clones/claude-ops"
 
+# shellcheck source=tools/ops/sync-clone.sh
+. "$SCRIPT_DIR/sync-clone.sh"
+
 # Sync clone before starting
-cd "$CLONE"
-git checkout main 2>&1 | grep -v "Already on"
-git pull --ff-only || git pull
+sync_clone "$CLONE"
 npm ci --silent
 
 # Kill existing session

--- a/tools/ops/sync-clone.sh
+++ b/tools/ops/sync-clone.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# tools/ops/sync-clone.sh
+# Shared clone sync logic with robust error handling.
+# Usage: . tools/ops/sync-clone.sh && sync_clone /path/to/clone
+#
+# On ff-only failure, attempts git reset --hard origin/main.
+# If reset also fails, creates a GitHub issue and exits non-zero.
+
+sync_clone() {
+  local clone_dir="$1"
+  local clone_name
+  clone_name="$(basename "$clone_dir")"
+
+  cd "$clone_dir" || {
+    echo "FATAL: clone directory does not exist: $clone_dir"
+    return 1
+  }
+
+  git checkout main 2>/dev/null
+
+  # Fetch latest from origin
+  git fetch origin main
+
+  # Attempt fast-forward pull
+  if git pull --ff-only origin main 2>/dev/null; then
+    return 0
+  fi
+
+  echo "WARNING: git pull --ff-only failed for $clone_name — clone has diverged from origin/main"
+  echo "Attempting git reset --hard origin/main (clones should never have local changes on main)..."
+
+  if git reset --hard origin/main; then
+    echo "OK: reset $clone_name to origin/main successfully"
+    return 0
+  fi
+
+  echo "FATAL: git reset --hard origin/main also failed for $clone_name"
+
+  # Create a GitHub issue if the reset fails — npm may not be available,
+  # so fall back to gh CLI directly
+  if command -v gh >/dev/null 2>&1; then
+    gh issue create \
+      --title "ops: clone $clone_name failed to sync — manual intervention required" \
+      --label "bug,priority:high" \
+      --body "$(cat <<ISSUE_EOF
+## Problem
+Clone \`$clone_name\` at \`$clone_dir\` failed both \`git pull --ff-only\` and \`git reset --hard origin/main\`.
+
+## Details
+- **Clone**: \`$clone_dir\`
+- **Host**: $(hostname)
+- **Time**: $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+- **Branch**: $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')
+- **HEAD**: $(git rev-parse HEAD 2>/dev/null || echo 'unknown')
+- **Status**:
+\`\`\`
+$(git status --short 2>/dev/null || echo 'git status failed')
+\`\`\`
+
+## Resolution
+SSH into the machine and manually fix the clone:
+\`\`\`bash
+cd $clone_dir
+git fetch origin
+git reset --hard origin/main
+\`\`\`
+ISSUE_EOF
+)" 2>/dev/null && echo "GitHub issue created for $clone_name sync failure" \
+    || echo "WARNING: failed to create GitHub issue (gh CLI error)"
+  else
+    echo "WARNING: gh CLI not available — could not create GitHub issue"
+  fi
+
+  return 1
+}


### PR DESCRIPTION
Closes #179

## Summary
- Extracts shared `sync_clone()` function into `tools/ops/sync-clone.sh` that all clone launcher scripts now source
- On `git pull --ff-only` failure: logs clearly, attempts `git reset --hard origin/main` (clones should never have local changes on main)
- If reset also fails: automatically creates a `priority:high` GitHub issue with diagnostic details (hostname, HEAD, git status)
- Updates prompt files (`ops-prompt.md`, `scheduler-prompt.md`) and `operations-plan.md` to use the same recovery pattern instead of silent warnings

## Test plan
- [ ] Verify `sync_clone.sh` is sourced correctly by running one of the launcher scripts
- [ ] Simulate ff-only failure by advancing a clone's main ahead of origin; confirm reset recovery works
- [ ] Verify GitHub issue creation on double failure (mock by making reset fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)