### PR TITLE
feat: trending story lines hero on home page

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1310,3 +1310,65 @@ main {
 .article-meta.consolidated-meta > .other-sources {
   margin-left: 0.35rem;
 }
+
+/* Trending story lines hero */
+.trending-hero {
+  margin: 0 0 2.5rem 0;
+  padding: 1.5rem 0 2rem 0;
+  border-top: 3px double var(--ink);
+  border-bottom: 3px double var(--ink);
+}
+.trending-hero-title {
+  margin: 0 0 1.25rem 0;
+  font-size: 1.5rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.trending-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.25rem;
+}
+@media (max-width: 700px) {
+  .trending-grid { grid-template-columns: 1fr; }
+}
+.trending-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-alt, #faf7f0);
+  border: 1px solid var(--ink);
+  border-radius: 4px;
+  overflow: hidden;
+  box-shadow: 3px 3px 0 var(--ink);
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+.trending-card:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 4px 4px 0 var(--ink);
+}
+.trending-thumb-link { display: block; }
+.trending-thumb {
+  display: block;
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  border-bottom: 1px solid var(--ink);
+}
+.trending-body { padding: 1rem 1.1rem 1.1rem 1.1rem; }
+.trending-link { text-decoration: none; color: inherit; }
+.trending-link:hover .trending-title { text-decoration: underline; }
+.trending-title {
+  margin: 0 0 0.6rem 0;
+  font-size: 1.25rem;
+  line-height: 1.25;
+}
+.trending-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+}
+.trending-author { font-weight: 600; color: var(--ink); }
+.trending-time { font-style: italic; }

--- a/tools/static-site/pages/home.ts
+++ b/tools/static-site/pages/home.ts
@@ -7,7 +7,9 @@ import {
   staticLayout,
   renderStaticArticleCard,
   renderStaticPagination,
+  renderTrendingHero,
   type StaticArticle,
+  type TrendingArticle,
 } from '../templates.js';
 import { writeFile, extractExcerpt } from '../utils.js';
 import { getDisplayTagsBulk, getConsolidationBulk } from './tag.js';
@@ -119,13 +121,72 @@ async function getArticlesForPage(
 }
 
 /**
+ * Get consolidated commentaries with at least one source article
+ * (published or created) within the last 7 days. Ordered by the
+ * most-recent source's created_at DESC.
+ */
+export async function getTrendingConsolidations(
+  pool: Pool
+): Promise<TrendingArticle[]> {
+  const result = await pool.query<ArticleRow & { most_recent_source_created_at: string; source_count: string }>(`
+    SELECT
+      a.id,
+      a.title,
+      a.author_name,
+      p.name as publication_name,
+      p.slug as publication_slug,
+      a.published_at,
+      a.estimated_read_time_minutes,
+      a.content_path,
+      a.image_path,
+      a.original_url,
+      mr.most_recent_source_created_at,
+      mr.source_count
+    FROM app.articles a
+    JOIN app.publications p ON a.publication_id = p.id
+    JOIN (
+      SELECT
+        cs.commentary_article_id,
+        MAX(src.created_at) AS most_recent_source_created_at,
+        COUNT(*) AS source_count
+      FROM app.commentary_sources cs
+      JOIN app.articles src ON src.id = cs.source_article_id
+      GROUP BY cs.commentary_article_id
+      HAVING MAX(GREATEST(COALESCE(src.published_at, 'epoch'::timestamptz), src.created_at))
+             >= NOW() - INTERVAL '7 days'
+    ) mr ON mr.commentary_article_id = a.id
+    WHERE ${READY_WHERE}
+      AND a.is_consolidated = true
+    ORDER BY mr.most_recent_source_created_at DESC
+  `);
+
+  return result.rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    author: row.author_name ?? 'Unknown',
+    publicationName: row.publication_name,
+    publicationSlug: row.publication_slug,
+    publishedAt: row.published_at,
+    estimatedReadTimeMinutes: row.estimated_read_time_minutes,
+    excerpt: '',
+    url: row.original_url,
+    imagePath: row.image_path,
+    displayTag: null,
+    isConsolidated: true,
+    sourceCount: parseInt(row.source_count, 10),
+    mostRecentSourceAt: row.most_recent_source_created_at,
+  }));
+}
+
+/**
  * Generate a single home page
  */
 function generateHomePage(
   articles: StaticArticle[],
   currentPage: number,
   totalPages: number,
-  pathToRoot: string
+  pathToRoot: string,
+  trending: TrendingArticle[] = []
 ): string {
   const articleCards = articles
     .map((article) => renderStaticArticleCard(article, pathToRoot))
@@ -133,7 +194,11 @@ function generateHomePage(
 
   const pagination = renderStaticPagination(currentPage, totalPages, pathToRoot);
 
+  // Only render the trending hero on page 1.
+  const heroHtml = currentPage === 1 ? renderTrendingHero(trending, pathToRoot) : '';
+
   const content = `
+    ${heroHtml}
     <section class="article-list">
       ${articleCards}
       ${pagination}
@@ -152,6 +217,7 @@ export async function generateHomePages(
 ): Promise<{ pagesGenerated: number; articlesProcessed: number }> {
   const totalArticles = await getTotalArticleCount(pool);
   const totalPages = Math.ceil(totalArticles / ARTICLES_PER_PAGE);
+  const trending = await getTrendingConsolidations(pool);
 
   let articlesProcessed = 0;
 
@@ -162,7 +228,7 @@ export async function generateHomePages(
     // Path to root differs based on page location
     const pathToRoot = page === 1 ? './' : '../../';
 
-    const html = generateHomePage(articles, page, totalPages, pathToRoot);
+    const html = generateHomePage(articles, page, totalPages, pathToRoot, trending);
 
     // Write to appropriate location
     const filePath =

--- a/tools/static-site/templates.test.ts
+++ b/tools/static-site/templates.test.ts
@@ -8,8 +8,11 @@ import {
   renderSourceExcerpt,
   renderInterlacedSourcesAndDeepDives,
   renderStaticArticleCard,
+  renderTrendingHero,
+  formatTimeAgo,
   type CommentarySource,
   type StaticArticle,
+  type TrendingArticle,
 } from './templates.js';
 
 const PATH = '../../';
@@ -179,5 +182,60 @@ describe('renderStaticArticleCard', () => {
     );
     expect(html).not.toContain('source-count-badge');
     expect(html).not.toContain('Brian Edwards');
+  });
+});
+
+function mkTrending(overrides: Partial<TrendingArticle> = {}): TrendingArticle {
+  return {
+    ...mkStaticArticle(),
+    isConsolidated: true,
+    sourceCount: 3,
+    imagePath: 'images/foo.jpg',
+    mostRecentSourceAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    ...overrides,
+  };
+}
+
+describe('formatTimeAgo', () => {
+  const now = new Date('2026-04-06T12:00:00Z');
+  it('formats minutes', () => {
+    expect(formatTimeAgo('2026-04-06T11:55:00Z', now)).toBe('5 minutes ago');
+  });
+  it('formats hours', () => {
+    expect(formatTimeAgo('2026-04-06T09:00:00Z', now)).toBe('3 hours ago');
+  });
+  it('formats days', () => {
+    expect(formatTimeAgo('2026-04-03T12:00:00Z', now)).toBe('3 days ago');
+  });
+  it('singularizes 1 day', () => {
+    expect(formatTimeAgo('2026-04-05T12:00:00Z', now)).toBe('1 day ago');
+  });
+});
+
+describe('renderTrendingHero', () => {
+  it('returns empty string when there are no trending consolidations', () => {
+    expect(renderTrendingHero([], './')).toBe('');
+  });
+
+  it('renders a section with header, card, image, badge, author, and time ago', () => {
+    const html = renderTrendingHero([mkTrending({ id: 'abc', title: 'Big Story', sourceCount: 4 })], './');
+    expect(html).toContain('class="trending-hero"');
+    expect(html).toContain('Trending story lines');
+    expect(html).toContain('class="trending-card"');
+    expect(html).toContain('class="trending-grid"');
+    expect(html).toContain('href="./article/abc/index.html"');
+    expect(html).toContain('<h3 class="trending-title">Big Story</h3>');
+    expect(html).toContain('by Brian Edwards');
+    expect(html).toContain('4 sources');
+    expect(html).toContain('days ago');
+    expect(html).toContain('src="./images/foo.jpg"');
+  });
+
+  it('renders multiple cards in order', () => {
+    const html = renderTrendingHero([
+      mkTrending({ id: 'first', title: 'First Story' }),
+      mkTrending({ id: 'second', title: 'Second Story' }),
+    ], './');
+    expect(html.indexOf('First Story')).toBeLessThan(html.indexOf('Second Story'));
   });
 });

--- a/tools/static-site/templates.ts
+++ b/tools/static-site/templates.ts
@@ -26,6 +26,71 @@ export interface StaticArticle {
   sourceCount?: number;
 }
 
+export interface TrendingArticle extends StaticArticle {
+  /** ISO timestamp of the most recent source's created_at (drives ordering + "time ago"). */
+  mostRecentSourceAt: string;
+}
+
+/**
+ * Format an ISO timestamp as a short relative phrase: "3 days ago", "5 hours ago", etc.
+ * Exported for tests.
+ */
+export function formatTimeAgo(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) {return '';}
+  const diffMs = Math.max(0, now.getTime() - then);
+  const mins = Math.floor(diffMs / 60000);
+  if (mins < 1) {return 'just now';}
+  if (mins < 60) {return `${mins} minute${mins === 1 ? '' : 's'} ago`;}
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) {return `${hours} hour${hours === 1 ? '' : 's'} ago`;}
+  const days = Math.floor(hours / 24);
+  if (days < 7) {return `${days} day${days === 1 ? '' : 's'} ago`;}
+  const weeks = Math.floor(days / 7);
+  return `${weeks} week${weeks === 1 ? '' : 's'} ago`;
+}
+
+/**
+ * Render the "Trending story lines" hero section for the home page.
+ * Returns an empty string when there are no qualifying consolidations,
+ * so the home page renders identically to before.
+ */
+export function renderTrendingHero(
+  trending: TrendingArticle[],
+  pathToRoot: string = './'
+): string {
+  if (trending.length === 0) {return '';}
+
+  const cards = trending.map((a) => {
+    const articleUrl = `${pathToRoot}article/${a.id}/index.html`;
+    const imgHtml = a.imagePath
+      ? `<a href="${articleUrl}" class="trending-thumb-link"><img class="trending-thumb" src="${pathToRoot}${a.imagePath}" alt="${escapeHtml(a.title)}" loading="lazy"></a>`
+      : '';
+    const sourceCount = a.sourceCount ?? 0;
+    const timeAgo = formatTimeAgo(a.mostRecentSourceAt);
+    return `<article class="trending-card">
+  ${imgHtml}
+  <div class="trending-body">
+    <a href="${articleUrl}" class="trending-link">
+      <h3 class="trending-title">${escapeHtml(a.title)}</h3>
+    </a>
+    <div class="trending-meta">
+      <span class="trending-author">by Brian Edwards</span>
+      <span class="source-count-badge">${sourceCount} sources</span>
+      ${timeAgo ? `<span class="trending-time">${escapeHtml(timeAgo)}</span>` : ''}
+    </div>
+  </div>
+</article>`;
+  }).join('\n');
+
+  return `<section class="trending-hero" aria-label="Trending story lines">
+  <h2 class="trending-hero-title">Trending story lines</h2>
+  <div class="trending-grid">
+    ${cards}
+  </div>
+</section>`;
+}
+
 /**
  * A source article that was synthesized into a multi-source commentary.
  * Position is 0-based and determines ordering + interlacing with deep dives.


### PR DESCRIPTION
## Summary
- Adds a "Trending story lines" hero at the top of the home page showing consolidated multi-source commentaries whose most recent source is within the last 7 days
- New SQL query in `home.ts` joins `commentary_sources` with a 7-day recency HAVING filter (published_at OR created_at), respects the existing READY gate, ordered by most-recent-source `created_at DESC`
- New `renderTrendingHero` template + `.trending-hero` / `.trending-grid` / `.trending-card` CSS with 2-col desktop / 1-col mobile, bordered card with image, "by Brian Edwards", N-sources badge, and relative time ("3 days ago")
- Hero is hidden when there are zero qualifying consolidations — backward compatible

## Test plan
- [x] `npm run lint && npm run typecheck && npm run test` (303 tests pass)
- [x] New snapshot tests for `renderTrendingHero` and `formatTimeAgo`
- [x] `npm run static:generate -- --only home` runs cleanly; with the current DB (most recent source 2026-03-25, NOW ~2026-04-07) no rows match the 7-day rule so the home page is unchanged — verified empty-state branch
- [ ] Once fresher sources land (next ingest cycle within 7 days of a consolidation), hero will appear automatically