### PR TITLE
feat: topic tag overhaul (#349)

### DIFF
--- a/src/db/migrations/021_tag_overhaul.sql
+++ b/src/db/migrations/021_tag_overhaul.sql
@@ -1,0 +1,62 @@
+-- Migration 021: Topic tag overhaul (#349)
+--
+-- 1. Adds finer-grained tags so the Hex Digest premium epub can section
+--    Literature, Media Criticism, Real Estate, and individual sports
+--    (NFL, NBA, soccer) instead of bucketing them under generic "culture"
+--    or "sports".
+-- 2. Audits known false positives. The pre-existing keyword backfill in
+--    migration 013 caught a lot of articles whose titles mention "season",
+--    "league", "draft", "coach" in non-sports contexts. We don't blow
+--    those rows away (the LLM may legitimately retag them) but we lower
+--    obvious mismatches so they fall under the Digest 50+ threshold.
+
+-- ── New tags ────────────────────────────────────────────────────────
+INSERT INTO app.tags (slug, name, description) VALUES
+  ('literature',  'Literature',  'Novels, poetry, literary criticism, authors, book reviews, the literary world'),
+  ('media-criticism', 'Media Criticism', 'Critique of journalism, news outlets, press coverage, media bias, framing'),
+  ('real-estate', 'Real Estate', 'Housing market, mortgages, property, REITs, commercial real estate, brokerage'),
+  ('nfl',         'NFL',         'National Football League, American football, NFL teams, players, draft, Super Bowl'),
+  ('nba',         'NBA',         'National Basketball Association, basketball, NBA teams, players, playoffs, finals'),
+  ('soccer',      'Soccer',      'Association football, Premier League, La Liga, Bundesliga, MLS, World Cup, UEFA, FIFA')
+ON CONFLICT (slug) DO NOTHING;
+
+-- ── Audit existing assignments ──────────────────────────────────────
+-- Lower confidence on tags that the keyword backfill commonly mis-fires on.
+-- Articles that genuinely match will be re-scored 50+ on the next
+-- scheduled tag-articles run.
+
+-- music: drop political-music false positives ("the music of the spheres",
+-- "this song", etc. — anything where the title obviously isn't about music)
+UPDATE app.article_tags at
+SET score = LEAST(at.score, 40)
+WHERE at.tag_slug = 'music'
+  AND at.score < 70
+  AND EXISTS (
+    SELECT 1 FROM app.articles a
+    WHERE a.id = at.article_id
+      AND LOWER(a.title) !~ '(music|song|album|band|guitar|piano|orchestra|symphony|jazz|rock|hip.?hop|rap|opera|concert|musician|singer|composer)'
+  );
+
+-- faith: drop political/cultural usage of "church", "priest", "gospel"
+UPDATE app.article_tags at
+SET score = LEAST(at.score, 40)
+WHERE at.tag_slug = 'faith'
+  AND at.score < 70
+  AND EXISTS (
+    SELECT 1 FROM app.articles a
+    WHERE a.id = at.article_id
+      AND LOWER(a.title) !~ '(faith|religion|religious|church|christian|catholic|protestant|jewish|judaism|islam|muslim|buddhis|hindu|theology|spiritual|prayer|scripture|bible|gospel|pope|priest|rabbi|imam)'
+  );
+
+-- sports: the migration 013 keyword sweep was aggressive. Demote any
+-- sports tag whose article title doesn't actually contain a clear sports
+-- keyword. Genuine sports articles get re-scored 50+ on next LLM pass.
+UPDATE app.article_tags at
+SET score = LEAST(at.score, 40)
+WHERE at.tag_slug = 'sports'
+  AND at.score >= 50
+  AND EXISTS (
+    SELECT 1 FROM app.articles a
+    WHERE a.id = at.article_id
+      AND LOWER(a.title) !~ '(ufc|mma|nfl|nba|mlb|nhl|f1|formula.?1|olympic|super.?bowl|world.?cup|quarterback|touchdown|playoff|boxing|wrestling|tennis|golf|soccer|football|basketball|baseball|hockey|athlete|espn|stadium)'
+  );

--- a/tools/static-site/pages/weekly.ts
+++ b/tools/static-site/pages/weekly.ts
@@ -310,7 +310,15 @@ async function ensureCoverImage(
 /**
  * Get articles for a given week, each assigned to its highest-scored tag.
  * Articles included if published_at >= saturday 00:00 UTC AND published_at < friday 12:30 UTC.
+ *
+ * Digest section assignment uses a stricter threshold (DIGEST_TAG_MIN_SCORE)
+ * than the Reader/private library tag pages (which include any tag scoring
+ * 30+ at insert time). This keeps weak tag matches out of premium-epub
+ * sections — articles whose top tag scores below the threshold fall back
+ * to the default "culture" bucket. See issue #349.
  */
+const DIGEST_TAG_MIN_SCORE = 50;
+
 async function getArticlesForWeek(
   pool: Pool,
   weekStart: Date,
@@ -326,11 +334,12 @@ async function getArticlesForWeek(
       a.affiliate_links
     FROM app.articles a
     JOIN app.publications p ON a.publication_id = p.id
-    LEFT JOIN app.article_tags at ON at.article_id = a.id
+    LEFT JOIN app.article_tags at
+      ON at.article_id = a.id AND at.score >= $3
     LEFT JOIN app.tags t ON t.slug = at.tag_slug
     WHERE a.published_at >= $1 AND a.published_at < $2
     ORDER BY a.id, at.score DESC NULLS LAST
-  `, [weekStart.toISOString(), weekEnd.toISOString()]);
+  `, [weekStart.toISOString(), weekEnd.toISOString(), DIGEST_TAG_MIN_SCORE]);
   return rows;
 }
 


### PR DESCRIPTION
Closes #349.

## Summary
Adds finer-grained topic tags so the Hex Digest premium epub can section Literature, Media Criticism, Real Estate, and individual sports (NFL, NBA, soccer) instead of bucketing them under generic `culture` or `sports`. Audits known false positives and raises the Digest section-assignment threshold to 50+ while leaving the Reader / public tag pages at the existing 30+ floor.

## Changes
- **`src/db/migrations/021_tag_overhaul.sql`**
  - Adds new tags: `literature`, `media-criticism`, `real-estate`, `nfl`, `nba`, `soccer`.
  - Audits existing assignments by demoting weak `music`, `faith`, and `sports` rows below 50 when the article title doesn't contain a hard keyword for that topic. Demoted (not deleted) so the next scheduled `tag-articles` run can re-score them with the LLM.
- **`tools/static-site/pages/weekly.ts`**
  - `getArticlesForWeek` now joins `app.article_tags` with `score >= DIGEST_TAG_MIN_SCORE` (50). Articles whose top tag scores below 50 fall back to the default `culture` bucket for Digest sectioning.

The Qwen tagging prompt loads `app.tags` dynamically (`tag-articles.ts` line 31, `article-rewrite.ts` line 104), so the new tags are picked up automatically with no prompt-code change.

## Scoring rationale
- **Reader (30+)** keeps the existing insert-time floor in `tag-articles.ts` / `article-rewrite.ts` (`if (ts.score < 30) continue`). This is the right floor for tag-page browsing on hex-index.com — wide net, surface anything plausibly relevant.
- **Digest (50+)** is stricter because section assignment in the premium epub is editorial: a soft 35-score `music` tag shouldn't put a politics article into the Music section. 50+ is the tagging prompt's own "clearly relevant" rubric (`100 = primary topic. 50+ = clearly relevant. Below 30 = not relevant`).

## Re-tagging existing articles
The audit step in migration 021 demotes obvious mismatches but does **not** re-run the LLM. Per the issue checklist, full re-tagging will happen organically on the next scheduled `tag-articles` cycle (every even hour at :15) — that job picks up any article whose tag count is below MIN_TAGS, and the new tags are now in the pool it scores against. No manual job runs from this PR.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (197 passing)
- [ ] After merge: confirm migration 021 applies cleanly on Postgres
- [ ] After next `tag-articles` cycle: spot-check that new articles receive `literature` / `media-criticism` / `nfl` / `nba` / `soccer` / `real-estate` where appropriate
- [ ] After next `build-weekly` (Thu 23:00): verify the Reader epub buckets articles by the stricter 50+ tag and that previously-misclassified music/faith/sports articles no longer appear in those sections