### PR TITLE
feat: backfill mode for consolidation worker (closes #452)

### DIFF
--- a/tools/editorial/consolidate.test.ts
+++ b/tools/editorial/consolidate.test.ts
@@ -10,9 +10,11 @@ import { describe, expect, it } from 'vitest';
 import type { CandidateGroup } from './consolidation-candidates.js';
 import {
   type ConsolidationPlan,
+  buildBackfillChunks,
   formatPlan,
   makeStubSynthesizer,
   parseArgs,
+  runBackfill,
   runModeA,
   runModeB,
 } from './consolidate.js';
@@ -49,10 +51,22 @@ interface WikiLinkRow {
   topic_summary: string;
 }
 
+interface FakeBackfillRow {
+  id: string;
+  publication_id: string;
+  publication_name: string;
+  title: string;
+  created_at: Date;
+  word_count: number | null;
+  tags: string[];
+}
+
 class FakeDb {
   articles = new Map<string, FakeArticle>();
   commentarySources: CommentarySourceRow[] = [];
   wikiLinks: WikiLinkRow[] = [];
+  /** Extra metadata only the backfill queries need. */
+  meta = new Map<string, { created_at: Date; word_count: number | null; tags: string[] }>();
 
   query<T extends Record<string, unknown> = Record<string, unknown>>(
     sql: string,
@@ -237,6 +251,62 @@ class FakeDb {
       return { rows: [] };
     }
 
+    if (s.startsWith('SELECT a.id, a.title, a.publication_id')) {
+      // Range query from findCandidatesInRange. Two param shapes:
+      //   [start, end]                              (with consolidated_into filter)
+      //   [start, end]                              (fallback)
+      const start = params[0] as Date;
+      const end = params[1] as Date;
+      const out: FakeBackfillRow[] = [];
+      for (const a of this.articles.values()) {
+        const m = this.meta.get(a.id);
+        if (!m) { continue; }
+        if (a.consolidated_into !== null || a.is_consolidated) { continue; }
+        if (m.created_at < start || m.created_at >= end) { continue; }
+        out.push({
+          id: a.id,
+          publication_id: a.publication_id,
+          publication_name: a.publication_name,
+          title: a.title,
+          created_at: m.created_at,
+          word_count: m.word_count,
+          tags: m.tags,
+        });
+      }
+      // Expand into one row per tag (matching the LEFT JOIN shape).
+      const flat: Record<string, unknown>[] = [];
+      for (const r of out) {
+        if (r.tags.length === 0) {
+          flat.push({ ...r, tag_slug: null });
+        } else {
+          for (const t of r.tags) { flat.push({ ...r, tag_slug: t }); }
+        }
+      }
+      return { rows: flat as unknown as T[] };
+    }
+
+    if (s.startsWith('SELECT MIN(created_at)')) {
+      let min: Date | null = null;
+      let max: Date | null = null;
+      for (const m of this.meta.values()) {
+        if (!min || m.created_at < min) { min = m.created_at; }
+        if (!max || m.created_at > max) { max = m.created_at; }
+      }
+      // Some callers select MIN only, others MIN+MAX. Both fields are
+      // safe to return.
+      return { rows: [{ min, max }] as unknown as T[] };
+    }
+
+    if (s.startsWith('SELECT COUNT(*)::text AS count FROM app.articles')) {
+      if (s.includes('WHERE')) {
+        const n = [...this.articles.values()].filter(
+          (a) => a.consolidated_into !== null || a.is_consolidated,
+        ).length;
+        return { rows: [{ count: String(n) }] as unknown as T[] };
+      }
+      return { rows: [{ count: String(this.articles.size) }] as unknown as T[] };
+    }
+
     throw new Error(`FakeDb: unhandled SQL: ${s.slice(0, 80)}`);
   }
 }
@@ -289,11 +359,30 @@ describe('parseArgs', () => {
       apply: false,
       limit: 10,
       addTo: undefined,
+      backfill: false,
+      backfillStatus: false,
     });
   });
   it('parses --apply --limit 3', () => {
     const p = parseArgs(['node', 'x', '--apply', '--limit', '3']);
-    expect(p).toEqual({ dryRun: false, apply: true, limit: 3, addTo: undefined });
+    expect(p).toEqual({
+      dryRun: false,
+      apply: true,
+      limit: 3,
+      addTo: undefined,
+      backfill: false,
+      backfillStatus: false,
+    });
+  });
+  it('parses --backfill --apply --limit 5', () => {
+    const p = parseArgs(['node', 'x', '--backfill', '--apply', '--limit', '5']);
+    expect(p.backfill).toBe(true);
+    expect(p.apply).toBe(true);
+    expect(p.limit).toBe(5);
+  });
+  it('parses --backfill-status', () => {
+    const p = parseArgs(['node', 'x', '--backfill-status']);
+    expect(p.backfillStatus).toBe(true);
   });
   it('parses --add-to', () => {
     const p = parseArgs(['node', 'x', '--add-to', 'com-1', 'src-2']);
@@ -441,6 +530,142 @@ describe('runModeA dry-run on a fixture group', () => {
       loadSources: () => Promise.resolve([]),
     });
     expect(plan).toBeNull();
+  });
+});
+
+describe('buildBackfillChunks', () => {
+  it('produces newest-first 14-day chunks within bounds', () => {
+    const earliest = new Date('2026-01-01T00:00:00Z');
+    const latest = new Date('2026-03-01T00:00:00Z');
+    const chunks = buildBackfillChunks(earliest, latest, 14);
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0].end.getTime()).toBe(latest.getTime());
+    // Each chunk's end must be >= start, all within bounds.
+    for (const c of chunks) {
+      expect(c.end.getTime()).toBeGreaterThan(c.start.getTime());
+      expect(c.start.getTime()).toBeGreaterThanOrEqual(earliest.getTime());
+      expect(c.end.getTime()).toBeLessThanOrEqual(latest.getTime());
+    }
+    // Last chunk must reach the floor exactly.
+    expect(chunks[chunks.length - 1].start.getTime()).toBe(earliest.getTime());
+  });
+
+  it('returns a single chunk when range is shorter than chunk size', () => {
+    const chunks = buildBackfillChunks(
+      new Date('2026-04-01T00:00:00Z'),
+      new Date('2026-04-05T00:00:00Z'),
+      14,
+    );
+    expect(chunks).toHaveLength(1);
+  });
+});
+
+describe('runBackfill --dry-run on multi-chunk fixture', () => {
+  function seedThreeChunks(db: FakeDb): void {
+    // Three groups, one per 14-day chunk, walking back from 2026-04-01.
+    const groups = [
+      { offset: 0, idPrefix: 'a' },
+      { offset: 20, idPrefix: 'b' },
+      { offset: 50, idPrefix: 'c' },
+    ];
+    const tags = ['energy', 'grid', 'policy'];
+    for (const g of groups) {
+      const created = new Date('2026-04-01T00:00:00Z');
+      created.setUTCDate(created.getUTCDate() - g.offset);
+      const mk = (
+        suffix: string,
+        pub: string,
+        author: string,
+        title: string,
+      ): void => {
+        const id = `${g.idPrefix}${g.idPrefix}${g.idPrefix}${g.idPrefix}${g.idPrefix}${g.idPrefix}${g.idPrefix}${g.idPrefix}-0000-0000-0000-00000000000${suffix}`;
+        db.articles.set(id, {
+          id,
+          title,
+          slug: id,
+          author_name: author,
+          publication_id: pub,
+          publication_name: `Pub-${pub}`,
+          original_url: `https://x.test/${id}`,
+          rewritten_content_path: null,
+          content_path: null,
+          full_content_path: null,
+          affiliate_links: [],
+          is_consolidated: false,
+          consolidated_into: null,
+        });
+        db.meta.set(id, { created_at: created, word_count: 1000, tags: [...tags] });
+      };
+      mk('1', `${g.idPrefix}-pub-alpha`, 'Alice', 'National power grid strain rising rapidly across regions');
+      mk('2', `${g.idPrefix}-pub-beta`, 'Bob', 'National power grid strain rising rapidly nationwide');
+      mk('3', `${g.idPrefix}-pub-gamma`, 'Carol', 'National power grid strain rising rapidly everywhere');
+    }
+  }
+
+  it('walks chunks, finds groups, and never mutates in dry-run', async () => {
+    const db = new FakeDb();
+    seedThreeChunks(db);
+
+    const result = await runBackfill({
+      db: db as unknown as Parameters<typeof runBackfill>[0]['db'],
+      synthesizer: makeStubSynthesizer(),
+      apply: false,
+      limit: 10,
+      now: new Date('2026-04-02T00:00:00Z'),
+      log: () => undefined,
+      loadSources: (rows) =>
+        Promise.resolve(rows.map((r) => ({
+          id: r.id,
+          title: r.title,
+          author_name: r.author_name,
+          publication_id: r.publication_id,
+          publication_name: r.publication_name,
+          original_url: r.original_url,
+          rewritten_html: '<p>stub rewrite</p>',
+          excerpt: `excerpt for ${r.id}`,
+        }))),
+    });
+
+    expect(result.chunksScanned).toBeGreaterThanOrEqual(3);
+    expect(result.groupsFound).toBe(3);
+    expect(result.groupsProcessed).toBe(3);
+    expect(result.plans).toHaveLength(3);
+    expect(result.hitLimit).toBe(false);
+
+    // Pure dry-run: no commentary_sources, no consolidated_into.
+    expect(db.commentarySources).toHaveLength(0);
+    for (const a of db.articles.values()) {
+      expect(a.is_consolidated).toBe(false);
+      expect(a.consolidated_into).toBeNull();
+    }
+  });
+
+  it('honors --limit by stopping early', async () => {
+    const db = new FakeDb();
+    seedThreeChunks(db);
+
+    const result = await runBackfill({
+      db: db as unknown as Parameters<typeof runBackfill>[0]['db'],
+      synthesizer: makeStubSynthesizer(),
+      apply: false,
+      limit: 1,
+      now: new Date('2026-04-02T00:00:00Z'),
+      log: () => undefined,
+      loadSources: (rows) =>
+        Promise.resolve(rows.map((r) => ({
+          id: r.id,
+          title: r.title,
+          author_name: r.author_name,
+          publication_id: r.publication_id,
+          publication_name: r.publication_name,
+          original_url: r.original_url,
+          rewritten_html: '<p>stub rewrite</p>',
+          excerpt: `excerpt for ${r.id}`,
+        }))),
+    });
+
+    expect(result.groupsProcessed).toBe(1);
+    expect(result.hitLimit).toBe(true);
   });
 });
 

--- a/tools/editorial/consolidate.ts
+++ b/tools/editorial/consolidate.ts
@@ -12,6 +12,15 @@
  *   tsx tools/editorial/consolidate.ts --apply --limit 3
  *   tsx tools/editorial/consolidate.ts --add-to <commentary_id> <source_id>
  *
+ * Backfill (issue #452) — walks historical articles in 14-day chunks
+ * (created_at DESC) and applies Mode A to anything still single-source.
+ * Idempotent: skips rows already marked is_consolidated or already
+ * absorbed (consolidated_into IS NOT NULL). Honors --limit and --dry-run.
+ *
+ *   tsx tools/editorial/consolidate.ts --backfill --dry-run
+ *   tsx tools/editorial/consolidate.ts --backfill --apply --limit 5
+ *   tsx tools/editorial/consolidate.ts --backfill-status
+ *
  * The LLM synthesis step is hidden behind the CommentarySynthesizer
  * interface (see consolidate-helpers.ts). The default implementation
  * spawns `claude -p` as a subprocess. Tests inject a fake.
@@ -24,7 +33,11 @@ import { mkdir, readFile, writeFile } from 'fs/promises';
 import { dirname, join, resolve } from 'path';
 import type { Pool, PoolClient } from 'pg';
 import type { CandidateGroup, QueryableDb } from './consolidation-candidates.js';
-import { findConsolidationCandidates } from './consolidation-candidates.js';
+import {
+  TIME_WINDOW_DAYS,
+  findCandidatesInRange,
+  findConsolidationCandidates,
+} from './consolidation-candidates.js';
 import {
   type AffiliateLink,
   type CommentarySynthesizer,
@@ -481,6 +494,207 @@ export async function runModeB(opts: ModeBOptions): Promise<void> {
   ]);
 }
 
+// ── Backfill (issue #452) ───────────────────────────────────────────
+
+export interface BackfillOptions {
+  db: DbClient;
+  synthesizer: CommentarySynthesizer;
+  apply: boolean;
+  /** Hard cap on groups processed per invocation (default 5). */
+  limit?: number;
+  /** Chunk size in days (default 14). */
+  chunkDays?: number;
+  /** Override "now" for deterministic tests. */
+  now?: Date;
+  /** Override the historical floor (default = oldest article in DB). */
+  earliest?: Date;
+  /** Injectable source loader for tests. */
+  loadSources?: ModeAOptions['loadSources'];
+  libraryRoot?: string;
+  /** Optional progress sink (defaults to console.info). */
+  log?: (msg: string) => void;
+}
+
+export interface BackfillResult {
+  chunksScanned: number;
+  groupsFound: number;
+  groupsProcessed: number;
+  plans: ConsolidationPlan[];
+  hitLimit: boolean;
+}
+
+interface ChunkRange { start: Date; end: Date }
+
+/** Inclusive earliest, exclusive latest — yields newest chunk first. */
+export function buildBackfillChunks(
+  earliest: Date,
+  latest: Date,
+  chunkDays: number,
+): ChunkRange[] {
+  const out: ChunkRange[] = [];
+  const ms = chunkDays * 24 * 60 * 60 * 1000;
+  let end = latest.getTime();
+  const floor = earliest.getTime();
+  while (end > floor) {
+    const start = Math.max(floor, end - ms);
+    out.push({ start: new Date(start), end: new Date(end) });
+    end = start;
+  }
+  return out;
+}
+
+async function fetchEarliestArticleDate(db: QueryableDb): Promise<Date | null> {
+  const { rows } = await db.query<{ min: Date | string | null }>(
+    `SELECT MIN(created_at) AS min FROM app.articles`,
+  );
+  const v = rows[0]?.min ?? null;
+  if (v === null) { return null; }
+  return v instanceof Date ? v : new Date(v);
+}
+
+/**
+ * Walk historical articles in 14-day chunks (newest first) and apply
+ * Mode A consolidation to each candidate group, up to `limit`. Idempotent:
+ * already-consolidated articles are excluded by `findCandidatesInRange`,
+ * and `runModeA` re-checks before mutating.
+ */
+export async function runBackfill(opts: BackfillOptions): Promise<BackfillResult> {
+  const limit = opts.limit ?? 5;
+  const chunkDays = opts.chunkDays ?? TIME_WINDOW_DAYS;
+  const now = opts.now ?? new Date();
+  const log = opts.log ?? ((m: string) => { console.info(m); });
+  const queryable = opts.db as unknown as QueryableDb;
+
+  const earliest =
+    opts.earliest ?? (await fetchEarliestArticleDate(queryable)) ?? new Date(now);
+  const chunks = buildBackfillChunks(earliest, now, chunkDays);
+
+  const result: BackfillResult = {
+    chunksScanned: 0,
+    groupsFound: 0,
+    groupsProcessed: 0,
+    plans: [],
+    hitLimit: false,
+  };
+
+  for (const chunk of chunks) {
+    result.chunksScanned++;
+    log(
+      `chunk ${result.chunksScanned}/${chunks.length}: ` +
+      `${chunk.start.toISOString().slice(0, 10)} → ${chunk.end.toISOString().slice(0, 10)}`,
+    );
+    const groups = await findCandidatesInRange(queryable, {
+      start: chunk.start,
+      end: chunk.end,
+    });
+    result.groupsFound += groups.length;
+    if (groups.length === 0) { continue; }
+    log(`  ${groups.length} candidate group(s)`);
+
+    for (const group of groups) {
+      if (result.groupsProcessed >= limit) {
+        result.hitLimit = true;
+        break;
+      }
+      const plan = await runModeA({
+        db: opts.db,
+        synthesizer: opts.synthesizer,
+        group,
+        groupIndex: result.groupsProcessed,
+        apply: opts.apply,
+        libraryRoot: opts.libraryRoot,
+        loadSources: opts.loadSources,
+      });
+      if (plan) {
+        result.plans.push(plan);
+        result.groupsProcessed++;
+        log(formatPlan(plan));
+        log('');
+      }
+    }
+    if (result.hitLimit) { break; }
+  }
+
+  return result;
+}
+
+export interface BackfillStatus {
+  totalArticles: number;
+  alreadyConsolidated: number;
+  estimatedRemainingGroups: number;
+  earliest: Date | null;
+  latest: Date | null;
+}
+
+/**
+ * Quick status report for the backfill driver. Counts use efficient
+ * aggregate queries; the "estimated remaining" walks chunks once with
+ * candidate detection but does not mutate.
+ */
+export async function getBackfillStatus(
+  db: DbClient,
+  opts: { chunkDays?: number; now?: Date } = {},
+): Promise<BackfillStatus> {
+  const queryable = db as unknown as QueryableDb;
+  const chunkDays = opts.chunkDays ?? TIME_WINDOW_DAYS;
+  const now = opts.now ?? new Date();
+
+  const totalRes = await queryable.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count FROM app.articles`,
+  );
+  const total = Number(totalRes.rows[0]?.count ?? 0);
+
+  let consolidated: number;
+  try {
+    const consRes = await queryable.query<{ count: string }>(
+      `SELECT COUNT(*)::text AS count FROM app.articles
+        WHERE consolidated_into IS NOT NULL OR is_consolidated = true`,
+    );
+    consolidated = Number(consRes.rows[0]?.count ?? 0);
+  } catch {
+    consolidated = 0;
+  }
+
+  const rangeRes = await queryable.query<{ min: Date | string | null; max: Date | string | null }>(
+    `SELECT MIN(created_at) AS min, MAX(created_at) AS max FROM app.articles`,
+  );
+  const minRaw = rangeRes.rows[0]?.min ?? null;
+  const maxRaw = rangeRes.rows[0]?.max ?? null;
+  const earliest = minRaw === null ? null : (minRaw instanceof Date ? minRaw : new Date(minRaw));
+  const latest = maxRaw === null ? null : (maxRaw instanceof Date ? maxRaw : new Date(maxRaw));
+
+  let estimated = 0;
+  if (earliest) {
+    const chunks = buildBackfillChunks(earliest, now, chunkDays);
+    for (const chunk of chunks) {
+      const groups = await findCandidatesInRange(queryable, {
+        start: chunk.start,
+        end: chunk.end,
+      });
+      estimated += groups.length;
+    }
+  }
+
+  return {
+    totalArticles: total,
+    alreadyConsolidated: consolidated,
+    estimatedRemainingGroups: estimated,
+    earliest,
+    latest,
+  };
+}
+
+export function formatBackfillStatus(s: BackfillStatus): string {
+  const fmt = (d: Date | null): string => d ? d.toISOString().slice(0, 10) : '(none)';
+  const lines: string[] = [];
+  lines.push('Backfill status:');
+  lines.push(`  total articles:           ${s.totalArticles}`);
+  lines.push(`  already consolidated:     ${s.alreadyConsolidated}`);
+  lines.push(`  est. remaining groups:    ${s.estimatedRemainingGroups}`);
+  lines.push(`  date range:               ${fmt(s.earliest)} → ${fmt(s.latest)}`);
+  return lines.join('\n');
+}
+
 // ── Plan printer ────────────────────────────────────────────────────
 
 export function formatPlan(plan: ConsolidationPlan): string {
@@ -505,6 +719,8 @@ interface CliArgs {
   apply: boolean;
   limit: number;
   addTo?: { commentaryId: string; sourceId: string };
+  backfill: boolean;
+  backfillStatus: boolean;
 }
 
 export function parseArgs(argv: string[]): CliArgs {
@@ -516,13 +732,22 @@ export function parseArgs(argv: string[]): CliArgs {
     if (!commentaryId || !sourceId) {
       throw new Error('--add-to requires <commentary_id> <source_id>');
     }
-    return { dryRun: false, apply: true, limit: 1, addTo: { commentaryId, sourceId } };
+    return {
+      dryRun: false,
+      apply: true,
+      limit: 1,
+      addTo: { commentaryId, sourceId },
+      backfill: false,
+      backfillStatus: false,
+    };
   }
   const apply = args.includes('--apply');
   const dryRun = args.includes('--dry-run') || !apply;
   const limitIdx = args.indexOf('--limit');
   const limit = limitIdx >= 0 ? Number(args[limitIdx + 1]) : 10;
-  return { dryRun, apply, limit, addTo: undefined };
+  const backfill = args.includes('--backfill');
+  const backfillStatus = args.includes('--backfill-status');
+  return { dryRun, apply, limit, addTo: undefined, backfill, backfillStatus };
 }
 
 async function cliMain(): Promise<void> {
@@ -536,6 +761,28 @@ async function cliMain(): Promise<void> {
   const synthesizer = makeClaudeCliSynthesizer();
 
   try {
+    if (cli.backfillStatus) {
+      const status = await getBackfillStatus(pool);
+      console.info(formatBackfillStatus(status));
+      return;
+    }
+
+    if (cli.backfill) {
+      const limit = cli.limit > 0 ? cli.limit : 5;
+      const result = await runBackfill({
+        db: pool,
+        synthesizer,
+        apply: cli.apply,
+        limit,
+      });
+      console.info(
+        `Backfill: scanned ${result.chunksScanned} chunk(s), ` +
+        `found ${result.groupsFound} group(s), processed ${result.groupsProcessed}` +
+        (result.hitLimit ? ' (limit reached)' : ''),
+      );
+      return;
+    }
+
     if (cli.addTo) {
       await runModeB({
         db: pool,

--- a/tools/editorial/consolidation-candidates.ts
+++ b/tools/editorial/consolidation-candidates.ts
@@ -382,6 +382,85 @@ export async function findConsolidationCandidates(
   return groupArticles(articles);
 }
 
+// ── Backfill helpers (issue #452) ───────────────────────────────────
+
+export interface RangeOptions {
+  /** Inclusive lower bound (created_at >= start). */
+  start: Date;
+  /** Exclusive upper bound (created_at < end). */
+  end: Date;
+  /** Hard cap on rows pulled (default 1000). */
+  limit?: number;
+}
+
+/**
+ * Find candidate groups whose articles fall within an explicit
+ * `[start, end)` window. Skips articles already absorbed
+ * (`consolidated_into IS NOT NULL`) or marked `is_consolidated = true`.
+ *
+ * Used by the backfill driver in `consolidate.ts` to walk history in
+ * fixed 14-day chunks. Unlike `findConsolidationCandidates`, this does
+ * not depend on `NOW()`.
+ */
+export async function findCandidatesInRange(
+  db: QueryableDb,
+  opts: RangeOptions,
+): Promise<CandidateGroup[]> {
+  const limit = opts.limit ?? 1000;
+
+  const baseSelect = `
+    SELECT a.id, a.title, a.publication_id,
+           p.name AS publication_name,
+           a.created_at, a.word_count,
+           at.tag_slug
+    FROM app.articles a
+    JOIN app.publications p ON a.publication_id = p.id
+    LEFT JOIN app.article_tags at ON at.article_id = a.id
+  `;
+  const where = `WHERE a.created_at >= $1 AND a.created_at < $2`;
+  const order = `ORDER BY a.created_at DESC`;
+
+  let rows: DbRow[];
+  try {
+    const sql = `${baseSelect} ${where}
+      AND a.consolidated_into IS NULL
+      AND (a.is_consolidated IS NULL OR a.is_consolidated = false)
+      ${order}`;
+    const res = await db.query<DbRow>(sql, [opts.start, opts.end]);
+    rows = res.rows;
+  } catch {
+    const sql = `${baseSelect} ${where} ${order}`;
+    const res = await db.query<DbRow>(sql, [opts.start, opts.end]);
+    rows = res.rows;
+  }
+
+  const byId = new Map<string, Article>();
+  for (const r of rows) {
+    let a = byId.get(r.id);
+    if (!a) {
+      a = {
+        id: r.id,
+        title: r.title,
+        publication_id: r.publication_id,
+        publication_name: r.publication_name ?? undefined,
+        created_at: r.created_at instanceof Date ? r.created_at : new Date(r.created_at),
+        word_count: r.word_count,
+        tags: [],
+      };
+      byId.set(r.id, a);
+    }
+    if (r.tag_slug && !a.tags.includes(r.tag_slug)) {
+      a.tags.push(r.tag_slug);
+    }
+  }
+
+  const articles = [...byId.values()]
+    .sort((a, b) => b.created_at.getTime() - a.created_at.getTime())
+    .slice(0, limit);
+
+  return groupArticles(articles);
+}
+
 // ── CLI wrapper ─────────────────────────────────────────────────────
 
 async function cliMain(): Promise<void> {


### PR DESCRIPTION
## Summary

- Adds `--backfill` and `--backfill-status` modes to `tools/editorial/consolidate.ts`.
- Walks historical articles in 14-day chunks (created_at DESC), calls `findConsolidationCandidates` on each chunk, and applies Mode A to candidate groups still single-source.
- Idempotent (skips `is_consolidated` / `consolidated_into IS NOT NULL`), honors `--limit N` and `--dry-run`.
- New `findCandidatesInRange()` helper accepts an explicit `[start, end)` window instead of `NOW() - interval`.
- `--backfill-status` prints total articles, already-consolidated count, estimated remaining groups, and date range.

Closes #452.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` — 282 passing
- [x] New integration tests cover `runBackfill --dry-run` across a multi-chunk fixture, `--limit` early-exit, chunk builder, and CLI parsing
- [ ] Manual smoke against live DB intentionally NOT performed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)