### PR TITLE
fix: retry and skip on no-Trump policy failures in consolidate (closes #467)

### DIFF
--- a/tools/editorial/consolidate-helpers.test.ts
+++ b/tools/editorial/consolidate-helpers.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
+  FORBIDDEN_TERMS,
   type SourceArticle,
+  appendRetryReminder,
   buildSynthesisPrompt,
   containsTrumpMention,
+  makeProgrammableSynthesizer,
   makeStubSynthesizer,
   mergeAffiliateLinks,
   mergeWikipediaLinks,
+  synthesizeWithRetry,
   verifyCandidateGroup,
 } from './consolidate-helpers.js';
 
@@ -97,6 +101,96 @@ describe('buildSynthesisPrompt', () => {
     expect(prompt).toMatch(/"title"/);
     expect(prompt).toMatch(/"html"/);
     expect(prompt).toMatch(/"primarySourceId"/);
+  });
+  it('lists every forbidden term explicitly', () => {
+    for (const term of FORBIDDEN_TERMS) {
+      expect(prompt).toContain(term);
+    }
+  });
+  it('includes a closing reminder after the JSON spec', () => {
+    expect(prompt).toMatch(/FINAL REMINDER/);
+  });
+  it('opens with a system policy preamble', () => {
+    expect(prompt).toMatch(/SYSTEM POLICY/);
+  });
+});
+
+describe('appendRetryReminder', () => {
+  it('returns the prompt unchanged on attempt 1', () => {
+    expect(appendRetryReminder('base', 1)).toBe('base');
+  });
+  it('appends a stronger reminder on attempts 2 and 3', () => {
+    const a2 = appendRetryReminder('base', 2);
+    const a3 = appendRetryReminder('base', 3);
+    expect(a2).toMatch(/IMPORTANT/);
+    expect(a2).toMatch(/forbidden/);
+    expect(a3).toMatch(/CRITICAL/);
+    expect(a3).toMatch(/FINAL ATTEMPT/);
+  });
+});
+
+describe('synthesizeWithRetry', () => {
+  it('returns clean output on first attempt', async () => {
+    const calls: string[] = [];
+    const result = await synthesizeWithRetry('BASE', (prompt) => {
+      calls.push(prompt);
+      return Promise.resolve({
+        title: 'Clean title',
+        html: '<p>Clean body about the administration.</p>',
+        primarySourceId: 'src-1',
+      });
+    });
+    expect(result.title).toBe('Clean title');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe('BASE');
+  });
+
+  it('retries when first output mentions Trump and accepts a clean second attempt', async () => {
+    const calls: string[] = [];
+    const result = await synthesizeWithRetry('BASE', (prompt) => {
+      calls.push(prompt);
+      if (calls.length === 1) {
+        return Promise.resolve({
+          title: 'Trump speaks',
+          html: '<p>The Trump administration responded.</p>',
+          primarySourceId: 'src-1',
+        });
+      }
+      return Promise.resolve({
+        title: 'Administration speaks',
+        html: '<p>The White House responded.</p>',
+        primarySourceId: 'src-1',
+      });
+    });
+    expect(result.title).toBe('Administration speaks');
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toMatch(/IMPORTANT/);
+  });
+
+  it('throws after 3 failed attempts', async () => {
+    let n = 0;
+    await expect(
+      synthesizeWithRetry('BASE', () => {
+        n += 1;
+        return Promise.resolve({
+          title: 'Trump again',
+          html: '<p>Trump.</p>',
+          primarySourceId: 'src-1',
+        });
+      }),
+    ).rejects.toThrow(/no-Trump/);
+    expect(n).toBe(3);
+  });
+});
+
+describe('makeProgrammableSynthesizer', () => {
+  it('can simulate a Trump-containing output', async () => {
+    const s = makeProgrammableSynthesizer(['trump']);
+    const result = await s.synthesizeCommentary([
+      mkSource('a', 'p1', 'Alice', 'A'),
+      mkSource('b', 'p2', 'Bob', 'B'),
+    ]);
+    expect(containsTrumpMention(result.title) || containsTrumpMention(result.html)).toBe(true);
   });
 });
 

--- a/tools/editorial/consolidate-helpers.ts
+++ b/tools/editorial/consolidate-helpers.ts
@@ -87,6 +87,48 @@ export function containsTrumpMention(text: string): boolean {
   return TRUMP_RE.test(text);
 }
 
+/** Explicit forbidden-terms list shown to the model. */
+export const FORBIDDEN_TERMS = [
+  'Trump',
+  'Donald Trump',
+  "Trump's",
+  'Trump administration',
+];
+
+/** Approved institutional substitutes. */
+export const APPROVED_SUBSTITUTES = [
+  'the administration',
+  'the White House',
+  'the executive branch',
+  'specific agency names (e.g. the State Department, the Pentagon)',
+];
+
+const NO_TRUMP_PREAMBLE = `SYSTEM POLICY (HARD CONSTRAINT, READ FIRST):
+You must NEVER use any of the following forbidden terms anywhere in the title or HTML body:
+${FORBIDDEN_TERMS.map((t) => `  - "${t}"`).join('\n')}
+Instead, refer to the executive only with institutional language:
+${APPROVED_SUBSTITUTES.map((t) => `  - ${t}`).join('\n')}
+Output containing any forbidden term will be rejected and you will be asked to rewrite.`;
+
+const NO_TRUMP_RULE = `Do NOT mention "Trump" or "Donald Trump" anywhere in the title or body. Forbidden terms: ${FORBIDDEN_TERMS.map((t) => `"${t}"`).join(', ')}. Use institutional language instead: ${APPROVED_SUBSTITUTES.join(', ')}.`;
+
+const NO_TRUMP_FOOTER_REMINDER = `
+
+FINAL REMINDER (do not ignore):
+Re-read your output before returning it. If it contains any of [${FORBIDDEN_TERMS.map((t) => `"${t}"`).join(', ')}], rewrite using institutional language (${APPROVED_SUBSTITUTES.join(', ')}). This is a hard policy gate — non-compliant output is discarded.`;
+
+/**
+ * Append a progressively stronger no-Trump reminder to a prompt for retries.
+ * attempt is 1-indexed; attempt 1 returns the prompt unchanged.
+ */
+export function appendRetryReminder(prompt: string, attempt: number): string {
+  if (attempt <= 1) { return prompt; }
+  const intensity = attempt === 2 ? 'IMPORTANT' : 'CRITICAL — FINAL ATTEMPT';
+  return `${prompt}
+
+${intensity}: your previous draft contained "Trump" which is forbidden by hard policy. Rewrite using institutional language only (${APPROVED_SUBSTITUTES.join(', ')}). Do NOT use any of [${FORBIDDEN_TERMS.map((t) => `"${t}"`).join(', ')}] anywhere in the title or body. This is attempt ${String(attempt)} of 3.`;
+}
+
 // ── Prompt construction ─────────────────────────────────────────────
 
 /**
@@ -95,10 +137,12 @@ export function containsTrumpMention(text: string): boolean {
  * source's attribution line are present.
  */
 export function buildSynthesisPrompt(sources: SourceArticle[]): string {
-  const header = `You are Brian Edwards, writing a consolidated "by Brian Edwards" commentary that synthesizes ${sources.length} source articles reporting on the same or similar story.
+  const header = `${NO_TRUMP_PREAMBLE}
+
+You are Brian Edwards, writing a consolidated "by Brian Edwards" commentary that synthesizes ${sources.length} source articles reporting on the same or similar story.
 
 EDITORIAL POLICY — NON-NEGOTIABLE:
-- Do NOT mention "Trump" or "Donald Trump" anywhere in the title or body. Reframe around the underlying news, policy, institutions, agencies, or officials (e.g. "the administration", "the White House", "the executive branch").
+- ${NO_TRUMP_RULE}
 - Write in the THIRD person. Never use "I", "we", or "you".
 - Preserve direct quotes from each source, attributed by author.
 - Explicitly contrast and integrate the diverse voices — do not simply summarize.
@@ -138,6 +182,7 @@ Return a JSON object (and nothing else) with exactly these keys:
   "html":  "<commentary HTML body — no wrapper tags>",
   "primarySourceId": "<id of the source whose voice dominates>"
 }
+${NO_TRUMP_FOOTER_REMINDER}
 `;
 
   return header + body + footer;
@@ -150,10 +195,12 @@ export function buildRevisionPrompt(
   sources: SourceArticle[],
   newSource: SourceArticle,
 ): string {
-  return `You are Brian Edwards. An existing consolidated commentary needs to be revised to incorporate a newly arrived source article on the same story.
+  return `${NO_TRUMP_PREAMBLE}
+
+You are Brian Edwards. An existing consolidated commentary needs to be revised to incorporate a newly arrived source article on the same story.
 
 EDITORIAL POLICY — NON-NEGOTIABLE:
-- Do NOT mention "Trump" or "Donald Trump" anywhere in the title or body.
+- ${NO_TRUMP_RULE}
 - Third person only. No "I"/"we"/"you".
 - Preserve direct quotes from every source, attributed by author.
 - Keep the Bottom Line section and counterpoints structure.
@@ -184,6 +231,7 @@ Return a JSON object (and nothing else):
   "html":  "<revised commentary HTML body>",
   "primarySourceId": "<id of dominant source; may be unchanged>"
 }
+${NO_TRUMP_FOOTER_REMINDER}
 `;
 }
 
@@ -244,6 +292,81 @@ ${quotes}
       return synth([...sources, newSource]);
     },
   };
+}
+
+/**
+ * Wrap a single-attempt synthesis function with a retry loop that
+ * re-checks the no-Trump policy. Up to `maxAttempts` calls; subsequent
+ * attempts get a progressively stronger reminder appended to the prompt.
+ *
+ * The runner is responsible for building the base prompt and parsing
+ * output; this helper just re-invokes with the (possibly augmented)
+ * prompt and validates.
+ *
+ * Throws after the final attempt if the output still violates policy.
+ */
+export async function synthesizeWithRetry(
+  basePrompt: string,
+  runOnce: (prompt: string) => Promise<SynthesisResult>,
+  maxAttempts = 3,
+): Promise<SynthesisResult> {
+  let lastErr: Error | null = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const prompt = appendRetryReminder(basePrompt, attempt);
+    let result: SynthesisResult;
+    try {
+      result = await runOnce(prompt);
+    } catch (err) {
+      lastErr = err instanceof Error ? err : new Error(String(err));
+      continue;
+    }
+    if (
+      !containsTrumpMention(result.title) &&
+      !containsTrumpMention(result.html)
+    ) {
+      return result;
+    }
+    lastErr = new Error(
+      `attempt ${String(attempt)}/${String(maxAttempts)}: synthesis violates no-Trump policy`,
+    );
+  }
+  throw lastErr ?? new Error('synthesis failed after retries');
+}
+
+/**
+ * Test helper: a synthesizer whose outputs are programmable per-call.
+ * Each entry is either a SynthesisResult or 'trump' to emit a
+ * forbidden-term-containing payload. The synthesizer cycles through
+ * the entries; when exhausted it reuses the last entry.
+ */
+export function makeProgrammableSynthesizer(
+  outputs: Array<SynthesisResult | 'trump'>,
+): CommentarySynthesizer & { calls: number } {
+  const state = { calls: 0 };
+  function pick(sources: SourceArticle[]): SynthesisResult {
+    const idx = Math.min(state.calls, outputs.length - 1);
+    state.calls += 1;
+    const out = outputs[idx];
+    if (out === 'trump') {
+      return {
+        title: 'Trump policy explained',
+        html: '<p>The Trump administration announced new measures.</p>',
+        primarySourceId: sources[0]?.id ?? 'unknown',
+      };
+    }
+    return out;
+  }
+  const obj: CommentarySynthesizer & { calls: number } = {
+    calls: 0,
+    synthesizeCommentary(sources) {
+      return Promise.resolve(pick(sources));
+    },
+    reviseCommentary(_t, _h, sources, newSrc) {
+      return Promise.resolve(pick([...sources, newSrc]));
+    },
+  };
+  Object.defineProperty(obj, 'calls', { get: () => state.calls });
+  return obj;
 }
 
 function escapeHtml(s: string): string {

--- a/tools/editorial/consolidate.test.ts
+++ b/tools/editorial/consolidate.test.ts
@@ -3,9 +3,10 @@
  * fake DB and the stub synthesizer so it runs offline and without
  * Postgres.
  */
-import { mkdtemp } from 'fs/promises';
+import { mkdtemp, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { makeProgrammableSynthesizer } from './consolidate-helpers.js';
 import { describe, expect, it } from 'vitest';
 import type { CandidateGroup } from './consolidation-candidates.js';
 import {
@@ -392,6 +393,46 @@ describe('runModeA dry-run on a fixture group', () => {
     );
     expect(primaryRows).toHaveLength(1);
     expect(primaryRows[0].source_article_id).toBe(p.primarySourceId);
+  });
+
+  it('skips and logs (does not throw) when synthesis always returns Trump output', async () => {
+    const db = new FakeDb();
+    const group = seedGroup(db);
+    const synth = makeProgrammableSynthesizer(['trump', 'trump', 'trump', 'trump']);
+    const libraryRoot = await mkdtemp(join(tmpdir(), 'consolidate-skip-'));
+
+    const plan = await runModeA({
+      db: db as unknown as Parameters<typeof runModeA>[0]['db'],
+      synthesizer: synth,
+      group,
+      groupIndex: 0,
+      apply: false,
+      libraryRoot,
+      loadSources: (rows) =>
+        Promise.resolve(rows.map((r) => ({
+          id: r.id,
+          title: r.title,
+          author_name: r.author_name,
+          publication_id: r.publication_id,
+          publication_name: r.publication_name,
+          original_url: r.original_url,
+          rewritten_html: '<p>stub</p>',
+          excerpt: 'x',
+        }))),
+    });
+
+    expect(plan).toBeNull();
+    // No DB mutations.
+    expect(db.commentarySources).toHaveLength(0);
+    for (const a of db.articles.values()) {
+      expect(a.consolidated_into).toBeNull();
+    }
+    // Skipped log written.
+    const logContent = await readFile(join(libraryRoot, 'consolidation-skipped.log'), 'utf-8');
+    expect(logContent).toMatch(/no-Trump policy/);
+    for (const a of group.articles) {
+      expect(logContent).toContain(a.id);
+    }
   });
 
   it('rejects a group where all sources share one publication', async () => {

--- a/tools/editorial/consolidate.ts
+++ b/tools/editorial/consolidate.ts
@@ -20,7 +20,7 @@
 import 'dotenv/config';
 import { spawn } from 'child_process';
 import { randomUUID } from 'crypto';
-import { mkdir, readFile, writeFile } from 'fs/promises';
+import { appendFile, mkdir, readFile, writeFile } from 'fs/promises';
 import { dirname, join, resolve } from 'path';
 import type { Pool, PoolClient } from 'pg';
 import type { CandidateGroup, QueryableDb } from './consolidation-candidates.js';
@@ -35,6 +35,7 @@ import {
   buildSynthesisPrompt,
   containsTrumpMention,
   makeStubSynthesizer,
+  synthesizeWithRetry,
   mergeAffiliateLinks,
   mergeWikipediaLinks,
   verifyCandidateGroup,
@@ -113,24 +114,39 @@ function parseSynthesisJson(stdout: string): SynthesisResult {
 export function makeClaudeCliSynthesizer(): CommentarySynthesizer {
   return {
     async synthesizeCommentary(sources: SourceArticle[]): Promise<SynthesisResult> {
-      const prompt = buildSynthesisPrompt(sources);
-      const stdout = await runClaudeCli(prompt);
-      const result = parseSynthesisJson(stdout);
-      if (containsTrumpMention(result.title) || containsTrumpMention(result.html)) {
-        throw new Error('synthesis violates no-Trump policy');
-      }
-      return result;
+      const basePrompt = buildSynthesisPrompt(sources);
+      return await synthesizeWithRetry(basePrompt, async (prompt) => {
+        const stdout = await runClaudeCli(prompt);
+        return parseSynthesisJson(stdout);
+      });
     },
     async reviseCommentary(existingTitle, existingHtml, sources, newSource) {
-      const prompt = buildRevisionPrompt(existingTitle, existingHtml, sources, newSource);
-      const stdout = await runClaudeCli(prompt);
-      const result = parseSynthesisJson(stdout);
-      if (containsTrumpMention(result.title) || containsTrumpMention(result.html)) {
-        throw new Error('revision violates no-Trump policy');
-      }
-      return result;
+      const basePrompt = buildRevisionPrompt(existingTitle, existingHtml, sources, newSource);
+      return await synthesizeWithRetry(basePrompt, async (prompt) => {
+        const stdout = await runClaudeCli(prompt);
+        return parseSynthesisJson(stdout);
+      });
     },
   };
+}
+
+// ── Skipped-group log ───────────────────────────────────────────────
+
+/** Append a single skip record to library/consolidation-skipped.log. */
+export async function logSkippedGroup(
+  articleIds: string[],
+  reason: string,
+  libraryRoot?: string,
+): Promise<void> {
+  const root = libraryRoot ?? LIBRARY_ROOT;
+  const path = join(root, 'consolidation-skipped.log');
+  const line = `${new Date().toISOString()} | ${articleIds.join(',')} | ${reason}\n`;
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, line, 'utf-8');
+  } catch (err) {
+    console.warn(`failed to write skipped log: ${String(err)}`);
+  }
 }
 
 // ── DB helpers ──────────────────────────────────────────────────────
@@ -251,9 +267,20 @@ export async function runModeA(opts: ModeAOptions): Promise<ConsolidationPlan | 
   const loadSources = opts.loadSources ?? (async (rs) => Promise.all(rs.map(rowToSourceArticle)));
   const sources = await loadSources(rows);
 
-  const synth = await synthesizer.synthesizeCommentary(sources);
+  let synth: SynthesisResult;
+  try {
+    synth = await synthesizer.synthesizeCommentary(sources);
+  } catch (err) {
+    const reason = `synthesis failed: ${err instanceof Error ? err.message : String(err)}`;
+    console.warn(`  skip group ${String(groupIndex + 1)}: ${reason}`);
+    await logSkippedGroup(rows.map((r) => r.id), reason, opts.libraryRoot);
+    return null;
+  }
   if (containsTrumpMention(synth.title) || containsTrumpMention(synth.html)) {
-    throw new Error(`group ${groupIndex + 1}: synthesis violates no-Trump policy`);
+    const reason = 'synthesis violates no-Trump policy after retries';
+    console.warn(`  skip group ${String(groupIndex + 1)}: ${reason}`);
+    await logSkippedGroup(rows.map((r) => r.id), reason, opts.libraryRoot);
+    return null;
   }
 
   const commentaryId = randomUUID();
@@ -552,16 +579,25 @@ async function cliMain(): Promise<void> {
 
     const capped = groups.slice(0, cli.limit);
     for (let i = 0; i < capped.length; i++) {
-      const plan = await runModeA({
-        db: pool,
-        synthesizer,
-        group: capped[i],
-        groupIndex: i,
-        apply: cli.apply,
-      });
-      if (plan) {
-        console.info(formatPlan(plan));
-        console.info('');
+      try {
+        const plan = await runModeA({
+          db: pool,
+          synthesizer,
+          group: capped[i],
+          groupIndex: i,
+          apply: cli.apply,
+        });
+        if (plan) {
+          console.info(formatPlan(plan));
+          console.info('');
+        }
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        console.warn(`  group ${String(i + 1)} failed unexpectedly: ${reason}`);
+        await logSkippedGroup(
+          capped[i].articles.map((a) => a.id),
+          `unexpected error: ${reason}`,
+        );
       }
     }
   } finally {


### PR DESCRIPTION
## Summary
- Strengthens the synthesis prompt with an explicit `FORBIDDEN_TERMS` list shown both as a system preamble and a closing reminder, plus approved institutional substitutes.
- Wraps `claude -p` synthesis in a 3-attempt retry loop (`synthesizeWithRetry`) that re-checks the no-Trump policy and appends progressively stronger reminders on attempts 2 and 3.
- `runModeA` now logs and skips groups whose synthesis still violates policy after retries instead of throwing — the CLI continues to the next group. Skipped groups append to `library/consolidation-skipped.log` (gitignored via `*.log`).
- Adds unit tests covering the forbidden-terms list in the prompt, the programmable Trump-emitting synthesizer, the retry-success path, the 3-strike failure path, and the runModeA skip-and-log behavior.

Closes #467.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (286 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)