### PR TITLE
feat: strip Trump from titles and commentary (editorial policy)

### DIFF
--- a/src/ingestion/pipeline.ts
+++ b/src/ingestion/pipeline.ts
@@ -6,6 +6,7 @@
 import { fetchFeed } from '../feed/fetcher.js';
 import { FeedItem } from '../feed/types.js';
 import { convertFeedItem, slugify } from '../markdown/converter.js';
+import { normalizeTitle } from '../shared/title-normalizer.js';
 import { storeArticle, articleExists } from '../markdown/storage.js';
 import { LibraryConfig } from '../markdown/types.js';
 import { config } from '../config.js';
@@ -151,7 +152,7 @@ export async function processArticle(
         if (!existing) {
           await createArticle(options.db, {
             publication_id: publicationId,
-            title: item.title,
+            title: normalizeTitle(item.title),
             slug: articleSlug,
             original_url: item.url,
             content_path: stored.path,

--- a/src/markdown/converter.ts
+++ b/src/markdown/converter.ts
@@ -12,6 +12,7 @@ import {
 } from './types.js';
 import { FeedItem } from '../feed/types.js';
 import { countWords, estimateReadTime } from '../feed/parser.js';
+import { normalizeTitle } from '../shared/title-normalizer.js';
 
 // Configure Turndown for clean markdown output
 const turndown = new TurndownService({
@@ -237,7 +238,7 @@ export function convertFeedItem(
   const links = extractLinks(item.contentHtml, item.url);
 
   const metadata: ArticleMetadata = {
-    title: item.title,
+    title: normalizeTitle(item.title),
     author: item.author,
     publication: publication.name,
     publication_slug: publication.slug,

--- a/src/shared/title-normalizer.test.ts
+++ b/src/shared/title-normalizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeTitle } from './title-normalizer.js';
+import { normalizeTitle, stripTrump } from './title-normalizer.js';
 
 describe('normalizeTitle', () => {
   it('fixes ALL CAPS titles', () => {
@@ -71,8 +71,8 @@ describe('normalizeTitle', () => {
   });
 
   it('strips parenthetical asides at end', () => {
-    expect(normalizeTitle('Trump Fires FBI Director (Full Interview)'))
-      .toBe('Trump Fires FBI Director');
+    expect(normalizeTitle('The Administration Fires FBI Director (Full Interview)'))
+      .toBe('The Administration Fires FBI Director');
   });
 
   it('keeps parenthetical in middle of title', () => {
@@ -101,5 +101,56 @@ describe('normalizeTitle', () => {
 
   it('handles whitespace-only string', () => {
     expect(normalizeTitle('   ')).toBe('');
+  });
+});
+
+describe('stripTrump (editorial policy)', () => {
+  it("removes leading possessive \"Trump's\"", () => {
+    expect(stripTrump("Trump's Tiger-Riding Predicament | Digest: March 2026"))
+      .toBe('Tiger-Riding Predicament | Digest: March 2026');
+  });
+
+  it('removes bare "Trump" mid-sentence', () => {
+    expect(stripTrump('What did Trump know about Epstein?'))
+      .toBe('What did know about Epstein?');
+  });
+
+  it('removes "Trump\'s" after a colon', () => {
+    expect(stripTrump("NEW POLL: Trump's approval stuck at record low"))
+      .toBe('NEW POLL: approval stuck at record low');
+  });
+
+  it('removes "Donald Trump" full name', () => {
+    expect(stripTrump('Donald Trump meets with European leaders'))
+      .toBe('meets with European leaders');
+  });
+
+  it("removes \"Donald Trump's\" full possessive", () => {
+    expect(stripTrump("Donald Trump's cabinet picks under fire"))
+      .toBe('cabinet picks under fire');
+  });
+
+  it('is case-insensitive but preserves surrounding casing', () => {
+    expect(stripTrump('TRUMP ANNOUNCES NEW TARIFFS'))
+      .toBe('ANNOUNCES NEW TARIFFS');
+  });
+
+  it('handles em-dash attached: "Trump\u2014" ', () => {
+    expect(stripTrump('Trump\u2014and his allies\u2014push new policy'))
+      .toBe('and his allies\u2014push new policy');
+  });
+
+  it('keeps original if stripping would empty the title', () => {
+    expect(stripTrump('Trump')).toBe('Trump');
+  });
+
+  it("handles curly-apostrophe possessive \"Trump\u2019s\"", () => {
+    expect(stripTrump('Trump\u2019s approval rating falls'))
+      .toBe('approval rating falls');
+  });
+
+  it('does not touch unrelated words like "trumpet"', () => {
+    expect(stripTrump('The trumpet player arrives'))
+      .toBe('The trumpet player arrives');
   });
 });

--- a/src/shared/title-normalizer.ts
+++ b/src/shared/title-normalizer.ts
@@ -2,8 +2,46 @@
  * Normalize article titles — deterministic rules, no LLM needed.
  * Applied at ingestion time and as a one-time backfill.
  */
+/**
+ * Editorial policy: strip "Trump" / "Donald Trump" / possessive and dash-attached
+ * variants from titles. Case-insensitive match, preserves surrounding casing.
+ *
+ * Matches (at word boundaries):
+ *   - "Donald Trump's", "Donald Trump"
+ *   - "Trump's", "Trump\u2019s", "Trump\u2014" (em dash), "Trump-", "Trump"
+ *
+ * Returns the input unchanged if the stripped result is empty (edge case —
+ * caller logs a warning).
+ */
+export function stripTrump(title: string): string {
+  // Order matters: match "Donald Trump" variants before bare "Trump".
+  // Trailing optional possessive ('s / \u2019s) or dash (-, \u2013, \u2014) absorbed
+  // into the match so it gets removed cleanly.
+  const trumpRegex = /\b(?:donald\s+)?trump(?:['\u2019]s|\s*[-\u2013\u2014]|'s)?\b/gi;
+  let out = title.replace(trumpRegex, '');
+
+  // Collapse multiple spaces left by the removal
+  out = out.replace(/\s{2,}/g, ' ');
+
+  // Strip leading/trailing stray punctuation & whitespace left orphaned
+  // (colons, dashes, pipes, commas) — e.g. "| foo" or ": foo"
+  out = out.replace(/^[\s:|\-\u2013\u2014,;]+/, '');
+  out = out.replace(/[\s:|\-\u2013\u2014,;]+$/, '');
+
+  out = out.trim();
+
+  if (out.length === 0 && title.trim().length > 0) {
+    console.warn(`stripTrump: normalization emptied title, keeping original: "${title}"`);
+    return title;
+  }
+  return out;
+}
+
 export function normalizeTitle(title: string): string {
   let t = title.trim();
+
+  // Editorial policy: strip Trump references before any other processing.
+  t = stripTrump(t);
 
   // Strip emoji prefixes (e.g., "🧠 Community Wisdom: ...")
   t = t.replace(/^(?:\p{Emoji_Presentation}|\p{Extended_Pictographic})+\s*/u, '');

--- a/tools/editorial/strip-trump-titles.ts
+++ b/tools/editorial/strip-trump-titles.ts
@@ -1,0 +1,72 @@
+/**
+ * Editorial backfill: strip "Trump" / "Donald Trump" from existing
+ * `app.articles.title` values using the shared normalizeTitle() function
+ * (which now applies stripTrump).
+ *
+ * Usage:
+ *   npx tsx tools/editorial/strip-trump-titles.ts           # dry run (default)
+ *   npx tsx tools/editorial/strip-trump-titles.ts --apply   # perform updates
+ *
+ * Do NOT run this as part of an automated loop — the loop owner will run
+ * it manually after merge.
+ */
+
+import 'dotenv/config';
+import { Pool } from 'pg';
+import { normalizeTitle } from '../../src/shared/title-normalizer.js';
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const apply = args.includes('--apply');
+  const dryRun = !apply;
+
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) {
+    throw new Error('DATABASE_URL required');
+  }
+
+  const pool = new Pool({ connectionString: dbUrl });
+
+  try {
+    const { rows } = await pool.query<{ id: string; title: string }>(
+      `SELECT id, title FROM app.articles WHERE title ~* 'trump' ORDER BY published_at DESC NULLS LAST`,
+    );
+
+    console.info(`Found ${rows.length} articles matching /trump/i`);
+    console.info(dryRun ? '(dry run — no updates will be made)' : '(APPLY mode — updates will be written)');
+    console.info('');
+
+    let changed = 0;
+    let unchanged = 0;
+    for (const row of rows) {
+      const normalized = normalizeTitle(row.title);
+      if (normalized !== row.title) {
+        console.info(`  [${row.id}]`);
+        console.info(`    old: "${row.title}"`);
+        console.info(`    new: "${normalized}"`);
+        changed++;
+        if (apply) {
+          await pool.query('UPDATE app.articles SET title = $1 WHERE id = $2', [
+            normalized,
+            row.id,
+          ]);
+        }
+      } else {
+        unchanged++;
+      }
+    }
+
+    console.info('');
+    console.info(`Summary: ${changed} would change, ${unchanged} unchanged (of ${rows.length} matched)`);
+    if (dryRun && changed > 0) {
+      console.info('Re-run with --apply to write these updates.');
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/tools/jobs/article-rewrite.ts
+++ b/tools/jobs/article-rewrite.ts
@@ -190,6 +190,8 @@ async function main(): Promise<void> {
 
         const prompt = `You are a commentator at a curated reading library. Your readers are smart, busy people who use text-to-speech. Your job: write commentary on this piece that makes them glad they spent 15 minutes with you. You are not rewriting the article — you are commenting on the author's coverage, weaving in direct quotes and paraphrasing throughout.
 
+EDITORIAL POLICY: Do NOT mention "Trump" or "Donald Trump" in your commentary. If the source article centers on Trump's actions or reactions, reframe around the underlying news event, the policy effect, the stakeholders affected, or institutional dynamics. The reader wants analysis of what is happening in the world — not coverage of one politician's personality or reactions. Use "the administration", "the White House", "the executive branch", or the specific agency/official by name when referring to the actions of US government actors.
+
 TITLE: "${article.title}"
 AUTHOR: ${article.author_name ?? 'Unknown'}
 PUBLICATION: ${article.publication_name}

--- a/tools/jobs/yt-ingest.ts
+++ b/tools/jobs/yt-ingest.ts
@@ -13,6 +13,7 @@ import { readFile, writeFile, mkdir } from 'fs/promises';
 import { readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { execSync } from 'child_process';
+import { normalizeTitle } from '../../src/shared/title-normalizer.js';
 
 
 // ── CLI args ────────────────────────────────────────────────────────
@@ -244,7 +245,7 @@ async function main(): Promise<void> {
              VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'text', $11, $12)`,
             [
               pubId,
-              info.title,
+              normalizeTitle(info.title),
               articleSlug,
               videoUrl,
               contentPath,


### PR DESCRIPTION
## Summary

Standing editorial policy: titles and Qwen commentary must not mention "Trump" or "Donald Trump". Focus on the news, not one politician's personality or reactions.

Per Brian's directive: "three changes required, in one PR".

### 1. Title cleanup at ingest time
- New `stripTrump()` function in `src/shared/title-normalizer.ts`, called from `normalizeTitle()` before any other transforms.
- Removes `Trump`, `Trump's` (straight or curly apostrophe), `Donald Trump`, `Donald Trump's`, and dash-attached variants (`Trump—`, `Trump-`), case-insensitive, preserving surrounding casing.
- Collapses resulting double spaces; trims orphaned leading/trailing punctuation (colons, dashes, pipes, commas).
- If the result is empty (e.g. bare title was just "Trump"), keeps the original and logs a warning — per directive's explicit edge case.
- Wired into Substack ingest via `convertFeedItem()` and `pipeline.createArticle()`, and into YouTube ingest via `tools/jobs/yt-ingest.ts`.
- 10 new unit tests covering the directive's examples and edge cases (curly apostrophe, em-dash attached, "trumpet" false positive, empty-result fallback, ALL-CAPS preserving case, full possessive name).

**The regex used:**
```js
/\b(?:donald\s+)?trump(?:['\u2019]s|\s*[-\u2013\u2014]|'s)?\b/gi
```

### 2. Qwen article-rewrite prompt update
Added an explicit `EDITORIAL POLICY` block near the top of the system prompt in `tools/jobs/article-rewrite.ts` instructing the model to reframe Trump-centric coverage around the underlying news event, policy effect, stakeholders, or institutional dynamics — using "the administration", "the White House", "the executive branch", or the specific agency/official by name.

### 3. Backfill script
New `tools/editorial/strip-trump-titles.ts`:
- Selects `app.articles` where `title ~* 'trump'`
- Applies the shared `normalizeTitle()` (so logic stays in one place)
- Prints a diff summary per row (old → new)
- `--dry-run` is the default; `--apply` performs updates
- **Not run** by this PR — the loop owner runs it manually after merge.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 210 passed (12 files), including the 10 new `stripTrump` cases
- [ ] After merge: run `npx tsx tools/editorial/strip-trump-titles.ts` to preview, then `--apply` to backfill, then `npm run static:generate -- --only home,tags,articles` to refresh docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)