### PR TITLE
fix: replace hardcoded paths and portable date commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ ALWAYS:
   every 5m: postgres-watchdog
 ```
 
-Services managed via `svc` at `/Users/bedwards/vibe/sea-gang/tools/svc`.
+Services managed via `svc` at `$HOME/vibe/sea-gang/tools/svc`.
 
 ### Pipeline Steps
 1. **Ingest**: Scrape Substack RSS + YouTube transcripts → Postgres

--- a/operations-plan.md
+++ b/operations-plan.md
@@ -230,7 +230,7 @@ If stashes exist:
 ## 5. GPU Status Check
 
 ```bash
-/Users/bedwards/vibe/sea-gang/tools/svc ls
+$HOME/vibe/sea-gang/tools/svc ls
 ```
 
 - Verify the expected Qwen job is running (check even/odd hour schedule)
@@ -453,11 +453,11 @@ through Friday morning.
 ## Check: Is It Epub Season?
 
 ```bash
-day=$(date +%u)  # 1=Mon, 4=Thu, 5=Fri
+day=$(date +%a)  # Mon, Thu, Fri
 hour=$(date +%H)
-if [ "$day" = "4" ] && [ "$hour" -ge "22" ]; then
+if [ "$day" = "Thu" ] && [ "$hour" -ge "22" ]; then
   echo "ACTIVE: Thursday evening review window"
-elif [ "$day" = "5" ] && [ "$hour" -lt "7" ]; then
+elif [ "$day" = "Fri" ] && [ "$hour" -lt "7" ]; then
   echo "ACTIVE: Friday morning review window"
 else
   echo "INACTIVE: Not epub season. Sleeping."

--- a/tools/claude-loop/scheduler-prompt.md
+++ b/tools/claude-loop/scheduler-prompt.md
@@ -13,7 +13,7 @@ Claude loops do the work themselves or spawn background Agent workers.
 ## Step 1: Check the Clock
 
 ```bash
-echo "Day: $(date +%u) Hour: $(date +%H) Minute: $(date +%M)"
+echo "Day: $(date +%a) Hour: $(date +%H) Minute: $(date +%M)"
 echo "Day name: $(date +%A)"
 ```
 


### PR DESCRIPTION
## Summary

- Replace `/Users/bedwards/` hardcoded paths with `$HOME/` in `CLAUDE.md`, `operations-plan.md`
- Replace `date +%u` (numeric day-of-week) with `date +%a` (abbreviated name like Thu, Fri) in `operations-plan.md` and `tools/claude-loop/scheduler-prompt.md` for readability and portability
- Update conditionals to compare against day names instead of numeric values

Closes #178

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (197 tests)
- [ ] Verify no remaining `/Users/bedwards/` in prompt/script files
- [ ] Verify `date +%a` produces expected output on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)