### PR TITLE
feat: loosen consolidation thresholds + recency primary + extend-recent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,20 @@ npm run static:preview    # Preview at localhost:3000
 - **Substack articles**: ~200 word excerpts with "Read full article" links
 - **Wikipedia rewrites**: Full content (we own copyright on our rewrites)
 
+## Consolidation (Mode A / B / C)
+
+`tools/editorial/consolidate.ts` synthesizes multi-source "by Brian Edwards" commentaries. Three modes:
+
+- **Mode A** — find a new candidate group and create a fresh consolidation.
+- **Mode B** — add one source to an existing consolidation (`--add-to <commentary_id> <source_id>`).
+- **Mode C** — scan recent un-consolidated articles and extend existing consolidations (<4 sources) with them (`--extend-recent`).
+
+**Thresholds** (`tools/editorial/consolidation-candidates.ts`): tag Jaccard ≥ 0.4, title cosine ≥ 0.5, 14-day window, max 4 sources per consolidation.
+
+**Primary source = most recent article** (byline rule). Mode C forces the newly-added article to become primary since it is newer than the existing primary by construction.
+
+**The unified loop runs `--auto --apply --limit 1`** each cycle, which does Mode A followed by Mode C in one invocation.
+
 ## Wikipedia Integration
 
 Each article gets 3 related Wikipedia deep dives. Topic selection must be specific and esoteric — "Battle of Thermopylae" not "Ancient Greece". Rewrites should read like magazine features, not encyclopedia entries. Vary sentence/paragraph length, spell out acronyms, explain from first principles. Optimized for Speechify text-to-speech.

--- a/tools/editorial/consolidate.test.ts
+++ b/tools/editorial/consolidate.test.ts
@@ -12,12 +12,14 @@ import type { CandidateGroup } from './consolidation-candidates.js';
 import {
   type ConsolidationPlan,
   buildBackfillChunks,
+  findExtendMatches,
   formatPlan,
   makeStubSynthesizer,
   parseArgs,
   runBackfill,
   runModeA,
   runModeB,
+  runModeC,
 } from './consolidate.js';
 
 // ── Fake DB ─────────────────────────────────────────────────────────
@@ -68,6 +70,10 @@ class FakeDb {
   wikiLinks: WikiLinkRow[] = [];
   /** Extra metadata only the backfill queries need. */
   meta = new Map<string, { created_at: Date; word_count: number | null; tags: string[] }>();
+  /** article_id -> tag slugs (for Mode C extend tests) */
+  tags = new Map<string, string[]>();
+  /** article_id -> created_at override (for Mode C extend tests) */
+  createdAt = new Map<string, Date>();
 
   query<T extends Record<string, unknown> = Record<string, unknown>>(
     sql: string,
@@ -252,6 +258,69 @@ class FakeDb {
       return { rows: [] };
     }
 
+    // Mode C: recent un-consolidated articles with tags.
+    if (s.startsWith('SELECT a.id, a.title, a.publication_id, a.created_at, at.tag_slug')) {
+      const rows: Record<string, unknown>[] = [];
+      for (const a of this.articles.values()) {
+        if (a.is_consolidated) { continue; }
+        if (a.consolidated_into !== null) { continue; }
+        const tagList = this.tags.get(a.id) ?? [];
+        const createdAt = this.createdAt.get(a.id) ?? new Date();
+        if (tagList.length === 0) {
+          rows.push({
+            id: a.id, title: a.title, publication_id: a.publication_id,
+            created_at: createdAt, tag_slug: null,
+          });
+        } else {
+          for (const tag of tagList) {
+            rows.push({
+              id: a.id, title: a.title, publication_id: a.publication_id,
+              created_at: createdAt, tag_slug: tag,
+            });
+          }
+        }
+      }
+      return { rows: rows as unknown as T[] };
+    }
+
+    // Mode C: existing consolidations with <4 sources.
+    if (s.startsWith('SELECT c.id, c.title,')) {
+      const rows: Record<string, unknown>[] = [];
+      for (const a of this.articles.values()) {
+        if (!a.is_consolidated) { continue; }
+        if (a.consolidated_into !== null) { continue; }
+        const sourceRows = this.commentarySources.filter(
+          (cs) => cs.commentary_article_id === a.id,
+        );
+        const sourcePubs = [
+          ...new Set(
+            sourceRows
+              .map((cs) => this.articles.get(cs.source_article_id)?.publication_id)
+              .filter((p): p is string => !!p),
+          ),
+        ];
+        const tagList = this.tags.get(a.id) ?? [];
+        if (tagList.length === 0) {
+          rows.push({
+            id: a.id, title: a.title,
+            source_count: String(sourceRows.length),
+            source_pubs: sourcePubs,
+            tag_slug: null,
+          });
+        } else {
+          for (const tag of tagList) {
+            rows.push({
+              id: a.id, title: a.title,
+              source_count: String(sourceRows.length),
+              source_pubs: sourcePubs,
+              tag_slug: tag,
+            });
+          }
+        }
+      }
+      return { rows: rows as unknown as T[] };
+    }
+
     if (s.startsWith('SELECT a.id, a.title, a.publication_id')) {
       // Range query from findCandidatesInRange. Two param shapes:
       //   [start, end]                              (with consolidated_into filter)
@@ -362,6 +431,8 @@ describe('parseArgs', () => {
       addTo: undefined,
       backfill: false,
       backfillStatus: false,
+      extendRecent: false,
+      auto: false,
     });
   });
   it('parses --apply --limit 3', () => {
@@ -373,6 +444,8 @@ describe('parseArgs', () => {
       addTo: undefined,
       backfill: false,
       backfillStatus: false,
+      extendRecent: false,
+      auto: false,
     });
   });
   it('parses --backfill --apply --limit 5', () => {
@@ -384,6 +457,17 @@ describe('parseArgs', () => {
   it('parses --backfill-status', () => {
     const p = parseArgs(['node', 'x', '--backfill-status']);
     expect(p.backfillStatus).toBe(true);
+  });
+  it('parses --extend-recent --apply', () => {
+    const p = parseArgs(['node', 'x', '--extend-recent', '--apply']);
+    expect(p.extendRecent).toBe(true);
+    expect(p.apply).toBe(true);
+  });
+  it('parses --auto', () => {
+    const p = parseArgs(['node', 'x', '--auto', '--apply', '--limit', '1']);
+    expect(p.auto).toBe(true);
+    expect(p.apply).toBe(true);
+    expect(p.limit).toBe(1);
   });
   it('parses --add-to', () => {
     const p = parseArgs(['node', 'x', '--add-to', 'com-1', 'src-2']);
@@ -765,5 +849,176 @@ describe('runModeB trigger prevents a 5th source', () => {
     expect(db.commentarySources.length).toBe(before);
     // New source NOT marked consolidated.
     expect(db.articles.get(newSourceId)?.consolidated_into).toBeNull();
+  });
+});
+
+// ── Mode C: extend-recent ───────────────────────────────────────────
+
+function seedExtendScenario(): FakeDb {
+  const db = new FakeDb();
+  // Existing consolidation with 2 sources (room for 2 more).
+  const commentaryId = 'ccccccc1-0000-0000-0000-000000000001';
+  db.articles.set(commentaryId, {
+    id: commentaryId,
+    title: 'Power grid strain across the region',
+    slug: 'power-grid-strain',
+    author_name: 'Brian Edwards',
+    publication_id: 'pub-alpha',
+    publication_name: 'Pub-alpha',
+    original_url: `hex-index://consolidated/${commentaryId}`,
+    rewritten_content_path: `rewritten/consolidated-${commentaryId}.html`,
+    content_path: null,
+    full_content_path: null,
+    affiliate_links: [],
+    is_consolidated: true,
+    consolidated_into: null,
+  });
+  db.tags.set(commentaryId, ['energy', 'grid', 'policy']);
+  db.commentarySources.push(
+    {
+      commentary_article_id: commentaryId,
+      source_article_id: 'src-old-1',
+      is_primary: true,
+      position: 0,
+    },
+    {
+      commentary_article_id: commentaryId,
+      source_article_id: 'src-old-2',
+      is_primary: false,
+      position: 1,
+    },
+  );
+  // Stub-out the old source articles so publication_id is resolvable.
+  for (const [sid, pub] of [
+    ['src-old-1', 'pub-beta'],
+    ['src-old-2', 'pub-gamma'],
+  ] as const) {
+    db.articles.set(sid, {
+      id: sid,
+      title: 'old',
+      slug: sid,
+      author_name: 'x',
+      publication_id: pub,
+      publication_name: `Pub-${pub}`,
+      original_url: `https://x.test/${sid}`,
+      rewritten_content_path: null,
+      content_path: null,
+      full_content_path: null,
+      affiliate_links: [],
+      is_consolidated: false,
+      consolidated_into: commentaryId,
+    });
+  }
+  // New recent article from a different publication on the same topic.
+  const newId = 'fffffff1-0000-0000-0000-000000000001';
+  db.articles.set(newId, {
+    id: newId,
+    title: 'Power grid strain across the region deepens',
+    slug: newId,
+    author_name: 'D. Delta',
+    publication_id: 'pub-delta',
+    publication_name: 'Pub-delta',
+    original_url: `https://x.test/${newId}`,
+    rewritten_content_path: null,
+    content_path: null,
+    full_content_path: null,
+    affiliate_links: [],
+    is_consolidated: false,
+    consolidated_into: null,
+  });
+  db.tags.set(newId, ['energy', 'grid', 'policy']);
+  db.createdAt.set(newId, new Date('2026-04-05T00:00:00Z'));
+  return db;
+}
+
+describe('findExtendMatches', () => {
+  it('matches a recent un-consolidated article to an existing commentary with room', async () => {
+    const db = seedExtendScenario();
+    const matches = await findExtendMatches(
+      db as unknown as Parameters<typeof findExtendMatches>[0],
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].newSourceId).toMatch(/fffffff1/);
+    expect(matches[0].commentaryId).toMatch(/ccccccc1/);
+    expect(matches[0].score).toBeGreaterThan(0.4);
+  });
+
+  it('skips commentaries that already have 4 sources', async () => {
+    const db = seedExtendScenario();
+    // Push two more sources up to 4.
+    const commentaryId = 'ccccccc1-0000-0000-0000-000000000001';
+    db.commentarySources.push(
+      {
+        commentary_article_id: commentaryId,
+        source_article_id: 'src-old-3',
+        is_primary: false,
+        position: 2,
+      },
+      {
+        commentary_article_id: commentaryId,
+        source_article_id: 'src-old-4',
+        is_primary: false,
+        position: 3,
+      },
+    );
+    db.articles.set('src-old-3', {
+      ...db.articles.get('src-old-1')!, id: 'src-old-3', publication_id: 'pub-eps',
+    });
+    db.articles.set('src-old-4', {
+      ...db.articles.get('src-old-1')!, id: 'src-old-4', publication_id: 'pub-zeta',
+    });
+    const matches = await findExtendMatches(
+      db as unknown as Parameters<typeof findExtendMatches>[0],
+    );
+    expect(matches).toHaveLength(0);
+  });
+
+  it('skips when the new article shares a publication with an existing source', async () => {
+    const db = seedExtendScenario();
+    const newId = 'fffffff1-0000-0000-0000-000000000001';
+    const a = db.articles.get(newId)!;
+    a.publication_id = 'pub-beta'; // same as src-old-1
+    const matches = await findExtendMatches(
+      db as unknown as Parameters<typeof findExtendMatches>[0],
+    );
+    expect(matches).toHaveLength(0);
+  });
+});
+
+describe('runModeC apply', () => {
+  it('adds the new source to the commentary via Mode B and forces primary', async () => {
+    const db = seedExtendScenario();
+    const libraryRoot = await mkdtemp(join(tmpdir(), 'consolidate-c-'));
+    const commentaryId = 'ccccccc1-0000-0000-0000-000000000001';
+    const newId = 'fffffff1-0000-0000-0000-000000000001';
+
+    const applied = await runModeC({
+      db: db as unknown as Parameters<typeof runModeC>[0]['db'],
+      synthesizer: makeStubSynthesizer(),
+      apply: true,
+      libraryRoot,
+      limit: 5,
+    });
+    expect(applied).toHaveLength(1);
+    // New source marked consolidated into the commentary.
+    expect(db.articles.get(newId)?.consolidated_into).toBe(commentaryId);
+    // New source row appended to commentary_sources.
+    const cs = db.commentarySources.filter((c) => c.commentary_article_id === commentaryId);
+    expect(cs.map((c) => c.source_article_id)).toContain(newId);
+    // forcePrimary flipped the new source to is_primary=true.
+    const primary = cs.find((c) => c.is_primary);
+    expect(primary?.source_article_id).toBe(newId);
+  });
+
+  it('dry-run returns matches without mutating', async () => {
+    const db = seedExtendScenario();
+    const before = db.commentarySources.length;
+    const matches = await runModeC({
+      db: db as unknown as Parameters<typeof runModeC>[0]['db'],
+      synthesizer: makeStubSynthesizer(),
+      apply: false,
+    });
+    expect(matches.length).toBeGreaterThan(0);
+    expect(db.commentarySources.length).toBe(before);
   });
 });

--- a/tools/editorial/consolidate.ts
+++ b/tools/editorial/consolidate.ts
@@ -34,9 +34,13 @@ import { dirname, join, resolve } from 'path';
 import type { Pool, PoolClient } from 'pg';
 import type { CandidateGroup, QueryableDb } from './consolidation-candidates.js';
 import {
+  TOPIC_JACCARD_MIN,
+  TITLE_COSINE_MIN,
   TIME_WINDOW_DAYS,
+  buildTitleTfIdf,
   findCandidatesInRange,
   findConsolidationCandidates,
+  jaccard,
 } from './consolidation-candidates.js';
 import {
   type AffiliateLink,
@@ -296,6 +300,13 @@ export async function runModeA(opts: ModeAOptions): Promise<ConsolidationPlan | 
     return null;
   }
 
+  // Primary source = most recent article in the group (byline at top uses
+  // the most recent voice). Overrides whatever the synthesizer suggested.
+  const mostRecent = [...group.articles].sort(
+    (a, b) => b.created_at.getTime() - a.created_at.getTime(),
+  )[0];
+  synth.primarySourceId = mostRecent.id;
+
   const commentaryId = randomUUID();
   const htmlPath = join('rewritten', `consolidated-${commentaryId}.html`);
 
@@ -403,6 +414,8 @@ export interface ModeBOptions {
   commentaryId: string;
   newSourceId: string;
   libraryRoot?: string;
+  /** If true, force the new source to become the commentary's primary. */
+  forcePrimary?: boolean;
 }
 
 export async function runModeB(opts: ModeBOptions): Promise<void> {
@@ -470,9 +483,9 @@ export async function runModeB(opts: ModeBOptions): Promise<void> {
     [commentaryId, revised.title, relPath],
   );
 
-  // Insert new source (not primary unless it genuinely displaces — we
-  // only displace if the synthesizer says so).
-  const becomePrimary = revised.primarySourceId === newSourceId;
+  // Insert new source. Become primary when explicitly forced (Mode C
+  // recency rule) or when the synthesizer picks it as dominant.
+  const becomePrimary = opts.forcePrimary === true || revised.primarySourceId === newSourceId;
   await db.query(
     `INSERT INTO app.commentary_sources
        (commentary_article_id, source_article_id, is_primary, position)
@@ -722,6 +735,198 @@ export function formatBackfillStatus(s: BackfillStatus): string {
   return lines.join('\n');
 }
 
+// ── Mode C: extend existing consolidations with new recent articles ─
+
+export interface ExtendMatch {
+  commentaryId: string;
+  commentaryTitle: string;
+  newSourceId: string;
+  newSourceTitle: string;
+  score: number;
+}
+
+interface RecentArticleRow extends Record<string, unknown> {
+  id: string;
+  title: string;
+  publication_id: string;
+  created_at: Date | string;
+  tag_slug: string | null;
+}
+
+interface CommentaryRow extends Record<string, unknown> {
+  id: string;
+  title: string;
+  source_count: string;
+  source_pubs: string[] | null;
+  tag_slug: string | null;
+}
+
+/**
+ * Find pairings of (recent un-consolidated article, existing
+ * consolidated commentary with <4 sources) whose titles + tags overlap
+ * above the loosened thresholds.
+ */
+export async function findExtendMatches(
+  db: DbClient,
+  opts: { days?: number; limit?: number } = {},
+): Promise<ExtendMatch[]> {
+  const days = opts.days ?? TIME_WINDOW_DAYS;
+  const limit = opts.limit ?? 200;
+
+  // Load recent un-consolidated articles (the candidates to add).
+  const recentSql = `
+    SELECT a.id, a.title, a.publication_id, a.created_at, at.tag_slug
+      FROM app.articles a
+      LEFT JOIN app.article_tags at ON at.article_id = a.id
+     WHERE a.created_at >= NOW() - ($1 || ' days')::interval
+       AND a.consolidated_into IS NULL
+       AND COALESCE(a.is_consolidated, false) = false
+     ORDER BY a.created_at DESC
+  `;
+  const recentRes = await db.query<RecentArticleRow>(recentSql, [String(days)]);
+
+  const byId = new Map<string, {
+    id: string;
+    title: string;
+    publication_id: string;
+    created_at: Date;
+    tags: Set<string>;
+  }>();
+  for (const r of recentRes.rows) {
+    let a = byId.get(r.id);
+    if (!a) {
+      a = {
+        id: r.id,
+        title: r.title,
+        publication_id: r.publication_id,
+        created_at: r.created_at instanceof Date ? r.created_at : new Date(r.created_at),
+        tags: new Set(),
+      };
+      byId.set(r.id, a);
+    }
+    if (r.tag_slug) { a.tags.add(r.tag_slug); }
+  }
+  const recents = [...byId.values()];
+
+  // Load existing consolidations with <4 sources and their aggregated tags+pubs.
+  const commentarySql = `
+    SELECT c.id, c.title,
+           (SELECT COUNT(*)::text FROM app.commentary_sources cs
+              WHERE cs.commentary_article_id = c.id) AS source_count,
+           (SELECT array_agg(DISTINCT sa.publication_id)
+              FROM app.commentary_sources cs
+              JOIN app.articles sa ON sa.id = cs.source_article_id
+             WHERE cs.commentary_article_id = c.id) AS source_pubs,
+           at.tag_slug
+      FROM app.articles c
+      LEFT JOIN app.article_tags at ON at.article_id = c.id
+     WHERE COALESCE(c.is_consolidated, false) = true
+       AND c.consolidated_into IS NULL
+  `;
+  const cRes = await db.query<CommentaryRow>(commentarySql, []);
+
+  const byCid = new Map<string, {
+    id: string;
+    title: string;
+    sourceCount: number;
+    sourcePubs: Set<string>;
+    tags: Set<string>;
+  }>();
+  for (const r of cRes.rows) {
+    let c = byCid.get(r.id);
+    if (!c) {
+      c = {
+        id: r.id,
+        title: r.title,
+        sourceCount: Number(r.source_count),
+        sourcePubs: new Set(r.source_pubs ?? []),
+        tags: new Set(),
+      };
+      byCid.set(r.id, c);
+    }
+    if (r.tag_slug) { c.tags.add(r.tag_slug); }
+  }
+
+  const matches: ExtendMatch[] = [];
+  for (const rec of recents) {
+    for (const com of byCid.values()) {
+      if (com.sourceCount >= 4) { continue; }
+      if (com.sourcePubs.has(rec.publication_id)) { continue; }
+      const tj = jaccard(rec.tags, com.tags);
+      if (tj < TOPIC_JACCARD_MIN) { continue; }
+      const sim = buildTitleTfIdf([rec.title, com.title]);
+      const ts = sim(0, 1);
+      if (ts < TITLE_COSINE_MIN) { continue; }
+      matches.push({
+        commentaryId: com.id,
+        commentaryTitle: com.title,
+        newSourceId: rec.id,
+        newSourceTitle: rec.title,
+        score: (tj + ts) / 2,
+      });
+    }
+  }
+
+  matches.sort((a, b) => b.score - a.score);
+
+  // De-dupe so each recent article matches only one commentary (the best).
+  const seenSrc = new Set<string>();
+  const seenCom = new Set<string>();
+  const deduped: ExtendMatch[] = [];
+  for (const m of matches) {
+    if (seenSrc.has(m.newSourceId)) { continue; }
+    if (seenCom.has(m.commentaryId)) { continue; }
+    seenSrc.add(m.newSourceId);
+    seenCom.add(m.commentaryId);
+    deduped.push(m);
+    if (deduped.length >= limit) { break; }
+  }
+  return deduped;
+}
+
+export interface RunModeCOptions {
+  db: DbClient;
+  synthesizer: CommentarySynthesizer;
+  apply: boolean;
+  limit?: number;
+  libraryRoot?: string;
+  days?: number;
+}
+
+/**
+ * Mode C: scan recent un-consolidated articles; for each, try to extend
+ * an existing consolidation (<4 sources) whose topic matches. Applies
+ * Mode B per match.
+ */
+export async function runModeC(opts: RunModeCOptions): Promise<ExtendMatch[]> {
+  const limit = opts.limit ?? 10;
+  const matches = await findExtendMatches(opts.db, { days: opts.days, limit });
+  if (!opts.apply) { return matches; }
+
+  const applied: ExtendMatch[] = [];
+  for (const m of matches.slice(0, limit)) {
+    try {
+      await runModeB({
+        db: opts.db,
+        synthesizer: opts.synthesizer,
+        commentaryId: m.commentaryId,
+        newSourceId: m.newSourceId,
+        libraryRoot: opts.libraryRoot,
+        forcePrimary: true,
+      });
+      applied.push(m);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(`extend skip ${m.commentaryId} <- ${m.newSourceId}: ${reason}`);
+      await logSkippedGroup(
+        [m.commentaryId, m.newSourceId],
+        `mode C extend failed: ${reason}`,
+      );
+    }
+  }
+  return applied;
+}
+
 // ── Plan printer ────────────────────────────────────────────────────
 
 export function formatPlan(plan: ConsolidationPlan): string {
@@ -748,6 +953,8 @@ interface CliArgs {
   addTo?: { commentaryId: string; sourceId: string };
   backfill: boolean;
   backfillStatus: boolean;
+  extendRecent: boolean;
+  auto: boolean;
 }
 
 export function parseArgs(argv: string[]): CliArgs {
@@ -766,6 +973,8 @@ export function parseArgs(argv: string[]): CliArgs {
       addTo: { commentaryId, sourceId },
       backfill: false,
       backfillStatus: false,
+      extendRecent: false,
+      auto: false,
     };
   }
   const apply = args.includes('--apply');
@@ -774,7 +983,18 @@ export function parseArgs(argv: string[]): CliArgs {
   const limit = limitIdx >= 0 ? Number(args[limitIdx + 1]) : 10;
   const backfill = args.includes('--backfill');
   const backfillStatus = args.includes('--backfill-status');
-  return { dryRun, apply, limit, addTo: undefined, backfill, backfillStatus };
+  const extendRecent = args.includes('--extend-recent');
+  const auto = args.includes('--auto');
+  return {
+    dryRun,
+    apply,
+    limit,
+    addTo: undefined,
+    backfill,
+    backfillStatus,
+    extendRecent,
+    auto,
+  };
 }
 
 async function cliMain(): Promise<void> {
@@ -821,31 +1041,58 @@ async function cliMain(): Promise<void> {
       return;
     }
 
-    const groups = await findConsolidationCandidates(pool as unknown as QueryableDb, { limit: 2000 });
-    console.info(`Found ${groups.length} candidate group(s)`);
-
-    const capped = groups.slice(0, cli.limit);
-    for (let i = 0; i < capped.length; i++) {
-      try {
-        const plan = await runModeA({
-          db: pool,
-          synthesizer,
-          group: capped[i],
-          groupIndex: i,
-          apply: cli.apply,
-        });
-        if (plan) {
-          console.info(formatPlan(plan));
-          console.info('');
+    const runModeAPass = async (): Promise<void> => {
+      const groups = await findConsolidationCandidates(pool as unknown as QueryableDb, { limit: 2000 });
+      console.info(`Found ${groups.length} candidate group(s)`);
+      const capped = groups.slice(0, cli.limit);
+      for (let i = 0; i < capped.length; i++) {
+        try {
+          const plan = await runModeA({
+            db: pool,
+            synthesizer,
+            group: capped[i],
+            groupIndex: i,
+            apply: cli.apply,
+          });
+          if (plan) {
+            console.info(formatPlan(plan));
+            console.info('');
+          }
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          console.warn(`  group ${String(i + 1)} failed unexpectedly: ${reason}`);
+          await logSkippedGroup(
+            capped[i].articles.map((a) => a.id),
+            `unexpected error: ${reason}`,
+          );
         }
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        console.warn(`  group ${String(i + 1)} failed unexpectedly: ${reason}`);
-        await logSkippedGroup(
-          capped[i].articles.map((a) => a.id),
-          `unexpected error: ${reason}`,
-        );
       }
+    };
+
+    const runModeCPass = async (): Promise<void> => {
+      const matches = await runModeC({
+        db: pool,
+        synthesizer,
+        apply: cli.apply,
+        limit: cli.limit,
+      });
+      console.info(`Extend-recent: ${matches.length} match(es)`);
+      for (const m of matches) {
+        console.info(
+          `  ${m.commentaryId} <- ${m.newSourceId}  score=${m.score.toFixed(3)}`,
+        );
+        console.info(`    commentary: ${m.commentaryTitle}`);
+        console.info(`    new source: ${m.newSourceTitle}`);
+      }
+    };
+
+    if (cli.auto) {
+      await runModeAPass();
+      await runModeCPass();
+    } else if (cli.extendRecent) {
+      await runModeCPass();
+    } else {
+      await runModeAPass();
     }
   } finally {
     await pool.end();

--- a/tools/editorial/consolidation-candidates.test.ts
+++ b/tools/editorial/consolidation-candidates.test.ts
@@ -59,7 +59,7 @@ describe('buildTitleTfIdf', () => {
       'China tightens export controls on rare earth metals',
       'Silicon Valley banks face new regulations',
     ]);
-    expect(sim(0, 1)).toBeGreaterThan(0.6);
+    expect(sim(0, 1)).toBeGreaterThan(0.5);
     expect(sim(0, 2)).toBeLessThan(0.3);
   });
 });
@@ -152,12 +152,13 @@ describe('groupArticles', () => {
     expect(groupArticles(articles)).toEqual([]);
   });
 
-  it('primary suggestion prefers highest word count', () => {
+  it('primary suggestion prefers the most recent article', () => {
     const articles: Article[] = [
+      // w1 has far more words but is older; w2 is newer and should win.
       mk('w1', 'China tightens rare earth export controls', 'pub1',
-        ['china', 'geopolitics', 'trade'], 0, 500),
+        ['china', 'geopolitics', 'trade'], 0, 9000),
       mk('w2', 'China tightens rare earth export rules', 'pub2',
-        ['china', 'geopolitics', 'trade'], 1, 2500),
+        ['china', 'geopolitics', 'trade'], 3, 500),
     ];
     const groups = groupArticles(articles);
     expect(groups).toHaveLength(1);
@@ -213,7 +214,8 @@ describe('findConsolidationCandidates (fake db)', () => {
     const groups: CandidateGroup[] = await findConsolidationCandidates(fakeDb, { days: 14 });
     expect(groups).toHaveLength(1);
     expect(groups[0].articles.map(a => a.id).sort()).toEqual(['a1', 'a2']);
-    expect(groups[0].primarySuggestion).toBe('a1');
+    // Most recent article wins as primary suggestion.
+    expect(groups[0].primarySuggestion).toBe('a2');
   });
 
   it('falls back when consolidated_into column does not exist', async () => {

--- a/tools/editorial/consolidation-candidates.ts
+++ b/tools/editorial/consolidation-candidates.ts
@@ -6,8 +6,8 @@
  * different publications).
  *
  * Scoring thresholds (tunable at the top of the file):
- *   - TOPIC_JACCARD_MIN   ≥ 0.5  — tag Jaccard similarity
- *   - TITLE_COSINE_MIN    ≥ 0.6  — title TF-IDF cosine similarity
+ *   - TOPIC_JACCARD_MIN   ≥ 0.4  — tag Jaccard similarity
+ *   - TITLE_COSINE_MIN    ≥ 0.5  — title TF-IDF cosine similarity
  *   - TIME_WINDOW_DAYS    ≤ 14   — created_at proximity
  *   - MAX_GROUP_SIZE      4      — hard cap per group
  *
@@ -20,8 +20,8 @@
  */
 
 // ── Tunable thresholds ──────────────────────────────────────────────
-export const TOPIC_JACCARD_MIN = 0.5;
-export const TITLE_COSINE_MIN = 0.6;
+export const TOPIC_JACCARD_MIN = 0.4;
+export const TITLE_COSINE_MIN = 0.5;
 export const TIME_WINDOW_DAYS = 14;
 export const MAX_GROUP_SIZE = 4;
 
@@ -257,12 +257,12 @@ export function groupArticles(articles: Article[]): CandidateGroup[] {
     }
     const score = count > 0 ? sum / count : 0;
 
-    // Primary suggestion: highest word count, tiebreak on most recent.
+    // Primary suggestion: most recent article, tiebreak on highest word count.
     const primary = [...groupArticles].sort((a, b) => {
-      const wa = a.word_count ?? 0;
-      const wb = b.word_count ?? 0;
-      if (wb !== wa) { return wb - wa; }
-      return b.created_at.getTime() - a.created_at.getTime();
+      const ta = a.created_at.getTime();
+      const tb = b.created_at.getTime();
+      if (tb !== ta) { return tb - ta; }
+      return (b.word_count ?? 0) - (a.word_count ?? 0);
     })[0];
 
     // Reasoning: shared tags, average title sim, source list.


### PR DESCRIPTION
## Summary
- Loosens candidate thresholds: tag Jaccard 0.5 -> 0.4, title cosine 0.6 -> 0.5 (14-day window unchanged).
- Primary-source rule is now **most recent** article (byline), replacing the highest-word-count rule in both `groupArticles` and `runModeA`.
- Adds **Mode C** (`--extend-recent`): scans recent un-consolidated articles and attaches them to existing consolidations that have <4 sources and pass the loosened topical thresholds. Invokes Mode B per match and forces the new (most-recent) source to become primary.
- Adds top-level `--auto` flag that runs Mode A then Mode C in one invocation. The unified loop will call `--auto --apply --limit 1` each cycle.
- 4-source cap remains enforced by the existing Mode B guard + DB trigger.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test` — 283/283 passing (added 7 new tests covering extend-matches, runModeC apply + dry-run, parseArgs for new flags, and updated primary-source pin).

Memory + CLAUDE.md updated to document the new behaviors.

Brian's directive: loosen thresholds slightly, allow recent articles to be folded into existing consolidations (cap 4), use the most-recent article in the byline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)