### PR TITLE
feat: consolidation candidate detection (closes #451)

### DIFF
--- a/tools/editorial/consolidation-candidates.test.ts
+++ b/tools/editorial/consolidation-candidates.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type Article,
+  type CandidateGroup,
+  type QueryableDb,
+  MAX_GROUP_SIZE,
+  buildTitleTfIdf,
+  findConsolidationCandidates,
+  groupArticles,
+  jaccard,
+  tokenizeTitle,
+} from './consolidation-candidates.js';
+
+const day = 24 * 60 * 60 * 1000;
+const T0 = new Date('2026-04-01T12:00:00Z').getTime();
+
+function mk(
+  id: string,
+  title: string,
+  pub: string,
+  tags: string[],
+  offsetDays = 0,
+  word_count: number | null = 800,
+): Article {
+  return {
+    id,
+    title,
+    publication_id: pub,
+    publication_name: `Pub-${pub}`,
+    created_at: new Date(T0 + offsetDays * day),
+    word_count,
+    tags,
+  };
+}
+
+describe('jaccard', () => {
+  it('returns 1 for identical sets', () => {
+    expect(jaccard(new Set(['a', 'b']), new Set(['a', 'b']))).toBe(1);
+  });
+  it('returns 0 for disjoint sets', () => {
+    expect(jaccard(new Set(['a']), new Set(['b']))).toBe(0);
+  });
+  it('handles partial overlap', () => {
+    expect(jaccard(new Set(['a', 'b']), new Set(['b', 'c']))).toBeCloseTo(1 / 3);
+  });
+});
+
+describe('tokenizeTitle', () => {
+  it('lowercases and strips stopwords and punctuation', () => {
+    const toks = tokenizeTitle('The Battle of Thermopylae, Revisited!');
+    expect(toks).toEqual(['battle', 'thermopylae', 'revisited']);
+  });
+});
+
+describe('buildTitleTfIdf', () => {
+  it('gives high similarity to near-identical titles', () => {
+    const sim = buildTitleTfIdf([
+      'China tightens export controls on rare earths',
+      'China tightens export controls on rare earth metals',
+      'Silicon Valley banks face new regulations',
+    ]);
+    expect(sim(0, 1)).toBeGreaterThan(0.6);
+    expect(sim(0, 2)).toBeLessThan(0.3);
+  });
+});
+
+describe('groupArticles', () => {
+  it('groups 3 clear pairs and ignores 3 singletons', () => {
+    // 3 pairs: china, climate, ai — each from 2 different publications.
+    // 3 singletons on unrelated topics.
+    const articles: Article[] = [
+      mk('a1', 'China tightens rare earth export controls', 'sinification',
+        ['china', 'geopolitics', 'trade'], 0),
+      mk('a2', 'China tightens rare earth export rules', 'chinatalk',
+        ['china', 'geopolitics', 'trade'], 1),
+
+      mk('b1', 'Arctic sea ice hits new record low', 'climatewire',
+        ['climate', 'arctic', 'science'], 0),
+      mk('b2', 'Arctic sea ice hits a new record low', 'carbonbrief',
+        ['climate', 'arctic', 'science'], 2),
+
+      mk('c1', 'OpenAI releases new reasoning model GPT', 'stratechery',
+        ['ai', 'openai', 'tech'], 0),
+      mk('c2', 'OpenAI releases new reasoning model GPT', 'platformer',
+        ['ai', 'openai', 'tech'], 3),
+
+      mk('s1', 'Obscure jazz pianist dies at 92', 'npr',
+        ['music', 'obituary'], 0),
+      mk('s2', 'Rare Roman coin found in English field', 'bbc',
+        ['archaeology', 'history'], 1),
+      mk('s3', 'New bakery opens in Brooklyn', 'eater',
+        ['food', 'nyc'], 2),
+    ];
+
+    const groups = groupArticles(articles);
+    expect(groups.length).toBe(3);
+    // Each group should have exactly 2 articles.
+    for (const g of groups) {
+      expect(g.articles.length).toBe(2);
+    }
+    // Each group's two articles should share the same topic.
+    const byTag = groups.map(g => g.articles.map(a => a.id).sort().join(','));
+    expect(byTag).toContain('a1,a2');
+    expect(byTag).toContain('b1,b2');
+    expect(byTag).toContain('c1,c2');
+  });
+
+  it('caps group size at 4 when 5 articles all match', () => {
+    const tags = ['china', 'geopolitics', 'trade'];
+    // Near-identical titles so every pair clears the title threshold.
+    const title = 'China tightens rare earth export controls';
+    const articles: Article[] = [
+      mk('x1', title, 'pub1', tags, 0),
+      mk('x2', title, 'pub2', tags, 1),
+      mk('x3', title, 'pub3', tags, 2),
+      mk('x4', title, 'pub4', tags, 3),
+      mk('x5', title, 'pub5', tags, 4),
+    ];
+
+    const groups = groupArticles(articles);
+    // First group should be capped at 4. The 5th article is leftover.
+    expect(groups.length).toBeGreaterThanOrEqual(1);
+    const primary = groups[0];
+    expect(primary.articles.length).toBe(MAX_GROUP_SIZE);
+
+    const allGrouped = new Set<string>();
+    for (const g of groups) {
+      for (const a of g.articles) { allGrouped.add(a.id); }
+    }
+    // At least one of the 5 is reported separately or left out of the cap.
+    expect(allGrouped.size).toBeLessThanOrEqual(5);
+    expect(primary.articles.length).toBe(4);
+  });
+
+  it('rejects same-publication pairs', () => {
+    const articles: Article[] = [
+      mk('s1', 'China tightens rare earth export controls', 'same-pub',
+        ['china', 'geopolitics', 'trade'], 0),
+      mk('s2', 'China tightens rare earth export rules new', 'same-pub',
+        ['china', 'geopolitics', 'trade'], 1),
+    ];
+    expect(groupArticles(articles)).toEqual([]);
+  });
+
+  it('rejects pairs beyond 14-day window', () => {
+    const articles: Article[] = [
+      mk('t1', 'China tightens rare earth export controls', 'pub1',
+        ['china', 'geopolitics', 'trade'], 0),
+      mk('t2', 'China tightens rare earth export rules', 'pub2',
+        ['china', 'geopolitics', 'trade'], 20),
+    ];
+    expect(groupArticles(articles)).toEqual([]);
+  });
+
+  it('primary suggestion prefers highest word count', () => {
+    const articles: Article[] = [
+      mk('w1', 'China tightens rare earth export controls', 'pub1',
+        ['china', 'geopolitics', 'trade'], 0, 500),
+      mk('w2', 'China tightens rare earth export rules', 'pub2',
+        ['china', 'geopolitics', 'trade'], 1, 2500),
+    ];
+    const groups = groupArticles(articles);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].primarySuggestion).toBe('w2');
+  });
+
+  it('reasoning lists shared tags and sources', () => {
+    const articles: Article[] = [
+      mk('r1', 'China tightens rare earth export controls', 'sinification',
+        ['china', 'geopolitics', 'trade'], 0),
+      mk('r2', 'China tightens rare earth export rules', 'chinatalk',
+        ['china', 'geopolitics', 'trade'], 1),
+    ];
+    const [g] = groupArticles(articles);
+    expect(g.reasoning).toContain('china');
+    expect(g.reasoning).toContain('Pub-sinification');
+    expect(g.reasoning).toContain('Pub-chinatalk');
+    expect(g.reasoning).toContain('title sim');
+  });
+});
+
+describe('findConsolidationCandidates (fake db)', () => {
+  it('collapses tag rows and groups correctly', async () => {
+    const iso = (off: number): string =>
+      new Date(T0 + off * day).toISOString();
+
+    const rows = [
+      { id: 'a1', title: 'China tightens rare earth export controls',
+        publication_id: 'p1', publication_name: 'Sinification',
+        created_at: iso(0), word_count: 1200, tag_slug: 'china' },
+      { id: 'a1', title: 'China tightens rare earth export controls',
+        publication_id: 'p1', publication_name: 'Sinification',
+        created_at: iso(0), word_count: 1200, tag_slug: 'geopolitics' },
+      { id: 'a1', title: 'China tightens rare earth export controls',
+        publication_id: 'p1', publication_name: 'Sinification',
+        created_at: iso(0), word_count: 1200, tag_slug: 'trade' },
+      { id: 'a2', title: 'China tightens rare earth export rules',
+        publication_id: 'p2', publication_name: 'ChinaTalk',
+        created_at: iso(1), word_count: 900, tag_slug: 'china' },
+      { id: 'a2', title: 'China tightens rare earth export rules',
+        publication_id: 'p2', publication_name: 'ChinaTalk',
+        created_at: iso(1), word_count: 900, tag_slug: 'geopolitics' },
+      { id: 'a2', title: 'China tightens rare earth export rules',
+        publication_id: 'p2', publication_name: 'ChinaTalk',
+        created_at: iso(1), word_count: 900, tag_slug: 'trade' },
+    ];
+
+    const fakeDb: QueryableDb = {
+      query: <T extends Record<string, unknown>>() =>
+        Promise.resolve({ rows: rows as unknown as T[] }),
+    };
+
+    const groups: CandidateGroup[] = await findConsolidationCandidates(fakeDb, { days: 14 });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].articles.map(a => a.id).sort()).toEqual(['a1', 'a2']);
+    expect(groups[0].primarySuggestion).toBe('a1');
+  });
+
+  it('falls back when consolidated_into column does not exist', async () => {
+    let calls = 0;
+    const fakeDb: QueryableDb = {
+      query: <T extends Record<string, unknown>>(sql: string) => {
+        calls++;
+        if (sql.includes('consolidated_into')) {
+          return Promise.reject(new Error('column "consolidated_into" does not exist'));
+        }
+        return Promise.resolve({ rows: [] as unknown as T[] });
+      },
+    };
+    const groups = await findConsolidationCandidates(fakeDb);
+    expect(groups).toEqual([]);
+    expect(calls).toBe(2);
+  });
+});

--- a/tools/editorial/consolidation-candidates.ts
+++ b/tools/editorial/consolidation-candidates.ts
@@ -1,0 +1,443 @@
+/**
+ * Consolidation candidate detection (issue #451).
+ *
+ * Pure, importable module that groups recent articles into candidate sets
+ * of 2–4 that are about the same story AND offer diverse takes (from
+ * different publications).
+ *
+ * Scoring thresholds (tunable at the top of the file):
+ *   - TOPIC_JACCARD_MIN   ≥ 0.5  — tag Jaccard similarity
+ *   - TITLE_COSINE_MIN    ≥ 0.6  — title TF-IDF cosine similarity
+ *   - TIME_WINDOW_DAYS    ≤ 14   — created_at proximity
+ *   - MAX_GROUP_SIZE      4      — hard cap per group
+ *
+ * Publication distinctness is required: same-publication pairs are
+ * rejected as follow-ups rather than "diverse voices".
+ *
+ * CLI usage (preview only — no DB mutation):
+ *   npx tsx tools/editorial/consolidation-candidates.ts --preview
+ *   npx tsx tools/editorial/consolidation-candidates.ts --preview --days 21 --limit 200
+ */
+
+// ── Tunable thresholds ──────────────────────────────────────────────
+export const TOPIC_JACCARD_MIN = 0.5;
+export const TITLE_COSINE_MIN = 0.6;
+export const TIME_WINDOW_DAYS = 14;
+export const MAX_GROUP_SIZE = 4;
+
+// ── Types ───────────────────────────────────────────────────────────
+export interface Article {
+  id: string;
+  title: string;
+  publication_id: string;
+  publication_name?: string;
+  created_at: Date;
+  word_count: number | null;
+  tags: string[];
+}
+
+export interface CandidateGroup {
+  articles: Article[];        // sorted by created_at asc
+  score: number;              // average pairwise combined score
+  primarySuggestion: string;  // article id
+  reasoning: string;          // human-readable summary
+}
+
+export interface FindOptions {
+  /** Look-back window in days for candidate pool (default 14). */
+  days?: number;
+  /** Hard cap on pool size (default 500). */
+  limit?: number;
+}
+
+/** Minimal DB interface so tests can pass a fake. */
+export interface QueryableDb {
+  query: <T extends Record<string, unknown> = Record<string, unknown>>(
+    sql: string,
+    params?: unknown[],
+  ) => Promise<{ rows: T[] }>;
+}
+
+// ── Similarity helpers ──────────────────────────────────────────────
+
+/** Jaccard similarity between two sets of strings. */
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) { return 0; }
+  let intersect = 0;
+  for (const x of a) {
+    if (b.has(x)) { intersect++; }
+  }
+  const union = a.size + b.size - intersect;
+  return union === 0 ? 0 : intersect / union;
+}
+
+const STOPWORDS = new Set([
+  'a', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'for', 'from',
+  'has', 'have', 'he', 'her', 'his', 'in', 'is', 'it', 'its', 'of',
+  'on', 'or', 'that', 'the', 'to', 'was', 'were', 'will', 'with',
+  'but', 'not', 'this', 'they', 'their', 'them', 'we', 'you', 'i',
+  'our', 'my', 'your', 'who', 'what', 'when', 'where', 'why', 'how',
+  'into', 'about', 'over', 'under', 'than', 'then', 'so', 'if',
+]);
+
+export function tokenizeTitle(title: string): string[] {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(w => w.length > 1 && !STOPWORDS.has(w));
+}
+
+/**
+ * Build a TF-IDF corpus from titles and return a function that computes
+ * cosine similarity between any two title indices.
+ */
+export function buildTitleTfIdf(titles: string[]): (i: number, j: number) => number {
+  const docs = titles.map(tokenizeTitle);
+  const N = docs.length;
+
+  // Document frequency
+  const df = new Map<string, number>();
+  for (const doc of docs) {
+    const seen = new Set(doc);
+    for (const term of seen) {
+      df.set(term, (df.get(term) ?? 0) + 1);
+    }
+  }
+
+  // Per-doc TF-IDF vector
+  const vectors: Map<string, number>[] = docs.map(doc => {
+    const tf = new Map<string, number>();
+    for (const term of doc) {
+      tf.set(term, (tf.get(term) ?? 0) + 1);
+    }
+    const vec = new Map<string, number>();
+    for (const [term, count] of tf) {
+      const idf = Math.log((N + 1) / ((df.get(term) ?? 0) + 1)) + 1;
+      vec.set(term, count * idf);
+    }
+    return vec;
+  });
+
+  // Pre-compute norms
+  const norms: number[] = vectors.map(v => {
+    let s = 0;
+    for (const w of v.values()) { s += w * w; }
+    return Math.sqrt(s);
+  });
+
+  return (i: number, j: number): number => {
+    const a = vectors[i];
+    const b = vectors[j];
+    if (!a || !b) { return 0; }
+    if (norms[i] === 0 || norms[j] === 0) { return 0; }
+    // Iterate the smaller vector.
+    const [small, big] = a.size <= b.size ? [a, b] : [b, a];
+    let dot = 0;
+    for (const [term, w] of small) {
+      const bw = big.get(term);
+      if (bw !== undefined) { dot += w * bw; }
+    }
+    return dot / (norms[i] * norms[j]);
+  };
+}
+
+// ── Core grouping ───────────────────────────────────────────────────
+
+interface ScoredPair {
+  i: number;
+  j: number;
+  topic: number;
+  title: number;
+  combined: number; // normalized sum / 2
+}
+
+/**
+ * Compute all passing pairs then greedily assemble groups capped at
+ * MAX_GROUP_SIZE. Exported for testability.
+ */
+export function groupArticles(articles: Article[]): CandidateGroup[] {
+  if (articles.length < 2) { return []; }
+
+  const tagSets = articles.map(a => new Set(a.tags));
+  const titleSim = buildTitleTfIdf(articles.map(a => a.title));
+  const timeMs = TIME_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+  const pairs: ScoredPair[] = [];
+  for (let i = 0; i < articles.length; i++) {
+    for (let j = i + 1; j < articles.length; j++) {
+      const A = articles[i];
+      const B = articles[j];
+      if (A.publication_id === B.publication_id) { continue; }
+      if (Math.abs(A.created_at.getTime() - B.created_at.getTime()) > timeMs) { continue; }
+      const topic = jaccard(tagSets[i], tagSets[j]);
+      if (topic < TOPIC_JACCARD_MIN) { continue; }
+      const title = titleSim(i, j);
+      if (title < TITLE_COSINE_MIN) { continue; }
+      pairs.push({ i, j, topic, title, combined: (topic + title) / 2 });
+    }
+  }
+
+  pairs.sort((a, b) => b.combined - a.combined);
+
+  // Greedy assembly. groupOf[idx] = group index or -1.
+  const groupOf = new Array<number>(articles.length).fill(-1);
+  const groups: number[][] = [];
+
+  const pairScore = new Map<string, number>();
+  const pairKey = (a: number, b: number): string => a < b ? `${a}:${b}` : `${b}:${a}`;
+  for (const p of pairs) {
+    pairScore.set(pairKey(p.i, p.j), p.combined);
+  }
+
+  const allPairwisePass = (idx: number, members: number[]): boolean => {
+    for (const m of members) {
+      if (!pairScore.has(pairKey(idx, m))) { return false; }
+    }
+    return true;
+  };
+
+  const pubsInGroup = (members: number[]): Set<string> => {
+    const s = new Set<string>();
+    for (const m of members) { s.add(articles[m].publication_id); }
+    return s;
+  };
+
+  for (const p of pairs) {
+    const gi = groupOf[p.i];
+    const gj = groupOf[p.j];
+
+    if (gi === -1 && gj === -1) {
+      const idx = groups.length;
+      groups.push([p.i, p.j]);
+      groupOf[p.i] = idx;
+      groupOf[p.j] = idx;
+      continue;
+    }
+
+    // Exactly one in a group — try to add the other.
+    if (gi !== -1 && gj === -1) {
+      const members = groups[gi];
+      if (members.length >= MAX_GROUP_SIZE) { continue; }
+      if (pubsInGroup(members).has(articles[p.j].publication_id)) { continue; }
+      if (!allPairwisePass(p.j, members)) { continue; }
+      members.push(p.j);
+      groupOf[p.j] = gi;
+      continue;
+    }
+    if (gj !== -1 && gi === -1) {
+      const members = groups[gj];
+      if (members.length >= MAX_GROUP_SIZE) { continue; }
+      if (pubsInGroup(members).has(articles[p.i].publication_id)) { continue; }
+      if (!allPairwisePass(p.i, members)) { continue; }
+      members.push(p.i);
+      groupOf[p.i] = gj;
+      continue;
+    }
+    // Both already grouped — skip (no merging across existing groups).
+  }
+
+  // Build CandidateGroup[]
+  const result: CandidateGroup[] = [];
+  for (const members of groups) {
+    if (members.length < 2) { continue; }
+    const sorted = [...members].sort((a, b) =>
+      articles[a].created_at.getTime() - articles[b].created_at.getTime(),
+    );
+    const groupArticles = sorted.map(idx => articles[idx]);
+
+    // Average pairwise combined score.
+    let sum = 0;
+    let count = 0;
+    for (let a = 0; a < sorted.length; a++) {
+      for (let b = a + 1; b < sorted.length; b++) {
+        const s = pairScore.get(pairKey(sorted[a], sorted[b]));
+        if (s !== undefined) { sum += s; count++; }
+      }
+    }
+    const score = count > 0 ? sum / count : 0;
+
+    // Primary suggestion: highest word count, tiebreak on most recent.
+    const primary = [...groupArticles].sort((a, b) => {
+      const wa = a.word_count ?? 0;
+      const wb = b.word_count ?? 0;
+      if (wb !== wa) { return wb - wa; }
+      return b.created_at.getTime() - a.created_at.getTime();
+    })[0];
+
+    // Reasoning: shared tags, average title sim, source list.
+    const sharedTags = sorted
+      .map(idx => new Set(articles[idx].tags))
+      .reduce<Set<string> | null>((acc, s) => {
+        if (acc === null) { return new Set(s); }
+        const out = new Set<string>();
+        for (const t of acc) { if (s.has(t)) { out.add(t); } }
+        return out;
+      }, null) ?? new Set<string>();
+
+    // Average title sim across pairs (from pairScore we only have combined, so
+    // recompute title sims for the reasoning line).
+    const titleSimFn = buildTitleTfIdf(groupArticles.map(a => a.title));
+    let titleSumLocal = 0;
+    let titleCountLocal = 0;
+    for (let a = 0; a < groupArticles.length; a++) {
+      for (let b = a + 1; b < groupArticles.length; b++) {
+        titleSumLocal += titleSimFn(a, b);
+        titleCountLocal++;
+      }
+    }
+    const avgTitleSim = titleCountLocal > 0 ? titleSumLocal / titleCountLocal : 0;
+
+    const sources = groupArticles
+      .map(a => a.publication_name ?? a.publication_id)
+      .join(', ');
+    const tagList = [...sharedTags].slice(0, 5).join(', ') || '(none)';
+
+    const reasoning =
+      `shared tags: ${tagList}; title sim ${avgTitleSim.toFixed(2)}; sources: ${sources}`;
+
+    result.push({
+      articles: groupArticles,
+      score,
+      primarySuggestion: primary.id,
+      reasoning,
+    });
+  }
+
+  // Sort output groups by score desc for stable presentation.
+  result.sort((a, b) => b.score - a.score);
+  return result;
+}
+
+// ── DB entrypoint ───────────────────────────────────────────────────
+
+interface DbRow extends Record<string, unknown> {
+  id: string;
+  title: string;
+  publication_id: string;
+  publication_name: string | null;
+  created_at: Date | string;
+  word_count: number | null;
+  tag_slug: string | null;
+}
+
+export async function findConsolidationCandidates(
+  db: QueryableDb,
+  opts: FindOptions = {},
+): Promise<CandidateGroup[]> {
+  const days = opts.days ?? TIME_WINDOW_DAYS;
+  const limit = opts.limit ?? 500;
+
+  // Pool: articles created within the window. The `consolidated_into`
+  // column is introduced in #448; we filter on it only if it exists
+  // (detected by a try/catch fallback) to avoid a hard dependency.
+  const baseSelect = `
+    SELECT a.id, a.title, a.publication_id,
+           p.name AS publication_name,
+           a.created_at, a.word_count,
+           at.tag_slug
+    FROM app.articles a
+    JOIN app.publications p ON a.publication_id = p.id
+    LEFT JOIN app.article_tags at ON at.article_id = a.id
+  `;
+  const whereRecent = `WHERE a.created_at >= NOW() - ($1 || ' days')::interval`;
+  const order = `ORDER BY a.created_at DESC`;
+
+  let rows: DbRow[];
+  try {
+    const sql = `${baseSelect} ${whereRecent} AND a.consolidated_into IS NULL ${order}`;
+    const res = await db.query<DbRow>(sql, [String(days)]);
+    rows = res.rows;
+  } catch {
+    const sql = `${baseSelect} ${whereRecent} ${order}`;
+    const res = await db.query<DbRow>(sql, [String(days)]);
+    rows = res.rows;
+  }
+
+  // Collapse per article id, gathering tags.
+  const byId = new Map<string, Article>();
+  for (const r of rows) {
+    let a = byId.get(r.id);
+    if (!a) {
+      a = {
+        id: r.id,
+        title: r.title,
+        publication_id: r.publication_id,
+        publication_name: r.publication_name ?? undefined,
+        created_at: r.created_at instanceof Date ? r.created_at : new Date(r.created_at),
+        word_count: r.word_count,
+        tags: [],
+      };
+      byId.set(r.id, a);
+    }
+    if (r.tag_slug && !a.tags.includes(r.tag_slug)) {
+      a.tags.push(r.tag_slug);
+    }
+  }
+
+  const articles = [...byId.values()]
+    .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+    .slice(0, limit);
+
+  return groupArticles(articles);
+}
+
+// ── CLI wrapper ─────────────────────────────────────────────────────
+
+async function cliMain(): Promise<void> {
+  const args = process.argv.slice(2);
+  const preview = args.includes('--preview');
+  const daysIdx = args.indexOf('--days');
+  const limitIdx = args.indexOf('--limit');
+  const days = daysIdx >= 0 ? Number(args[daysIdx + 1]) : TIME_WINDOW_DAYS;
+  const limit = limitIdx >= 0 ? Number(args[limitIdx + 1]) : 2000;
+
+  if (!preview) {
+    console.error('Usage: consolidation-candidates --preview [--days N] [--limit N]');
+    process.exit(2);
+  }
+
+  const { Pool } = await import('pg');
+  const dotenv = await import('dotenv');
+  dotenv.config();
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) { throw new Error('DATABASE_URL required'); }
+  const pool = new Pool({ connectionString: dbUrl });
+
+  try {
+    const groups = await findConsolidationCandidates(pool as unknown as QueryableDb, {
+      days,
+      limit,
+    });
+
+    console.info(
+      `Found ${groups.length} candidate group(s) in the last ${days} days ` +
+      `(jaccard≥${TOPIC_JACCARD_MIN}, title≥${TITLE_COSINE_MIN}, ≤${TIME_WINDOW_DAYS}d, ` +
+      `cap ${MAX_GROUP_SIZE})`,
+    );
+    console.info('');
+
+    for (let i = 0; i < groups.length; i++) {
+      const g = groups[i];
+      console.info(`Group ${i + 1}  score=${g.score.toFixed(3)}  primary=${g.primarySuggestion}`);
+      console.info(`  ${g.reasoning}`);
+      for (const a of g.articles) {
+        const pub = a.publication_name ?? a.publication_id;
+        const date = a.created_at.toISOString().slice(0, 10);
+        console.info(`    - [${date}] (${pub}) ${a.title}  {${a.id}}`);
+      }
+      console.info('');
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+// Only run CLI when invoked directly (not when imported by tests).
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  cliMain().catch((err: unknown) => {
+    console.error('Fatal:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #451.

## Summary

New pure module `tools/editorial/consolidation-candidates.ts` that groups recent articles into candidate sets of 2-4 about the same story but from different publications (diverse voices). Used by the upcoming consolidation worker (#449). No DB mutation.

This does **not** depend on the #448 schema work — the module queries `app.articles` + `app.article_tags` + `app.publications` with an automatic fallback when the `consolidated_into` column is absent.

## Scoring thresholds (tunable at the top of the file)

- **Topic overlap**: Jaccard on `app.article_tags` >= `0.5`
- **Title similarity**: TF-IDF cosine on tokenized titles >= `0.6` (stopword list + length>1 filter; no new embedding dependency)
- **Time proximity**: `|A.created_at - B.created_at| <= 14 days`
- **Publication distinctness**: A.publication_id != B.publication_id (same-publication pairs rejected as follow-ups)
- **Group size cap**: 4 (transitively-scored, greedy assembly in descending combined-score order)

The `primarySuggestion` picks the article with the highest `word_count` (tiebreak most recent). `reasoning` yields a human-readable line like `shared tags: china, geopolitics; title sim 0.78; sources: Sinification, China Talk`.

## Tests

`tools/editorial/consolidation-candidates.test.ts` (13 tests, all passing):

- `jaccard` unit tests
- `tokenizeTitle` stopword/punctuation handling
- `buildTitleTfIdf` cosine sanity
- `groupArticles`: 3-pairs + 3-singletons fixture returns exactly 3 groups
- Edge: 5 articles all matching are capped at a group of 4
- Edge: same-publication pairs rejected
- Edge: pair beyond 14-day window rejected
- Primary suggestion prefers highest word count
- Reasoning text includes shared tags + sources
- `findConsolidationCandidates` fake-DB test covering tag-row collapsing and the `consolidated_into` column fallback

## CLI preview

`npx tsx tools/editorial/consolidation-candidates.ts --preview [--days N] [--limit N]`

No DB mutation. Example from the current DB (14-day window, 2000 article pool):

```
Found 3 candidate group(s) in the last 14 days (jaccard>=0.5, title>=0.6, <=14d, cap 4)

Group 1  score=0.814  primary=1452dd98-527f-4a6c-88c0-ef7241b23ee0
  shared tags: housing-cities; title sim 0.51; sources: City Beautiful, Not Just Bikes
    - [2026-03-25] (City Beautiful) I Visited the Busiest Crossing in the World  {18827edf-45b8-40a2-85b8-b06cc45004e6}
    - [2026-03-25] (Not Just Bikes) I Visited the World's Busiest Train Station  {1452dd98-527f-4a6c-88c0-ef7241b23ee0}

Group 2  score=0.801  primary=c076628a-1c67-4c18-a2ac-426b5c70009b
  shared tags: defense, foreign-policy; title sim 0.52; sources: Good Times Bad Times, Perun
    - [2026-03-25] (Good Times Bad Times) Russia Fires Drones Into (NATO) Poland  {acdb2493-0770-4cc4-9a17-aca2c97d0595}
    - [2026-03-25] (Perun) Russia-NATO Confrontation - Drones over Poland & MiGs over the Baltic  {c076628a-1c67-4c18-a2ac-426b5c70009b}

Group 3  score=0.606  primary=e7687c49-a0f9-42ff-bc27-2a2736755420
  shared tags: foreign-policy; title sim 0.64; sources: CaspianReport, Perun
    - [2026-03-25] (CaspianReport) What's next for Venezuela?  {585a6725-9fc3-405b-bf94-dcba47f570c4}
    - [2026-03-25] (Perun) The U.S. Operation in Venezuela - Maduro's Capture & what next for Venezuela?  {e7687c49-a0f9-42ff-bc27-2a2736755420}
```

All three are real same-story matches across diverse publications — exactly what the consolidation worker will want to merge.

Note: the combined `score` column is the average pairwise `(jaccard + title_cosine)/2`; the `title sim` line in the reasoning is the raw average cosine (computed on the smaller in-group sub-corpus, which is why it can read slightly lower than the per-pair score used for ranking).

## Test plan

- [x] `npm run lint` (zero warnings)
- [x] `npm run typecheck`
- [x] `npm run test` (223 tests, 13 test files, all green)
- [x] `--preview` smoke test against live DB

Out of scope: the consolidation worker itself (#449), embedding pipeline (none exists; TF-IDF fallback used as the issue allows).