### PR TITLE
feat: add content scoring system with audit table and quality reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "job:audit-html": "tsx tools/jobs/audit-html.ts",
     "job:commentary-audit": "tsx tools/jobs/commentary-audit.ts",
     "job:model-report": "tsx tools/jobs/model-report.ts",
+    "job:quality-report": "tsx tools/jobs/quality-report.ts",
     "job:consolidate-weekly": "tsx tools/jobs/consolidate-weekly.ts",
     "job:send-weekly": "tsx tools/jobs/send-weekly.ts",
     "job:title-cleanup": "tsx tools/jobs/title-cleanup.ts",

--- a/src/db/migrations/020_content_audits.sql
+++ b/src/db/migrations/020_content_audits.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS app.content_audits (
+  id SERIAL PRIMARY KEY,
+  content_type TEXT NOT NULL,           -- 'article', 'wikipedia', 'title', 'affiliate'
+  content_id TEXT NOT NULL,             -- article or wikipedia article UUID
+  audited_by TEXT NOT NULL,             -- 'claude-editorial', 'claude-quality', 'claude-epub'
+  score_before INTEGER CHECK (score_before BETWEEN 0 AND 100),
+  score_after INTEGER CHECK (score_after BETWEEN 0 AND 100),
+  issues_found TEXT[],                  -- ['missing_counterpoints', 'no_bottom_line', 'think_tags']
+  changes_made TEXT[],                  -- ['added_counterpoint', 'fixed_title_case', 'removed_preamble']
+  notes TEXT,                           -- free-form editorial notes
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_content_audits_content ON app.content_audits (content_type, content_id);
+CREATE INDEX idx_content_audits_score ON app.content_audits (score_before);

--- a/tools/claude-loop/editorial-prompt.md
+++ b/tools/claude-loop/editorial-prompt.md
@@ -132,6 +132,31 @@ If an issue has been in-progress for >48h with no PR, investigate.
 - **One improvement per cycle** — pick the highest-impact item, do it well
 - **Verify production** after merges
 
+## Content Scoring (REQUIRED)
+
+Every time you evaluate content, score it 0-100 and log to the database:
+
+| Score | Meaning |
+|-------|---------|
+| 90-100 | Publication ready. Strong voice, direct quotes, counterpoints, clean formatting |
+| 80-89 | Good but minor issues. Missing a counterpoint, weak Bottom Line, could be tighter |
+| 70-79 | Acceptable but needs work. Summary-style instead of commentary, few quotes |
+| 50-69 | Below standard. Missing sections, weak voice, formatting issues |
+| 0-49 | Reject. Refusal text, garbled output, think tags, completely off-topic |
+
+After reviewing each piece of content, INSERT an audit record:
+
+```sql
+INSERT INTO app.content_audits (content_type, content_id, audited_by, score_before, score_after, issues_found, changes_made, notes)
+VALUES ('article', '<id>', 'claude-editorial', <score_before>, <score_after>, ARRAY['issue1', 'issue2'], ARRAY['change1'], 'notes');
+```
+
+- `score_before`: Score when you first read the content
+- `score_after`: Score after your improvements (NULL if you made no changes)
+- `issues_found`: Specific problems detected (e.g., 'missing_counterpoints', 'no_bottom_line', 'think_tags', 'weak_voice', 'summary_style')
+- `changes_made`: What you fixed (e.g., 'marked_dirty', 'added_tags', 'fixed_title')
+- Always log an audit record, even if the content is perfect (score 90+ with empty issues/changes arrays)
+
 ## Editorial Guidelines
 
 These are non-negotiable quality standards:

--- a/tools/claude-loop/epub-review-prompt.md
+++ b/tools/claude-loop/epub-review-prompt.md
@@ -65,6 +65,31 @@ Do not push directly to main. All changes go through PRs.
 echo "$(basename "$LATEST_EPUB")" >> tools/claude-loop/.epub-reviewed
 ```
 
+## Content Scoring (REQUIRED)
+
+Every time you evaluate content, score it 0-100 and log to the database:
+
+| Score | Meaning |
+|-------|---------|
+| 90-100 | Publication ready. Strong voice, direct quotes, counterpoints, clean formatting |
+| 80-89 | Good but minor issues. Missing a counterpoint, weak Bottom Line, could be tighter |
+| 70-79 | Acceptable but needs work. Summary-style instead of commentary, few quotes |
+| 50-69 | Below standard. Missing sections, weak voice, formatting issues |
+| 0-49 | Reject. Refusal text, garbled output, think tags, completely off-topic |
+
+After reviewing each piece of content, INSERT an audit record:
+
+```sql
+INSERT INTO app.content_audits (content_type, content_id, audited_by, score_before, score_after, issues_found, changes_made, notes)
+VALUES ('article', '<id>', 'claude-epub', <score_before>, <score_after>, ARRAY['issue1', 'issue2'], ARRAY['change1'], 'notes');
+```
+
+- `score_before`: Score when you first read the content
+- `score_after`: Score after your improvements (NULL if you made no changes)
+- `issues_found`: Specific problems detected (e.g., 'llm_artifacts', 'encoding_issues', 'missing_headings', 'duplicate_paragraphs', 'too_short')
+- `changes_made`: What you fixed (e.g., 'marked_dirty', 'regenerated_page')
+- Always log an audit record for every article in the epub
+
 ## Important
 - The first draft epub goes live immediately when build-weekly runs Thursday night
 - Your improved version replaces it on the live site

--- a/tools/claude-loop/quality-audit-prompt.md
+++ b/tools/claude-loop/quality-audit-prompt.md
@@ -45,6 +45,31 @@ UPDATE app.articles SET rewrite_dirty = true WHERE id = '{id}';
 UPDATE app.wikipedia_articles SET rewrite_dirty = true, status = 'stub' WHERE id = '{id}';
 ```
 
+## Content Scoring (REQUIRED)
+
+Every time you evaluate content, score it 0-100 and log to the database:
+
+| Score | Meaning |
+|-------|---------|
+| 90-100 | Publication ready. Strong voice, direct quotes, counterpoints, clean formatting |
+| 80-89 | Good but minor issues. Missing a counterpoint, weak Bottom Line, could be tighter |
+| 70-79 | Acceptable but needs work. Summary-style instead of commentary, few quotes |
+| 50-69 | Below standard. Missing sections, weak voice, formatting issues |
+| 0-49 | Reject. Refusal text, garbled output, think tags, completely off-topic |
+
+After reviewing each piece of content, INSERT an audit record:
+
+```sql
+INSERT INTO app.content_audits (content_type, content_id, audited_by, score_before, score_after, issues_found, changes_made, notes)
+VALUES ('article', '<id>', 'claude-quality', <score_before>, <score_after>, ARRAY['issue1', 'issue2'], ARRAY['change1'], 'notes');
+```
+
+- `score_before`: Score when you first read the content
+- `score_after`: Score after marking dirty or NULL if no action taken
+- `issues_found`: Specific problems detected (e.g., 'refusal_text', 'think_tags', 'mojibake', 'repeated_paragraphs', 'too_short', 'no_headings')
+- `changes_made`: What you fixed (e.g., 'marked_dirty', 'logged_warning')
+- Always log an audit record for every piece of content checked
+
 ## Step 4: Report
 
 Print a summary:

--- a/tools/jobs/quality-report.ts
+++ b/tools/jobs/quality-report.ts
@@ -1,0 +1,234 @@
+/**
+ * Quality report — queries the content_audits table to show scoring
+ * trends, common issues, and improvement over time.
+ *
+ * Usage:
+ *   npx tsx tools/jobs/quality-report.ts              # all time
+ *   npx tsx tools/jobs/quality-report.ts --days 7     # last 7 days
+ */
+
+import { Pool } from 'pg';
+import { config } from 'dotenv';
+
+config();
+
+const args = process.argv.slice(2);
+const daysIdx = args.indexOf('--days');
+const DAYS = (() => {
+  if (daysIdx < 0 || !args[daysIdx + 1]) { return null; }
+  const parsed = parseInt(args[daysIdx + 1], 10);
+  if (isNaN(parsed) || parsed <= 0) {
+    console.error(`Invalid --days value: ${args[daysIdx + 1]}. Must be a positive number.`);
+    process.exit(1);
+  }
+  return parsed;
+})();
+
+interface AvgScoreRow {
+  content_type: string;
+  audit_count: string;
+  avg_score_before: string | null;
+  avg_score_after: string | null;
+  avg_improvement: string | null;
+}
+
+interface CountRow {
+  issue?: string;
+  change?: string;
+  occurrences: string;
+}
+
+interface TrendRow {
+  week: Date;
+  audits: string;
+  avg_before: string | null;
+  avg_after: string | null;
+}
+
+interface AuditorRow {
+  audited_by: string;
+  audit_count: string;
+  avg_before: string | null;
+  avg_after: string | null;
+}
+
+interface LowScoreRow {
+  content_type: string;
+  content_id: string;
+  audited_by: string;
+  score_before: number;
+  score_after: number | null;
+  created_at: Date;
+}
+
+async function main(): Promise<void> {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) { throw new Error('DATABASE_URL required'); }
+
+  const pool = new Pool({ connectionString: dbUrl });
+
+  try {
+    const timeFilter = DAYS
+      ? `WHERE created_at > NOW() - INTERVAL '${DAYS} days'`
+      : '';
+    const timeFilterAnd = DAYS
+      ? `AND created_at > NOW() - INTERVAL '${DAYS} days'`
+      : '';
+
+    // 1. Average scores by content type
+    const avgScores = await pool.query<AvgScoreRow>(`
+      SELECT content_type,
+             COUNT(*) as audit_count,
+             ROUND(AVG(score_before), 1) as avg_score_before,
+             ROUND(AVG(score_after), 1) as avg_score_after,
+             ROUND(AVG(score_after) - AVG(score_before), 1) as avg_improvement
+      FROM app.content_audits
+      ${timeFilter}
+      GROUP BY content_type
+      ORDER BY content_type
+    `);
+
+    const period = DAYS ? `last ${DAYS} days` : 'all time';
+    console.info('='.repeat(70));
+    console.info(`CONTENT QUALITY REPORT — ${period}`);
+    console.info(`Generated: ${new Date().toISOString()}`);
+    console.info('='.repeat(70));
+
+    if (avgScores.rows.length === 0) {
+      console.info('\nNo audit records found. Content audits are logged by Claude loops.');
+      console.info('Run editorial, quality-audit, or epub-review loops to generate data.');
+      return;
+    }
+
+    console.info('\n## Average Scores by Content Type\n');
+    console.info('   Type          | Audits | Avg Before | Avg After | Improvement');
+    console.info('   ' + '-'.repeat(65));
+    for (const row of avgScores.rows) {
+      const improvement = row.avg_improvement != null
+        ? (parseFloat(row.avg_improvement) > 0 ? '+' : '') + row.avg_improvement
+        : 'n/a';
+      const before = row.avg_score_before ?? 'n/a';
+      const after = row.avg_score_after ?? 'n/a';
+      console.info(
+        `   ${row.content_type.padEnd(15)} | ${row.audit_count.padStart(6)} | ${before.padStart(10)} | ${after.padStart(9)} | ${improvement}`
+      );
+    }
+
+    // 2. Most common issues
+    const commonIssues = await pool.query<CountRow>(`
+      SELECT issue, COUNT(*) as occurrences
+      FROM app.content_audits, UNNEST(issues_found) AS issue
+      ${timeFilter}
+      GROUP BY issue
+      ORDER BY occurrences DESC
+      LIMIT 15
+    `);
+
+    if (commonIssues.rows.length > 0) {
+      console.info('\n## Most Common Issues\n');
+      for (const row of commonIssues.rows) {
+        console.info(`   ${row.occurrences.padStart(4)}x  ${row.issue}`);
+      }
+    }
+
+    // 3. Most common changes
+    const commonChanges = await pool.query<CountRow>(`
+      SELECT change, COUNT(*) as occurrences
+      FROM app.content_audits, UNNEST(changes_made) AS change
+      ${timeFilter}
+      GROUP BY change
+      ORDER BY occurrences DESC
+      LIMIT 15
+    `);
+
+    if (commonChanges.rows.length > 0) {
+      console.info('\n## Most Common Changes Made\n');
+      for (const row of commonChanges.rows) {
+        console.info(`   ${row.occurrences.padStart(4)}x  ${row.change}`);
+      }
+    }
+
+    // 4. Score trends over time (by week)
+    const trends = await pool.query<TrendRow>(`
+      SELECT DATE_TRUNC('week', created_at)::date as week,
+             COUNT(*) as audits,
+             ROUND(AVG(score_before), 1) as avg_before,
+             ROUND(AVG(score_after), 1) as avg_after
+      FROM app.content_audits
+      ${timeFilter}
+      GROUP BY week
+      ORDER BY week DESC
+      LIMIT 12
+    `);
+
+    if (trends.rows.length > 0) {
+      console.info('\n## Score Trends (by week)\n');
+      console.info('   Week         | Audits | Avg Before | Avg After');
+      console.info('   ' + '-'.repeat(50));
+      for (const row of trends.rows) {
+        const week = new Date(row.week).toISOString().slice(0, 10);
+        const avgBefore = row.avg_before ?? 'n/a';
+        const avgAfter = row.avg_after ?? 'n/a';
+        console.info(
+          `   ${week}    | ${row.audits.padStart(6)} | ${avgBefore.padStart(10)} | ${avgAfter.padStart(9)}`
+        );
+      }
+    }
+
+    // 5. Scores by auditor
+    const byAuditor = await pool.query<AuditorRow>(`
+      SELECT audited_by,
+             COUNT(*) as audit_count,
+             ROUND(AVG(score_before), 1) as avg_before,
+             ROUND(AVG(score_after), 1) as avg_after
+      FROM app.content_audits
+      ${timeFilter}
+      GROUP BY audited_by
+      ORDER BY audit_count DESC
+    `);
+
+    if (byAuditor.rows.length > 0) {
+      console.info('\n## Audits by Loop\n');
+      console.info('   Auditor               | Audits | Avg Before | Avg After');
+      console.info('   ' + '-'.repeat(60));
+      for (const row of byAuditor.rows) {
+        const auditorBefore = row.avg_before ?? 'n/a';
+        const auditorAfter = row.avg_after ?? 'n/a';
+        console.info(
+          `   ${row.audited_by.padEnd(23)} | ${row.audit_count.padStart(6)} | ${auditorBefore.padStart(10)} | ${auditorAfter.padStart(9)}`
+        );
+      }
+    }
+
+    // 6. Low-scoring content that may need attention
+    const lowScores = await pool.query<LowScoreRow>(`
+      SELECT content_type, content_id, audited_by, score_before, score_after, created_at
+      FROM app.content_audits
+      WHERE score_before IS NOT NULL AND score_before < 70
+      ${timeFilterAnd}
+      ORDER BY score_before ASC
+      LIMIT 10
+    `);
+
+    if (lowScores.rows.length > 0) {
+      console.info('\n## Low-Scoring Content (< 70)\n');
+      for (const row of lowScores.rows) {
+        const date = new Date(row.created_at).toISOString().slice(0, 10);
+        console.info(
+          `   [${row.score_before}] ${row.content_type}:${row.content_id.slice(0, 8)}... (${row.audited_by}, ${date})`
+        );
+      }
+    }
+
+    console.info('\n' + '='.repeat(70));
+    console.info('Run: npx tsx tools/jobs/quality-report.ts' + (DAYS ? ` --days ${DAYS}` : ''));
+    console.info('='.repeat(70));
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `app.content_audits` table (migration 020) for Claude loops to score content 0-100 and log all issues found and changes made
- Add content scoring rubric (0-100 scale) and audit INSERT instructions to editorial, quality-audit, and epub-review prompts
- Add `job:quality-report` npm script (`tools/jobs/quality-report.ts`) showing average scores by content type, most common issues, score trends over time, and low-scoring content

Closes #247

## Test plan
- [ ] Run `npm run db:migrate` to apply migration 020
- [ ] Verify `app.content_audits` table created with correct schema
- [ ] Run `npm run job:quality-report` (should show "No audit records found" initially)
- [ ] Insert a test audit record and verify the report shows it
- [ ] Review prompt files for correct rubric and SQL template

🤖 Generated with [Claude Code](https://claude.com/claude-code)