### PR TITLE
fix: stronger error handling for git pull --ff-only failures

### DIFF
--- a/tools/ops/claude-all-hex-index
+++ b/tools/ops/claude-all-hex-index
@@ -1,9 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 # Start all Claude loops in separate tmux sessions
 # Usage: bash tools/ops/claude-all-hex-index
 set -eu
 
 CLONES="$HOME/vibe/hex-index-clones"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# shellcheck source=tools/ops/sync-clone.sh
+source "$SCRIPT_DIR/sync-clone.sh"
 
 start_loop() {
   local name=$1
@@ -17,9 +21,7 @@ start_loop() {
   tmux kill-session -t "$name" 2>/dev/null || true
 
   # Update clone
-  cd "$CLONES/$clone"
-  git checkout main 2>/dev/null
-  git pull --ff-only origin main
+  sync_clone "$CLONES/$clone"
   npm ci --silent 2>/dev/null
 
   # Start session

--- a/tools/ops/claude-editorial-hex-index
+++ b/tools/ops/claude-editorial-hex-index
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
-cd ~/vibe/hex-index-clones/claude-editorial
-git checkout main
-git pull --ff-only origin main
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=tools/ops/sync-clone.sh
+source "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-editorial
 npm ci --silent
 tmux new-session -d -s claude-editorial -c ~/vibe/hex-index-clones/claude-editorial
 tmux send-keys -t claude-editorial "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/claude-epub-hex-index
+++ b/tools/ops/claude-epub-hex-index
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
-cd ~/vibe/hex-index-clones/claude-epub
-git checkout main
-git pull --ff-only origin main
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=tools/ops/sync-clone.sh
+source "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-epub
 npm ci --silent
 tmux new-session -d -s claude-epub -c ~/vibe/hex-index-clones/claude-epub
 tmux send-keys -t claude-epub "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/claude-memory-hex-index
+++ b/tools/ops/claude-memory-hex-index
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
-cd ~/vibe/hex-index-clones/claude-memory
-git checkout main
-git pull --ff-only origin main
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=tools/ops/sync-clone.sh
+source "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-memory
 npm ci --silent
 tmux new-session -d -s claude-memory -c ~/vibe/hex-index-clones/claude-memory
 tmux send-keys -t claude-memory "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/claude-ops-hex-index
+++ b/tools/ops/claude-ops-hex-index
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
-cd ~/vibe/hex-index-clones/claude-ops
-git checkout main
-git pull --ff-only origin main
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=tools/ops/sync-clone.sh
+source "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-ops
 npm ci --silent
 tmux new-session -d -s claude-ops -c ~/vibe/hex-index-clones/claude-ops
 tmux send-keys -t claude-ops "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/claude-quality-hex-index
+++ b/tools/ops/claude-quality-hex-index
@@ -1,8 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
-cd ~/vibe/hex-index-clones/claude-quality
-git checkout main
-git pull --ff-only origin main
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=tools/ops/sync-clone.sh
+source "$SCRIPT_DIR/sync-clone.sh"
+sync_clone ~/vibe/hex-index-clones/claude-quality
 npm ci --silent
 tmux new-session -d -s claude-quality -c ~/vibe/hex-index-clones/claude-quality
 tmux send-keys -t claude-quality "claude --dangerously-skip-permissions" Enter

--- a/tools/ops/start-loops.sh
+++ b/tools/ops/start-loops.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 SESSION="claude-loops"
 CLONE="$HOME/vibe/hex-index-clones/claude-ops"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Sync clone before starting
-cd "$CLONE"
-git checkout main 2>&1 | grep -v "Already on"
-git pull --ff-only
+# shellcheck source=tools/ops/sync-clone.sh
+source "$SCRIPT_DIR/sync-clone.sh"
+sync_clone "$CLONE"
 npm ci --silent
 
 # Kill existing session

--- a/tools/ops/sync-clone.sh
+++ b/tools/ops/sync-clone.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# tools/ops/sync-clone.sh
+# Shared function for syncing a clone to origin/main with robust error handling.
+# Source this file, then call: sync_clone /path/to/clone
+
+sync_clone() {
+  local clone_dir="${1:?sync_clone requires a directory argument}"
+
+  cd "$clone_dir" || {
+    echo "ERROR: cannot cd to $clone_dir"
+    return 1
+  }
+
+  git checkout main 2>/dev/null
+
+  echo "Syncing clone: $clone_dir"
+  git fetch origin main
+
+  if git pull --ff-only origin main; then
+    echo "Clone synced successfully: $clone_dir"
+    return 0
+  fi
+
+  echo "WARNING: git pull --ff-only failed in $clone_dir, resetting to origin/main"
+
+  if git reset --hard origin/main; then
+    echo "Reset to origin/main succeeded: $clone_dir"
+    return 0
+  fi
+
+  echo "ERROR: git reset --hard origin/main also failed in $clone_dir"
+
+  # File a GitHub issue so the failure is visible
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$clone_dir")"
+  if command -v npm >/dev/null 2>&1 && [ -f "$repo_root/package.json" ]; then
+    (cd "$repo_root" && npm run gh:issue -- \
+      --title "Clone sync failed: $clone_dir" \
+      --labels "bug,priority:high") || true
+  fi
+
+  return 1
+}


### PR DESCRIPTION
## Summary
- Extracts a shared `sync_clone()` function into `tools/ops/sync-clone.sh` that attempts `git pull --ff-only origin main`, falls back to `git reset --hard origin/main` on failure, and files a GitHub issue if both fail
- Updates all 7 launcher scripts (`claude-*-hex-index`, `claude-all-hex-index`, `start-loops.sh`) to source and use this shared function instead of bare `git pull --ff-only`

Closes #179

## Test plan
- [ ] Verify `bash -n tools/ops/sync-clone.sh` parses cleanly
- [ ] Verify each launcher script sources sync-clone.sh correctly
- [ ] Lint, typecheck, and unit tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)