### PR TITLE
feat: automated guard against banned publication slugs (#475)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -78,6 +78,26 @@ if [ -n "$CONTENT_MD_FILES" ]; then
     done
 fi
 
+# Banned publication slugs guard
+# Source of truth: src/shared/banned-publications.ts
+echo "Checking for banned publication slugs in content/ingest-subscribed.json..."
+if [ -f content/ingest-subscribed.json ] && [ -f src/shared/banned-publications.ts ]; then
+    BANNED_FOUND=$(node -e "
+        const fs = require('fs');
+        const src = fs.readFileSync('src/shared/banned-publications.ts', 'utf8');
+        const matches = src.match(/'([a-z0-9-]+)'/g) || [];
+        const banned = new Set(matches.map(m => m.slice(1, -1)));
+        const cfg = JSON.parse(fs.readFileSync('content/ingest-subscribed.json', 'utf8'));
+        const offenders = (cfg.publications || []).map(p => p.slug).filter(s => banned.has(s));
+        if (offenders.length) { console.log(offenders.join(',')); }
+    " 2>&1)
+    if [ -n "$BANNED_FOUND" ]; then
+        echo "❌ ERROR: Banned publication slugs found in content/ingest-subscribed.json: $BANNED_FOUND"
+        echo "   See src/shared/banned-publications.ts for the canonical list."
+        exit 1
+    fi
+fi
+
 # Check source file alphabetical order
 echo "Checking source file order..."
 npm run lint:sources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,16 @@ Twilio CLI profile: `hex-index` (already configured).
 
 **Subscriber list**: Managed externally in Google Sheet, fetched via authenticated Apps Script endpoint. Token: `SUBSCRIBER_TOKEN` in `~/.config/.env`.
 
+## Banned Publications
+
+Some publications must never be ingested. The canonical list of banned slugs lives in `src/shared/banned-publications.ts` (`BANNED_SLUGS`). Enforcement:
+
+- `src/shared/banned-publications.test.ts` parses `content/ingest-subscribed.json` and fails CI if any publication has a banned slug.
+- The pre-commit hook greps `content/ingest-subscribed.json` for banned slugs and blocks commits.
+- Database deletion of any banned publications already present in `app.publications` is handled separately by the loop owner — do not add deletion logic here.
+
+To add a new banned slug, edit `src/shared/banned-publications.ts` and add it to the `BANNED_SLUGS` set. Nothing else is required.
+
 ## Two-Site Architecture
 
 **Do not confuse the two sites. Do not regress either.**

--- a/src/shared/banned-publications.test.ts
+++ b/src/shared/banned-publications.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { BANNED_SLUGS } from './banned-publications.js';
+
+interface IngestPublication {
+  slug: string;
+  name?: string;
+}
+
+interface IngestConfig {
+  publications: IngestPublication[];
+}
+
+describe('banned-publications guard', () => {
+  it('BANNED_SLUGS contains the known-bad slugs', () => {
+    for (const slug of [
+      'a16zcrypto',
+      'thedailygwei',
+      'aliabdaal',
+      'vitadao',
+      'radreads',
+      'moderndatastack',
+      'simplicius',
+    ]) {
+      expect(BANNED_SLUGS.has(slug)).toBe(true);
+    }
+  });
+
+  it('content/ingest-subscribed.json contains no banned slugs', () => {
+    const path = resolve(process.cwd(), 'content/ingest-subscribed.json');
+    const raw = readFileSync(path, 'utf8');
+    const config = JSON.parse(raw) as IngestConfig;
+
+    expect(Array.isArray(config.publications)).toBe(true);
+
+    const offenders = config.publications
+      .map((p) => p.slug)
+      .filter((slug) => BANNED_SLUGS.has(slug));
+
+    expect(
+      offenders,
+      `Banned publication slugs found in content/ingest-subscribed.json: ${offenders.join(
+        ', '
+      )}. Remove them — see src/shared/banned-publications.ts`
+    ).toEqual([]);
+  });
+});

--- a/src/shared/banned-publications.ts
+++ b/src/shared/banned-publications.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical list of banned publication slugs.
+ *
+ * Publications listed here must NEVER appear in `content/ingest-subscribed.json`
+ * and must NEVER be present in the `app.publications` table.
+ *
+ * To add a new banned slug, append it to the set below. The accompanying test
+ * (`banned-publications.test.ts`) and the pre-commit hook will enforce that no
+ * banned slug sneaks back into the ingest config.
+ *
+ * Database deletion of banned publications is handled separately by the loop
+ * owner — this file is purely the source-of-truth list + ingest-config guard.
+ */
+export const BANNED_SLUGS: ReadonlySet<string> = new Set([
+  'a16zcrypto',
+  'thedailygwei',
+  'aliabdaal',
+  'vitadao',
+  'radreads',
+  'moderndatastack',
+  'simplicius',
+  'sinocism',
+  'web3-with-a16z',
+]);


### PR DESCRIPTION
## Summary
- Adds `src/shared/banned-publications.ts` as the canonical `BANNED_SLUGS` set (a16zcrypto, thedailygwei, aliabdaal, vitadao, radreads, moderndatastack, simplicius, sinocism, web3-with-a16z).
- Adds `src/shared/banned-publications.test.ts` which parses `content/ingest-subscribed.json` and fails if any publication slug is in `BANNED_SLUGS`.
- Adds a pre-commit hook step that greps `content/ingest-subscribed.json` against the canonical list and blocks the commit if any banned slug is present.
- Documents the guard in CLAUDE.md under a new "Banned Publications" section.

Database deletion of any banned publications already in `app.publications` is intentionally out of scope — that is owned by the loop owner.

Closes #475

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test` — 20 files / 298 tests passing
- [ ] Manually verify pre-commit hook fails when a banned slug is added to `content/ingest-subscribed.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)