### PR TITLE
fix: update editorial-prompt.md to match ops/editorial split

### DIFF
--- a/tools/claude-loop/editorial-prompt.md
+++ b/tools/claude-loop/editorial-prompt.md
@@ -5,36 +5,7 @@ You are the developmental contributing editor for hex-index.com. Every 2 hours, 
 **NEVER call `npx tsx tools/jobs/...` scripts.** Those are Qwen batch jobs managed by launchctl.
 Claude loops do the work themselves or spawn background Agent workers.
 
-## Priority 1: Merge Authority
-
-Check for open PRs that need attention:
-
-```bash
-gh pr list --state open --json number,title,statusCheckRollup,reviews,createdAt
-```
-
-For each open PR:
-1. **Checks pass, reviews clean** — Merge it (`gh pr merge --auto --squash`)
-2. **Checks failing** — Read the failure, fix it in the PR branch, push the fix
-3. **PR is stale (>24h, no activity)** — Investigate and either fix or close with explanation
-4. **PR has review feedback** — Address the feedback, push fixes
-
-Also check for Claude and Gemini review comments on all recent PRs (open and merged in the last 24h):
-
-```bash
-# Check open PRs
-npx tsx tools/github/pr-comments.ts --pr <number> --claude
-# Check Gemini comments
-gh api repos/bedwards/hex-index/pulls/<number>/comments --jq '.[] | select(.user.login | contains("gemini")) | {path: .path, body: .body[0:300]}'
-```
-
-For review feedback:
-- **Security issues**: fix immediately in the PR
-- **Critical bugs**: fix immediately in the PR
-- **Non-critical feedback** (style, refactoring, minor improvements): **create a GitHub issue** instead of fixing inline. Use: `gh issue create --title "<short description>" --label "enhancement,priority:low" --body "From Gemini/Claude review on PR #<number>. <details>"`
-- This prevents review feedback from being lost while keeping PRs moving fast
-
-## Priority 2: Friday Epub Review (Thursday night / Friday morning)
+## Priority 1: Friday Epub Review (Thursday night / Friday morning)
 
 If today is Thursday after 23:00 or Friday before 07:30, the weekly epub has been built and needs editorial review before it goes to subscribers at 07:30 CT.
 
@@ -57,13 +28,12 @@ For each article in the current week's epub:
 3. If issues found:
    - Edit the rewrite file directly in `library/rewrites/<id>.html`
    - Update the database timestamp: `UPDATE app.articles SET updated_at = NOW() WHERE id = '<id>'`
-   - After all fixes: `npm run static:generate -- --only articles,weekly` then deploy via `bash tools/cron/deploy.sh "fix: epub editorial polish"`
-   - Verify at https://hex-index.com/weekly/
+   - After all fixes, the ops loop will detect `library/` changes and handle deployment
 4. Log what was reviewed and what was fixed
 
 **This is the highest priority on Thursday night/Friday morning.** The epub goes to real subscribers at 07:30. It must be polished.
 
-## Priority 3: Content Quality (Last 7 Days)
+## Priority 2: Content Quality (Last 7 Days)
 
 Query recent articles:
 
@@ -103,7 +73,7 @@ For each recent article, check and fix:
 - If `tag_count` = 0, assign tags yourself from the valid list by inserting into `app.article_tags`
 - Valid topics: culture, ai-tech, economics, political-strategy, foreign-policy, science, philosophy, media, writing-craft, history, music, china, defense, faith, law-rights, public-health, housing-cities
 
-## Priority 4: Backfill Old Articles
+## Priority 3: Backfill Old Articles
 
 Query articles older than 7 days that don't meet current standards:
 
@@ -126,9 +96,9 @@ Pick ONE old article per cycle and check:
 - The next Qwen rewrite cycle will redo it with the current prompt
 - Log which article you flagged and why
 
-This is lower priority than new content — only do this when Priorities 1-3 have nothing actionable.
+This is lower priority than new content — only do this when Priorities 1-2 have nothing actionable.
 
-## Priority 5: Site Verification
+## Priority 4: Site Verification
 
 
 **Do NOT deploy directly.** Content deployment is handled by the Claude monitoring loop in ~/hex-index. It checks for new `library/` changes every 5 minutes, creates PRs with incremental `docs/` regeneration, and merges when checks pass. All other jobs (including this editorial loop) should only write to DB + `library/`.
@@ -138,7 +108,7 @@ After making content changes:
 2. After deploy, verify the production site: `curl -s https://hex-index.com | head -20`
 3. Check the most recently changed article renders correctly
 
-## Priority 6: Housekeeping
+## Priority 5: Housekeeping
 
 ### Check main branch health
 ```bash

--- a/tools/claude-loop/ops-prompt.md
+++ b/tools/claude-loop/ops-prompt.md
@@ -14,7 +14,7 @@ gh pr list --state open --json number,title,statusCheckRollup,reviews,createdAt,
 ```
 
 For each open PR:
-- **All checks green, no unresolved reviews** --> merge it: `gh pr merge --squash <number>`
+- **All checks green, no unresolved reviews** --> merge it: `gh pr merge --auto --squash <number>`
 - **Checks failing** --> read the failure, fix it in a worktree, push to the PR branch
 - **Claude/Gemini review feedback** --> read it: `npx tsx tools/github/pr-comments.ts --pr <number> --claude` and `gh api repos/bedwards/hex-index/pulls/<number>/comments --jq '.[] | select(.user.login | contains("gemini")) | {path: .path, body: .body[0:300]}'`
   - Security issues or critical bugs: fix immediately


### PR DESCRIPTION
Closes #176

## Summary
- Removed "Priority 1: Merge Authority" section from editorial-prompt.md (PR merge/review triage belongs in the ops loop)
- Removed deploy trigger (`deploy.sh`) from epub review section (ops loop handles deployment)
- Fixed ops-prompt.md to use `gh pr merge --auto --squash` instead of `gh pr merge --squash`
- Renumbered editorial priorities (1-5 instead of 1-6)

## Test plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (197 tests)
- [ ] Verify editorial loop no longer attempts PR merges or deploys
- [ ] Verify ops loop uses `--auto` flag for PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)