### PR TITLE
feat: truncate Wikipedia deep dives to 3 paragraphs in epub (closes #454)

### DIFF
--- a/tools/static-site/pages/epub-helpers.test.ts
+++ b/tools/static-site/pages/epub-helpers.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { truncateDeepDive } from './epub-helpers.js';
+
+const URL = 'https://hex-index.com/wikipedia/example-topic/';
+
+describe('truncateDeepDive', () => {
+  it('returns only the read-more link for zero-paragraph input', () => {
+    const out = truncateDeepDive('', 3, URL);
+    expect(out).toContain('Read full deep dive');
+    expect(out).toContain(URL);
+    expect(out).not.toContain('<p>Body');
+  });
+
+  it('returns empty string for empty input with no url', () => {
+    expect(truncateDeepDive('', 3)).toBe('');
+  });
+
+  it('keeps a single paragraph when only one exists (no padding)', () => {
+    const html = '<p>Only one.</p>';
+    const out = truncateDeepDive(html, 3, URL);
+    expect(out).toContain('<p>Only one.</p>');
+    expect(out).toContain('Read full deep dive');
+    // Only one <p> from the source; read-more adds exactly one more.
+    expect(out.match(/<p\b/g)?.length).toBe(2);
+  });
+
+  it('keeps exactly three paragraphs when three exist', () => {
+    const html = '<p>One.</p><p>Two.</p><p>Three.</p>';
+    const out = truncateDeepDive(html, 3, URL);
+    expect(out).toContain('<p>One.</p>');
+    expect(out).toContain('<p>Two.</p>');
+    expect(out).toContain('<p>Three.</p>');
+    expect(out).toContain('Read full deep dive');
+  });
+
+  it('truncates five paragraphs down to three and drops the rest', () => {
+    const html =
+      '<p>One.</p><p>Two.</p><p>Three.</p><p>Four.</p><p>Five.</p>';
+    const out = truncateDeepDive(html, 3, URL);
+    expect(out).toContain('<p>One.</p>');
+    expect(out).toContain('<p>Two.</p>');
+    expect(out).toContain('<p>Three.</p>');
+    expect(out).not.toContain('<p>Four.</p>');
+    expect(out).not.toContain('<p>Five.</p>');
+    // 3 source paragraphs + 1 read-more.
+    expect(out.match(/<p\b/g)?.length).toBe(4);
+  });
+
+  it('preserves a heading that appears before the paragraphs', () => {
+    const html =
+      '<h2>Origins</h2><p>One.</p><p>Two.</p><p>Three.</p><p>Four.</p>';
+    const out = truncateDeepDive(html, 3, URL);
+    expect(out).toContain('<h2>Origins</h2>');
+    expect(out).toContain('<p>One.</p>');
+    expect(out).toContain('<p>Three.</p>');
+    expect(out).not.toContain('<p>Four.</p>');
+    // Heading comes before first paragraph.
+    expect(out.indexOf('<h2>')).toBeLessThan(out.indexOf('<p>One.'));
+  });
+
+  it('does not count <p> nested inside lists or blockquotes', () => {
+    const html =
+      '<p>Top one.</p>' +
+      '<blockquote><p>Nested quote p.</p></blockquote>' +
+      '<p>Top two.</p>' +
+      '<ul><li><p>Nested list p.</p></li></ul>' +
+      '<p>Top three.</p>' +
+      '<p>Top four (should drop).</p>';
+    const out = truncateDeepDive(html, 3, URL);
+    expect(out).toContain('<p>Top one.</p>');
+    expect(out).toContain('<p>Top two.</p>');
+    expect(out).toContain('<p>Top three.</p>');
+    expect(out).not.toContain('Top four');
+    // The nested <blockquote> appears before the 3rd top-level <p>, so it
+    // is preserved in place as non-paragraph top-level content.
+    expect(out).toContain('<blockquote>');
+  });
+
+  it('omits the read-more link when no url is provided', () => {
+    const html = '<p>One.</p><p>Two.</p>';
+    const out = truncateDeepDive(html, 3);
+    expect(out).not.toContain('Read full deep dive');
+    expect(out).toContain('<p>One.</p>');
+    expect(out).toContain('<p>Two.</p>');
+  });
+
+  it('respects a custom maxParagraphs value', () => {
+    const html = '<p>One.</p><p>Two.</p><p>Three.</p>';
+    const out = truncateDeepDive(html, 1, URL);
+    expect(out).toContain('<p>One.</p>');
+    expect(out).not.toContain('<p>Two.</p>');
+    expect(out).not.toContain('<p>Three.</p>');
+  });
+});

--- a/tools/static-site/pages/epub-helpers.ts
+++ b/tools/static-site/pages/epub-helpers.ts
@@ -1,0 +1,151 @@
+/**
+ * Helpers for the weekly epub renderer.
+ *
+ * Wikipedia deep dives live in full on the public static site and in the
+ * private library. Inside the weekly Reader epub we truncate them to the
+ * first few top-level paragraphs and link out to the full rewrite. See #454.
+ */
+
+/**
+ * Truncate a Wikipedia deep-dive HTML fragment to the first `maxParagraphs`
+ * top-level `<p>` elements.
+ *
+ * Rules:
+ * - Counts only top-level `<p>` tags; `<p>` nested inside lists, blockquotes,
+ *   or other block elements does not count and is not preserved.
+ * - Headings (`<h1>`–`<h6>`) and other top-level non-paragraph content that
+ *   appear BEFORE the cutoff paragraph are preserved in place.
+ * - Everything after the Nth top-level `<p>` is dropped.
+ * - If fewer than `maxParagraphs` exist, the entire available content is kept
+ *   (no padding).
+ * - A "Read full deep dive" link to `readMoreUrl` is appended when provided.
+ *
+ * Pure function — no DOM, no I/O. Uses a lightweight regex tokenizer that is
+ * good enough for the Qwen-generated fragments we emit (simple well-formed
+ * markup: h2/h3, p, ul/li, blockquote, em/strong).
+ */
+export function truncateDeepDive(
+  html: string,
+  maxParagraphs: number = 3,
+  readMoreUrl?: string
+): string {
+  if (!html) {
+    return readMoreUrl ? renderReadMore(readMoreUrl) : '';
+  }
+
+  const tokens = tokenizeTopLevel(html);
+  const kept: string[] = [];
+  let paraCount = 0;
+
+  for (const tok of tokens) {
+    if (tok.kind === 'p') {
+      if (paraCount >= maxParagraphs) {
+        break;
+      }
+      kept.push(tok.raw);
+      paraCount++;
+      continue;
+    }
+    // Non-<p> top-level content (headings, etc.): keep only if we still have
+    // budget for more paragraphs — otherwise we'd be leaving trailing headings
+    // with no body.
+    if (paraCount >= maxParagraphs) {
+      break;
+    }
+    kept.push(tok.raw);
+  }
+
+  const body = kept.join('').trim();
+  if (!readMoreUrl) {
+    return body;
+  }
+  return `${body}${body ? '\n' : ''}${renderReadMore(readMoreUrl)}`;
+}
+
+function renderReadMore(url: string): string {
+  return `<p class="deep-dive-read-more">Read full deep dive: <a href="${escapeAttr(url)}">${escapeText(url)}</a></p>`;
+}
+
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+function escapeText(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+interface TopToken {
+  kind: 'p' | 'other';
+  raw: string;
+}
+
+/**
+ * Walk the HTML fragment tracking nesting depth so that only top-level tags
+ * are classified. Text between top-level tags is attached to 'other' tokens.
+ */
+function tokenizeTopLevel(html: string): TopToken[] {
+  const tokens: TopToken[] = [];
+  const tagRe = /<(\/?)([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/g;
+
+  let depth = 0;
+  let topStart = -1;
+  let topTag: string | null = null;
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tagRe.exec(html)) !== null) {
+    const [full, slash, rawName] = match;
+    const name = rawName.toLowerCase();
+    const isClose = slash === '/';
+    const isSelfClosing = full.endsWith('/>') || VOID_ELEMENTS.has(name);
+    const start = match.index;
+    const end = start + full.length;
+
+    if (depth === 0 && !isClose) {
+      // Starting a new top-level element.
+      topStart = start;
+      topTag = name;
+      if (isSelfClosing) {
+        tokens.push({
+          kind: name === 'p' ? 'p' : 'other',
+          raw: html.slice(topStart, end),
+        });
+        topStart = -1;
+        topTag = null;
+        cursor = end;
+        continue;
+      }
+      depth = 1;
+      cursor = end;
+      continue;
+    }
+
+    if (!isClose && !isSelfClosing) {
+      depth++;
+      continue;
+    }
+
+    if (isClose) {
+      depth--;
+      if (depth === 0 && topStart >= 0) {
+        tokens.push({
+          kind: topTag === 'p' ? 'p' : 'other',
+          raw: html.slice(topStart, end),
+        });
+        topStart = -1;
+        topTag = null;
+        cursor = end;
+      }
+    }
+  }
+
+  // Trailing whitespace/text outside any tag is ignored — the upstream
+  // Qwen output is always tag-wrapped.
+  void cursor;
+  return tokens;
+}
+
+const VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+  'link', 'meta', 'param', 'source', 'track', 'wbr',
+]);

--- a/tools/static-site/pages/weekly.ts
+++ b/tools/static-site/pages/weekly.ts
@@ -14,6 +14,7 @@ import { readFile, stat } from 'fs/promises';
 import archiver from 'archiver';
 import { createWriteStream, existsSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
+import { truncateDeepDive } from './epub-helpers.js';
 
 // Placeholder — fill in when Brian creates the Google Sheet
 const SUBSCRIBE_URL = 'https://script.google.com/macros/s/AKfycbw484H_YXlBlQ5lFGmz4-6nOls4jEBU5lWGL3yf5ZTQpyihux47AcwZ2MN2F1R9eFfoxw/exec';
@@ -594,15 +595,20 @@ ${navTocHtml}    </ol>
           imageHtml = `<img src="../images/${imgId}.${article.imageExt}" alt="${escapeXml(article.row.title)}" />`;
         }
 
-        // Deep dives
+        // Deep dives — truncated to first 3 top-level paragraphs inside the
+        // epub with a link out to the full rewrite on hex-index.com (#454).
+        // The public static site and private library continue to render the
+        // full deep-dive content; only the epub is trimmed.
         let deepDiveHtml = '';
         for (const dd of article.deepDives) {
           if (dd.content) {
+            const fullUrl = `https://hex-index.com/wikipedia/${dd.slug}/`;
+            const trimmed = truncateDeepDive(dd.content, 3, fullUrl);
             deepDiveHtml += `
   <div class="deep-dive">
     <p class="deep-dive-label">Deep Dive</p>
     <h3>${escapeXml(dd.title)}</h3>
-    ${htmlToXhtml(dd.content)}
+    ${htmlToXhtml(trimmed)}
   </div>`;
           }
         }


### PR DESCRIPTION
## Summary
- Adds pure `truncateDeepDive(html, maxParagraphs = 3, readMoreUrl?)` helper in `tools/static-site/pages/epub-helpers.ts` that keeps only top-level `<p>` elements (ignoring `<p>` nested in lists/blockquotes), preserves headings that appear before the cutoff, and appends a "Read full deep dive" link.
- Wires it into the weekly epub renderer (`tools/static-site/pages/weekly.ts`) so each Wikipedia deep-dive section in the epub is trimmed to the first 3 paragraphs with a link to `https://hex-index.com/wikipedia/{slug}/`.
- Static site and private library rendering are untouched — they still show full deep-dive content.

Closes #454.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 209 passed (13 files), 9 new cases in `epub-helpers.test.ts` covering 0/1/3/5 paragraphs, custom maxParagraphs, nested `<p>` in lists/blockquotes, heading preserved, no-url mode
- [ ] Spot-check next weekly epub after `build-weekly` runs

Generated with Claude Code