### PR TITLE
fix(workers): pre-commit guard against docs/ regen with missing library/ files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -98,6 +98,16 @@ if [ -f content/ingest-subscribed.json ] && [ -f src/shared/banned-publications.
     fi
 fi
 
+# Library drift guard (issue #474)
+# Block docs-only static regen commits when matching library/ files are
+# untracked on disk — they would vanish on the next static:clean, 404'ing
+# the article.
+echo "Checking for library/ drift vs docs/ regen..."
+npx tsx tools/ops/check-library-drift.ts
+if [ $? -ne 0 ]; then
+    exit 1
+fi
+
 # Check source file alphabetical order
 echo "Checking source file order..."
 npm run lint:sources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,14 @@ Excerpts are bordered block quotes styled with `.article-excerpt` / `.source-exc
 
 **Critical rule for Claude background workers writing rewrites:** write the HTML file directly into the **main repo** at `/Users/bedwards/hex-index/library/rewritten/...` (NOT into the agent's worktree-local library/) and commit it as part of the same change. If a worker writes to its own worktree's `library/`, the file vanishes when the worktree is cleaned and the DB ends up pointing at nothing.
 
+**Pre-commit drift guard (issue #474)**: `tools/ops/check-library-drift.ts` runs from `.husky/pre-commit` and blocks any commit that:
+
+1. Stages files under `docs/article/` or `docs/wikipedia/`,
+2. Stages **zero** files under `library/`,
+3. Stages **zero** files under `src/` or `tools/` (i.e. it's a pure docs static-regen, not a real code change),
+
+…while leaving uncommitted (untracked or unstaged-modified) `library/rewritten/**.html` or `library/wikipedia/**.html` files lying on disk. Those files are almost certainly the source content for the regenerated docs pages and would be wiped by the next `static:clean` or worktree teardown, 404'ing the article. Stage them and commit again, or delete them if they aren't the source.
+
 **Self-healing**: the article and wiki generators detect missing/empty content files at generation time and:
 1. Skip the page (no broken HTML emitted)
 2. For article rewrites: NULL `rewritten_content_path` and set `rewrite_dirty = true` so the scheduled rewrite job re-queues it

--- a/tools/ops/check-library-drift.test.ts
+++ b/tools/ops/check-library-drift.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { checkLibraryDrift } from './check-library-drift';
+
+describe('checkLibraryDrift (issue #474)', () => {
+  it('not applicable when no docs/article or docs/wikipedia files staged', () => {
+    const r = checkLibraryDrift({
+      stagedFiles: ['docs/index.html', 'docs/styles.css'],
+      untrackedOrUnstagedLibraryFiles: ['library/rewritten/foo/bar.html'],
+    });
+    expect(r.applicable).toBe(false);
+    expect(r.ok).toBe(true);
+  });
+
+  it('not applicable when commit also touches library/', () => {
+    const r = checkLibraryDrift({
+      stagedFiles: [
+        'docs/article/abc/index.html',
+        'library/rewritten/foo/bar.html',
+      ],
+      untrackedOrUnstagedLibraryFiles: [],
+    });
+    expect(r.applicable).toBe(false);
+    expect(r.ok).toBe(true);
+  });
+
+  it('not applicable when commit touches src/ or tools/ (real code change)', () => {
+    const r = checkLibraryDrift({
+      stagedFiles: ['docs/article/abc/index.html', 'src/db/queries.ts'],
+      untrackedOrUnstagedLibraryFiles: ['library/rewritten/foo/bar.html'],
+    });
+    expect(r.applicable).toBe(false);
+  });
+
+  it('passes when applicable and no uncommitted library content exists', () => {
+    const r = checkLibraryDrift({
+      stagedFiles: ['docs/article/abc/index.html'],
+      untrackedOrUnstagedLibraryFiles: [],
+    });
+    expect(r.applicable).toBe(true);
+    expect(r.ok).toBe(true);
+    expect(r.offendingFiles).toEqual([]);
+  });
+
+  it('fails when docs-only commit leaves untracked library/rewritten file behind', () => {
+    const r = checkLibraryDrift({
+      stagedFiles: [
+        'docs/article/abc/index.html',
+        'docs/article/abc/excerpt.html',
+      ],
+      untrackedOrUnstagedLibraryFiles: [
+        'library/rewritten/sinocism/some-piece.html',
+      ],
+    });
+    expect(r.applicable).toBe(true);
+    expect(r.ok).toBe(false);
+    expect(r.offendingFiles).toEqual([
+      'library/rewritten/sinocism/some-piece.html',
+    ]);
+    expect(r.reason).toMatch(/library/);
+  });
+
+  it('fails when docs-only commit leaves untracked library/wikipedia file behind', () => {
+    const r = checkLibraryDrift({
+      stagedFiles: ['docs/wikipedia/battle-of-thermopylae/index.html'],
+      untrackedOrUnstagedLibraryFiles: [
+        'library/wikipedia/battle-of-thermopylae.html',
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.offendingFiles).toEqual([
+      'library/wikipedia/battle-of-thermopylae.html',
+    ]);
+  });
+
+  it('ignores non-content library files (e.g. images)', () => {
+    const r = checkLibraryDrift({
+      stagedFiles: ['docs/article/abc/index.html'],
+      untrackedOrUnstagedLibraryFiles: [
+        'library/images/foo.png',
+        'library/rewritten/foo/notes.txt',
+      ],
+    });
+    expect(r.ok).toBe(true);
+    expect(r.offendingFiles).toEqual([]);
+  });
+
+  it('reports multiple offending files sorted', () => {
+    const r = checkLibraryDrift({
+      stagedFiles: ['docs/article/abc/index.html'],
+      untrackedOrUnstagedLibraryFiles: [
+        'library/rewritten/zeta/c.html',
+        'library/rewritten/alpha/a.html',
+        'library/wikipedia/middle.html',
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.offendingFiles).toEqual([
+      'library/rewritten/alpha/a.html',
+      'library/rewritten/zeta/c.html',
+      'library/wikipedia/middle.html',
+    ]);
+  });
+});

--- a/tools/ops/check-library-drift.ts
+++ b/tools/ops/check-library-drift.ts
@@ -1,0 +1,140 @@
+/**
+ * Pre-commit guard: catch worker commits that regenerate docs/ for an article
+ * or wikipedia page but forget to also stage the underlying library/ HTML file.
+ *
+ * Failure mode this prevents (issue #474):
+ *   1. A worktree agent writes library/rewritten/<pub>/<slug>.html (untracked)
+ *   2. Runs static:generate, which inlines the file into docs/article/<id>/index.html
+ *   3. Commits ONLY the docs/ regen
+ *   4. The untracked library file is wiped on the next `static:clean` /
+ *      worktree teardown, and the article 404s on hex-index.com.
+ *
+ * Heuristic
+ * ─────────
+ * If the staged commit:
+ *   • touches at least one  docs/article/*  or  docs/wikipedia/*  path,
+ *   • touches ZERO          library/*       paths,
+ *   • touches ZERO          src/* or tools/* paths
+ *     (i.e. it looks like a pure docs static-regen from a worker),
+ * then walk the working tree for any library/rewritten/**.html or
+ * library/wikipedia/**.html files that exist on disk but are NOT tracked
+ * by git (untracked or unstaged-new). Any such file is almost certainly the
+ * source content for one of the staged docs pages and MUST be committed too.
+ *
+ * The check is intentionally cheap and DB-free so it can run from a git hook.
+ *
+ * Exit codes:
+ *   0 — clean (or check not applicable)
+ *   1 — drift detected; commit blocked
+ */
+
+import { execSync } from 'child_process';
+
+export interface DriftCheckInput {
+  /** Output of `git diff --cached --name-only` (one path per line). */
+  stagedFiles: string[];
+  /**
+   * Output of `git ls-files --others --exclude-standard` PLUS
+   *           `git diff --name-only` (unstaged modifications),
+   * filtered to library/ paths. One path per line.
+   */
+  untrackedOrUnstagedLibraryFiles: string[];
+}
+
+export interface DriftCheckResult {
+  applicable: boolean;
+  ok: boolean;
+  offendingFiles: string[];
+  reason?: string;
+}
+
+const DOCS_CONTENT_RE = /^docs\/(article|wikipedia)\//;
+const LIBRARY_RE = /^library\//;
+const CODE_RE = /^(src|tools)\//;
+const LIBRARY_CONTENT_RE = /^library\/(rewritten|wikipedia)\/.+\.html$/;
+
+export function checkLibraryDrift(input: DriftCheckInput): DriftCheckResult {
+  const staged = input.stagedFiles.filter((f) => f.length > 0);
+
+  const touchesDocsContent = staged.some((f) => DOCS_CONTENT_RE.test(f));
+  const touchesLibrary = staged.some((f) => LIBRARY_RE.test(f));
+  const touchesCode = staged.some((f) => CODE_RE.test(f));
+
+  if (!touchesDocsContent || touchesLibrary || touchesCode) {
+    return { applicable: false, ok: true, offendingFiles: [] };
+  }
+
+  const offending = input.untrackedOrUnstagedLibraryFiles
+    .filter((f) => f.length > 0)
+    .filter((f) => LIBRARY_CONTENT_RE.test(f))
+    .sort();
+
+  if (offending.length === 0) {
+    return { applicable: true, ok: true, offendingFiles: [] };
+  }
+
+  return {
+    applicable: true,
+    ok: false,
+    offendingFiles: offending,
+    reason:
+      'Commit regenerates docs/article or docs/wikipedia pages but does not ' +
+      'include any library/ files, yet uncommitted library content files ' +
+      'exist on disk. Stage them or the article will 404 after the next clean.',
+  };
+}
+
+function git(cmd: string): string {
+  try {
+    return execSync(`git ${cmd}`, { encoding: 'utf-8' });
+  } catch {
+    return '';
+  }
+}
+
+function main(): void {
+  const stagedFiles = git('diff --cached --name-only').split('\n');
+  const untracked = git('ls-files --others --exclude-standard').split('\n');
+  const unstagedModified = git('diff --name-only').split('\n');
+
+  const candidates = [...untracked, ...unstagedModified].filter((f) =>
+    f.startsWith('library/'),
+  );
+
+  const result = checkLibraryDrift({
+    stagedFiles,
+    untrackedOrUnstagedLibraryFiles: candidates,
+  });
+
+  if (!result.applicable || result.ok) {
+    process.exit(0);
+  }
+
+  process.stderr.write('\n');
+  process.stderr.write('❌ Library drift detected (issue #474 guard)\n');
+  process.stderr.write('\n');
+  process.stderr.write(`${result.reason}\n`);
+  process.stderr.write('\n');
+  process.stderr.write('Uncommitted library content files:\n');
+  for (const f of result.offendingFiles) {
+    process.stderr.write(`  • ${f}\n`);
+  }
+  process.stderr.write('\n');
+  process.stderr.write(
+    'Fix: `git add` the library/ files above and amend your staging, ' +
+      'or remove them from disk if they are not the source of the staged docs pages.\n',
+  );
+  process.exit(1);
+}
+
+// Run when invoked as CLI (tsx tools/ops/check-library-drift.ts).
+// Vitest imports the module without triggering this branch.
+const invokedDirectly =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  /check-library-drift\.ts$/.test(process.argv[1]);
+
+if (invokedDirectly) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Adds `tools/ops/check-library-drift.ts`, wired into `.husky/pre-commit`, that blocks the worker failure mode behind issue #474: a docs-only static regen commit while the underlying `library/rewritten/**.html` or `library/wikipedia/**.html` source file is still untracked on disk and would be wiped by the next `static:clean`.
- Heuristic (matches task option 3): if the staged commit touches `docs/article/*` or `docs/wikipedia/*` but touches **zero** `library/*` AND **zero** `src/*` or `tools/*` files, walk the working tree for any uncommitted `library/rewritten/**.html` or `library/wikipedia/**.html` files. Any hit fails the commit with a clear remediation message.
- Pure-function core (`checkLibraryDrift`) so it is DB-free, fast, and unit-testable; the CLI wrapper queries `git diff --cached`, `git ls-files --others --exclude-standard`, and `git diff` for the actual paths.
- Documents the guard in the existing `CLAUDE.md` "Library Files Are Source-of-Truth" section.

Refs #474.

## Test plan
- [x] `npx vitest run tools/ops/check-library-drift.test.ts` — 8/8 pass, covers: not-applicable cases (no docs content / library also staged / src+tools also staged), passing case (no uncommitted library files), failing cases for `library/rewritten` and `library/wikipedia`, ignored non-content library files (images, .txt), multi-file sorted output.
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (zero warnings)
- [x] `npm test` — 21 files, 321/321 pass
- [x] Pre-commit hook ran end-to-end on this very commit (vacuous pass: not applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)