### PR TITLE
fix: auto-NULL broken content_path at runtime (#473)

### DIFF
--- a/tools/static-site/pages/article.test.ts
+++ b/tools/static-site/pages/article.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest';
+import { autoNullBrokenArticlePaths, generateArticlePage } from './article.js';
+
+interface QueryCall {
+  sql: string;
+  params: unknown[];
+}
+
+function makeFakePool() {
+  const calls: QueryCall[] = [];
+  return {
+    calls,
+    pool: {
+      query: vi.fn((sql: string, params: unknown[]) => {
+        calls.push({ sql, params });
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      }),
+    },
+  };
+}
+
+describe('autoNullBrokenArticlePaths', () => {
+  it('NULLs content_path when the source file is missing/empty', async () => {
+    const { pool, calls } = makeFakePool();
+    // loadContent returns '' to simulate a missing file (matches loadArticleContent's catch).
+    const loadContent = vi.fn((_path: string | null) => Promise.resolve(''));
+
+    const result = await autoNullBrokenArticlePaths({
+      pool,
+      articleId: 'art-1',
+      isConsolidated: false,
+      contentPath: 'missing/file.html',
+      rewrittenContentPath: null,
+      loadContent,
+    });
+
+    expect(result.contentNulled).toBe(true);
+    expect(result.rewriteNulled).toBe(false);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sql).toContain('UPDATE app.articles SET content_path = NULL');
+    expect(calls[0].params).toEqual(['art-1']);
+  });
+
+  it('NULLs both content_path and rewritten_content_path when both files are broken', async () => {
+    const { pool, calls } = makeFakePool();
+    const loadContent = vi.fn((_path: string | null) => Promise.resolve(''));
+
+    const result = await autoNullBrokenArticlePaths({
+      pool,
+      articleId: 'art-2',
+      isConsolidated: false,
+      contentPath: 'src.html',
+      rewrittenContentPath: 'rewrite.html',
+      loadContent,
+    });
+
+    expect(result.contentNulled).toBe(true);
+    expect(result.rewriteNulled).toBe(true);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].sql).toContain('content_path = NULL');
+    expect(calls[1].sql).toContain('rewritten_content_path = NULL');
+    expect(calls[1].sql).toContain('rewrite_dirty = true');
+  });
+
+  it('does not NULL content_path when source content is present', async () => {
+    const { pool, calls } = makeFakePool();
+    const longContent = '<p>' + 'word '.repeat(100) + '</p>';
+    const loadContent = vi.fn((path: string | null) =>
+      Promise.resolve(path === 'good.html' ? longContent : ''),
+    );
+
+    const result = await autoNullBrokenArticlePaths({
+      pool,
+      articleId: 'art-3',
+      isConsolidated: false,
+      contentPath: 'good.html',
+      rewrittenContentPath: null,
+      loadContent,
+    });
+
+    expect(result.contentNulled).toBe(false);
+    expect(calls).toHaveLength(0);
+    expect(result.rawContent).toBe(longContent);
+  });
+
+  it('skips path checks for consolidated commentary articles', async () => {
+    const { pool, calls } = makeFakePool();
+    const loadContent = vi.fn((_path: string | null) => Promise.resolve(''));
+
+    const result = await autoNullBrokenArticlePaths({
+      pool,
+      articleId: 'art-4',
+      isConsolidated: true,
+      contentPath: 'src.html',
+      rewrittenContentPath: 'rewrite.html',
+      loadContent,
+    });
+
+    expect(result.contentNulled).toBe(false);
+    expect(result.rewriteNulled).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('does not issue an UPDATE when content_path is already null', async () => {
+    const { pool, calls } = makeFakePool();
+    const loadContent = vi.fn((_path: string | null) => Promise.resolve(''));
+
+    const result = await autoNullBrokenArticlePaths({
+      pool,
+      articleId: 'art-5',
+      isConsolidated: false,
+      contentPath: null,
+      rewrittenContentPath: 'rewrite.html',
+      loadContent,
+    });
+
+    expect(result.contentNulled).toBe(false);
+    expect(result.rewriteNulled).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sql).toContain('rewritten_content_path = NULL');
+  });
+});
+
+describe('generateArticlePage with rewrite but missing content_path', () => {
+  it('still renders the rewrite when content_path is null and excerpt is empty', () => {
+    const article = {
+      id: 'art-render-1',
+      title: 'A Test Article',
+      author_name: 'Jane Doe',
+      publication_name: 'Test Pub',
+      publication_slug: 'test-pub',
+      published_at: '2026-04-01T00:00:00Z',
+      estimated_read_time_minutes: 5,
+      content_path: null,
+      rewritten_content_path: 'rewrites/art-render-1.html',
+      image_path: 'images/art-render-1.jpg',
+      original_url: 'https://example.com/post',
+      affiliate_links: null,
+      is_consolidated: false,
+    };
+    const rewriteHtml = '<p>This is the editorial commentary body of the rewrite.</p>';
+
+    const html = generateArticlePage(
+      article,
+      rewriteHtml,
+      [],
+      [],
+      '',
+      true, // isFullRewrite
+      '', // empty excerpt because content_path is null
+      [],
+    );
+
+    expect(html).toContain('A Test Article');
+    expect(html).toContain('editorial commentary body of the rewrite');
+    expect(html).toContain('Jane Doe');
+  });
+});

--- a/tools/static-site/pages/article.ts
+++ b/tools/static-site/pages/article.ts
@@ -26,6 +26,69 @@ async function loadArticleContent(contentPath: string | null): Promise<string> {
   }
 }
 
+interface QueryRunner {
+  query: (sql: string, params: unknown[]) => Promise<unknown>;
+}
+
+interface AutoNullPathsArgs {
+  pool: QueryRunner;
+  articleId: string;
+  isConsolidated: boolean;
+  contentPath: string | null;
+  rewrittenContentPath: string | null;
+  loadContent: (path: string | null) => Promise<string>;
+}
+
+interface AutoNullPathsResult {
+  contentNulled: boolean;
+  rewriteNulled: boolean;
+  rawContent: string;
+  rewriteContent: string;
+}
+
+/**
+ * Runtime defense against drifted DB paths: if `content_path` or
+ * `rewritten_content_path` reference missing/empty files, NULL them in the DB
+ * so the article cleanly hides (or downgrades to rewrite-only) until ingest
+ * reproduces the file. Exported for unit testing.
+ */
+export async function autoNullBrokenArticlePaths(
+  args: AutoNullPathsArgs,
+): Promise<AutoNullPathsResult> {
+  const { pool, articleId, isConsolidated, contentPath, rewrittenContentPath, loadContent } = args;
+  const result: AutoNullPathsResult = {
+    contentNulled: false,
+    rewriteNulled: false,
+    rawContent: '',
+    rewriteContent: '',
+  };
+
+  result.rawContent = await loadContent(contentPath);
+  if (rewrittenContentPath) {
+    result.rewriteContent = await loadContent(rewrittenContentPath);
+  }
+
+  if (!isConsolidated && contentPath && result.rawContent.trim().length < 200) {
+    await pool.query(
+      'UPDATE app.articles SET content_path = NULL WHERE id = $1',
+      [articleId],
+    );
+    result.contentNulled = true;
+    result.rawContent = '';
+  }
+
+  if (!isConsolidated && rewrittenContentPath && result.rewriteContent.trim().length < 200) {
+    await pool.query(
+      'UPDATE app.articles SET rewritten_content_path = NULL, rewrite_dirty = true WHERE id = $1',
+      [articleId],
+    );
+    result.rewriteNulled = true;
+    result.rewriteContent = '';
+  }
+
+  return result;
+}
+
 interface ArticleRow {
   id: string;
   title: string;
@@ -474,9 +537,25 @@ export async function generateArticlePages(
 
   let _skipped = 0;
   for (const article of articles) {
-    // If we have a rewritten version, use full content; otherwise excerpt
+    // Runtime defense: NULL out broken content/rewrite paths in the DB.
+    const auto = await autoNullBrokenArticlePaths({
+      pool,
+      articleId: article.id,
+      isConsolidated: article.is_consolidated,
+      contentPath: article.content_path,
+      rewrittenContentPath: article.rewritten_content_path,
+      loadContent: loadArticleContent,
+    });
+    if (auto.contentNulled) {
+      article.content_path = null;
+    }
+    if (auto.rewriteNulled) {
+      article.rewritten_content_path = null;
+    }
     const hasRewrite = !!article.rewritten_content_path;
-    const rawContent = await loadArticleContent(article.content_path);
+    const rawContent = auto.rawContent;
+    const rewriteContent = auto.rewriteContent;
+
     // HIDE articles that aren't fully processed yet: no rewrite AND no readable source content.
     // These show as empty pages with no commentary and no excerpt — worse than invisible.
     // Consolidated commentary articles don't have a content_path (they synthesize from sources),
@@ -485,32 +564,19 @@ export async function generateArticlePages(
       _skipped++;
       continue;
     }
-    // Also skip if rewrite is claimed but the rewrite file is empty/missing.
-    // SYSTEMIC: when this happens, NULL the path in the DB and mark rewrite_dirty
-    // so the scheduled rewrite job re-queues it. The DB and disk must agree.
-    if (hasRewrite && !article.is_consolidated) {
-      const rewriteCheck = await loadArticleContent(article.rewritten_content_path);
-      if (rewriteCheck.trim().length < 200) {
-        await pool.query(
-          'UPDATE app.articles SET rewritten_content_path = NULL, rewrite_dirty = true WHERE id = $1',
-          [article.id],
-        );
-        _skipped++;
-        continue;
-      }
+    // Also skip if rewrite was nulled by autoNullBrokenArticlePaths above.
+    if (auto.rewriteNulled) {
+      _skipped++;
+      continue;
     }
+
     const isYouTube = article.original_url.includes('youtube.com') || article.original_url.includes('youtu.be');
     // Clean speech artifacts from YouTube transcripts before excerpting,
     // so cleaning operates on plain text and excerpt boundary is computed on cleaned result
     const contentForExcerpt = isYouTube ? cleanTranscript(rawContent) : rawContent;
     const excerpt = extractHtmlExcerpt(contentForExcerpt, 400);
 
-    let displayContent: string;
-    if (hasRewrite) {
-      displayContent = await loadArticleContent(article.rewritten_content_path);
-    } else {
-      displayContent = excerpt;
-    }
+    const displayContent: string = hasRewrite ? rewriteContent : excerpt;
     const wikipediaLinks = await getLinkedWikipedia(pool, article.id);
 
     // Build book deep dives from affiliate_links on the article


### PR DESCRIPTION
## Summary
- Mirrors the existing `rewritten_content_path` auto-NULL pattern in `generateArticlePages` for `content_path`, so missing/empty source files self-heal at static-generate time.
- Unlike a broken rewrite, a broken `content_path` does **not** skip the article — the rewrite alone can render, with an empty excerpt section until ingest reproduces the source file. If both are broken (and the article isn't consolidated), the article is skipped.
- Extracts the check into `autoNullBrokenArticlePaths` so it can be unit tested without a real Pool/filesystem.

Closes #473.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (302 tests, +6 new in `tools/static-site/pages/article.test.ts`)
- [x] New unit tests cover: missing source file issues `UPDATE ... content_path = NULL`; both paths broken issues both UPDATEs; healthy content does not issue UPDATE; consolidated articles bypass the check; null `content_path` isn't re-NULLed.
- [x] New render test: an article with a rewrite but null `content_path` and empty excerpt still renders via `generateArticlePage`.