### PR TITLE
feat(quality): publish gate + wikipedia staleness auto-regen

### DIFF
--- a/tools/editorial/publish-gate.test.ts
+++ b/tools/editorial/publish-gate.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the publish gate. Uses an in-memory fake Pool and a temp
+ * library directory so it runs offline. Covers:
+ *
+ *  - missing body file          (HX-style root-cause)
+ *  - broken wiki link           (HX-002/003/004 shape)
+ *  - dirty wiki link row        (HX-002 variant)
+ *  - consolidated-without-dives (HX-001)
+ *  - all-good passes
+ *  - slug extraction regex
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, mkdir, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  runPublishGate,
+  extractWikipediaSlugsFromBody,
+  type PublishGateResult,
+} from './publish-gate.js';
+
+// ── Fake Pool ───────────────────────────────────────────────────────
+
+interface FakeArticle {
+  id: string;
+  rewritten_content_path: string | null;
+  is_consolidated: boolean;
+}
+interface FakeWiki {
+  slug: string;
+  status: string | null;
+  rewrite_dirty: boolean;
+  content_path: string | null;
+}
+
+class FakePool {
+  articles = new Map<string, FakeArticle>();
+  wikis = new Map<string, FakeWiki>();
+  deepDiveLinks = new Map<string, number>(); // article_id -> count
+
+  query(sql: string, params?: unknown[]): Promise<{ rows: unknown[] }> {
+    const s = sql.replace(/\s+/g, ' ').trim();
+    if (s.startsWith('SELECT id, rewritten_content_path')) {
+      const id = params?.[0] as string;
+      const a = this.articles.get(id);
+      return Promise.resolve({
+        rows: a
+          ? [{
+              id: a.id,
+              rewritten_content_path: a.rewritten_content_path,
+              is_consolidated: a.is_consolidated,
+            }]
+          : [],
+      });
+    }
+    if (s.startsWith('SELECT slug, status, rewrite_dirty, content_path')) {
+      const slugs = (params?.[0] as string[]) ?? [];
+      const out = slugs
+        .map((slug) => this.wikis.get(slug))
+        .filter((w): w is FakeWiki => !!w);
+      return Promise.resolve({ rows: out });
+    }
+    if (s.startsWith('SELECT COUNT(*) AS count FROM app.article_wikipedia_links')) {
+      const id = params?.[0] as string;
+      const n = this.deepDiveLinks.get(id) ?? 0;
+      return Promise.resolve({ rows: [{ count: String(n) }] });
+    }
+    throw new Error(`unexpected SQL in test: ${s}`);
+  }
+}
+
+// ── Temp library sandbox ────────────────────────────────────────────
+
+let tmpRoot: string;
+let prevCwd: string;
+
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), 'publish-gate-'));
+  await mkdir(join(tmpRoot, 'library', 'rewritten'), { recursive: true });
+  await mkdir(join(tmpRoot, 'library', 'wikipedia'), { recursive: true });
+  prevCwd = process.cwd();
+  process.chdir(tmpRoot);
+});
+
+afterEach(async () => {
+  process.chdir(prevCwd);
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+// Long enough body to exceed the 200-char minimum easily.
+const LONG_BODY = 'x'.repeat(300);
+
+async function writeLibFile(rel: string, contents: string): Promise<void> {
+  const full = join(tmpRoot, 'library', rel);
+  await mkdir(join(full, '..'), { recursive: true });
+  await writeFile(full, contents);
+}
+
+describe('extractWikipediaSlugsFromBody', () => {
+  it('extracts absolute, relative and index.html forms', () => {
+    const html = `
+      <a href="/wikipedia/foo-bar/">a</a>
+      <a href="../wikipedia/baz/index.html">b</a>
+      <a href='../wikipedia/QUX/'>c</a>
+      <a href="https://en.wikipedia.org/wiki/Ignored">skip</a>
+    `;
+    const slugs = extractWikipediaSlugsFromBody(html).sort();
+    expect(slugs).toEqual(['baz', 'foo-bar', 'qux']);
+  });
+});
+
+describe('runPublishGate', () => {
+  function asPool(p: FakePool) {
+    return p as unknown as import('pg').Pool;
+  }
+
+  it('fails when the body file is missing', async () => {
+    const pool = new FakePool();
+    pool.articles.set('a1', {
+      id: 'a1',
+      rewritten_content_path: 'rewritten/a1.html',
+      is_consolidated: false,
+    });
+
+    const r: PublishGateResult = await runPublishGate(asPool(pool), 'a1');
+    expect(r.ok).toBe(false);
+    expect(r.failures.join('\n')).toMatch(/body file missing/);
+  });
+
+  it('fails when an inline wiki link has no matching DB row', async () => {
+    const pool = new FakePool();
+    pool.articles.set('a1', {
+      id: 'a1',
+      rewritten_content_path: 'rewritten/a1.html',
+      is_consolidated: false,
+    });
+    await writeLibFile(
+      'rewritten/a1.html',
+      `<p>${LONG_BODY}</p><a href="../wikipedia/ghost/">x</a>`,
+    );
+
+    const r = await runPublishGate(asPool(pool), 'a1');
+    expect(r.ok).toBe(false);
+    expect(r.failures.some((f) => f.includes('/ghost/'))).toBe(true);
+  });
+
+  it('fails when an inline wiki link points to a dirty row', async () => {
+    const pool = new FakePool();
+    pool.articles.set('a1', {
+      id: 'a1',
+      rewritten_content_path: 'rewritten/a1.html',
+      is_consolidated: false,
+    });
+    pool.wikis.set('foo', {
+      slug: 'foo',
+      status: 'complete',
+      rewrite_dirty: true,
+      content_path: 'wikipedia/foo.html',
+    });
+    await writeLibFile('wikipedia/foo.html', LONG_BODY);
+    await writeLibFile(
+      'rewritten/a1.html',
+      `<p>${LONG_BODY}</p><a href="/wikipedia/foo/">x</a>`,
+    );
+
+    const r = await runPublishGate(asPool(pool), 'a1');
+    expect(r.ok).toBe(false);
+    expect(r.failures.join('\n')).toMatch(/rewrite_dirty=true/);
+  });
+
+  it('fails a consolidated article that has zero deep-dive links (HX-001)', async () => {
+    const pool = new FakePool();
+    pool.articles.set('c1', {
+      id: 'c1',
+      rewritten_content_path: 'rewritten/c1.html',
+      is_consolidated: true,
+    });
+    await writeLibFile('rewritten/c1.html', `<p>${LONG_BODY}</p>`);
+    // No entry in deepDiveLinks → count = 0
+
+    const r = await runPublishGate(asPool(pool), 'c1');
+    expect(r.ok).toBe(false);
+    expect(r.failures.some((f) => f.includes('HX-001'))).toBe(true);
+  });
+
+  it('passes when body + wiki links + deep-dive links are all healthy', async () => {
+    const pool = new FakePool();
+    pool.articles.set('c1', {
+      id: 'c1',
+      rewritten_content_path: 'rewritten/c1.html',
+      is_consolidated: true,
+    });
+    pool.wikis.set('foo', {
+      slug: 'foo',
+      status: 'complete',
+      rewrite_dirty: false,
+      content_path: 'wikipedia/foo.html',
+    });
+    pool.deepDiveLinks.set('c1', 3);
+    await writeLibFile('wikipedia/foo.html', LONG_BODY);
+    await writeLibFile(
+      'rewritten/c1.html',
+      `<p>${LONG_BODY}</p><a href="../wikipedia/foo/index.html">x</a>`,
+    );
+
+    const r = await runPublishGate(asPool(pool), 'c1');
+    expect(r.failures).toEqual([]);
+    expect(r.ok).toBe(true);
+  });
+});

--- a/tools/editorial/publish-gate.ts
+++ b/tools/editorial/publish-gate.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env npx tsx
+/**
+ * Publish gate — enforces quality invariants before an article goes live
+ * on the static site. Protects against the HX-001..004 class of incidents:
+ *
+ *   HX-001  consolidated commentary with zero wiki deep dives
+ *   HX-002  article body references /wikipedia/<slug>/ whose page is
+ *           missing on disk (root cause: stale static generation)
+ *   HX-003  same root cause as HX-002, multi-source consolidated
+ *   HX-004  same root cause as HX-002
+ *
+ * See docs-internal/quality-tracker.md for the full postmortem.
+ *
+ * Three entry points:
+ *   1. runPublishGate(pool, articleId) — library API used by the static
+ *      generator to decide whether to render a page.
+ *   2. --scan CLI — batch-reports failing articles across the site.
+ *   3. --hide CLI — additionally NULLs image_path on failing articles to
+ *      remove them from listings until they're fixed.
+ *
+ * Usage:
+ *   npx tsx tools/editorial/publish-gate.ts --scan
+ *   npx tsx tools/editorial/publish-gate.ts --scan --hide
+ */
+
+import type { Pool } from 'pg';
+import { readFile, stat } from 'fs/promises';
+import { join } from 'path';
+import { config } from 'dotenv';
+
+export interface PublishGateResult {
+  ok: boolean;
+  failures: string[];
+}
+
+interface ArticleRow {
+  id: string;
+  rewritten_content_path: string | null;
+  is_consolidated: boolean;
+}
+
+interface WikiRow {
+  slug: string;
+  status: string | null;
+  rewrite_dirty: boolean | null;
+  content_path: string | null;
+}
+
+function libraryDir(): string {
+  return join(process.cwd(), 'library');
+}
+
+/**
+ * Extract `/wikipedia/<slug>/` references from an article body. Matches
+ * absolute (`/wikipedia/foo/`) and relative (`../wikipedia/foo/`) forms,
+ * as well as `../wikipedia/foo/index.html`. Case-insensitive.
+ */
+export function extractWikipediaSlugsFromBody(html: string): string[] {
+  const slugs = new Set<string>();
+  const re = /href\s*=\s*["'](?:\.\.\/|\/)?wikipedia\/([a-z0-9][a-z0-9-]*)\/?(?:index\.html)?["']/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    slugs.add(m[1].toLowerCase());
+  }
+  return [...slugs];
+}
+
+async function fileExistsNonEmpty(path: string, minBytes = 1): Promise<boolean> {
+  try {
+    const st = await stat(path);
+    return st.isFile() && st.size >= minBytes;
+  } catch {
+    return false;
+  }
+}
+
+async function readIfExists(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the publish gate against a single article. Returns `{ok, failures}`
+ * where `failures` is a human-readable list of reasons the article would
+ * be hidden. `ok === true` iff the list is empty.
+ */
+export async function runPublishGate(
+  pool: Pool,
+  articleId: string,
+): Promise<PublishGateResult> {
+  const failures: string[] = [];
+
+  const { rows } = await pool.query<ArticleRow>(
+    `SELECT id, rewritten_content_path, COALESCE(is_consolidated, false) AS is_consolidated
+     FROM app.articles WHERE id = $1`,
+    [articleId],
+  );
+  if (rows.length === 0) {
+    return { ok: false, failures: [`article ${articleId} not found`] };
+  }
+  const article = rows[0];
+
+  // 1. Body file exists and is non-empty (>200 chars). Consolidated
+  //    commentaries also use rewritten_content_path (synthesized), so the
+  //    same check applies to both article kinds.
+  let bodyHtml = '';
+  if (!article.rewritten_content_path) {
+    failures.push('no rewritten_content_path set');
+  } else {
+    const fullPath = join(libraryDir(), article.rewritten_content_path);
+    const content = await readIfExists(fullPath);
+    if (content === null) {
+      failures.push(`body file missing: ${article.rewritten_content_path}`);
+    } else if (content.trim().length <= 200) {
+      failures.push(
+        `body file too small (<=200 chars): ${article.rewritten_content_path}`,
+      );
+    } else {
+      bodyHtml = content;
+    }
+  }
+
+  // 2. Every inline /wikipedia/<slug>/ link must resolve to a DB row that
+  //    is complete, not dirty, has a content_path, and whose library file
+  //    exists on disk.
+  if (bodyHtml) {
+    const slugs = extractWikipediaSlugsFromBody(bodyHtml);
+    if (slugs.length > 0) {
+      const { rows: wikiRows } = await pool.query<WikiRow>(
+        `SELECT slug, status, rewrite_dirty, content_path
+         FROM app.wikipedia_articles
+         WHERE slug = ANY($1::text[])`,
+        [slugs],
+      );
+      const wikiMap = new Map(wikiRows.map((r) => [r.slug.toLowerCase(), r]));
+      for (const slug of slugs) {
+        const w = wikiMap.get(slug);
+        if (!w) {
+          failures.push(`wiki link /${slug}/ has no DB row`);
+          continue;
+        }
+        if ((w.status ?? 'complete') !== 'complete') {
+          failures.push(`wiki link /${slug}/ status=${w.status}`);
+          continue;
+        }
+        if (w.rewrite_dirty) {
+          failures.push(`wiki link /${slug}/ rewrite_dirty=true`);
+          continue;
+        }
+        if (!w.content_path) {
+          failures.push(`wiki link /${slug}/ content_path is NULL`);
+          continue;
+        }
+        const fp = join(libraryDir(), w.content_path);
+        if (!(await fileExistsNonEmpty(fp))) {
+          failures.push(`wiki link /${slug}/ library file missing: ${w.content_path}`);
+        }
+      }
+    }
+  }
+
+  // 3. Consolidated commentaries must have at least one wiki deep-dive
+  //    linked via article_wikipedia_links (HX-001).
+  if (article.is_consolidated) {
+    const { rows: linkRows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM app.article_wikipedia_links WHERE article_id = $1`,
+      [articleId],
+    );
+    const n = parseInt(linkRows[0]?.count ?? '0', 10);
+    if (n === 0) {
+      failures.push('consolidated article has zero deep-dive links (HX-001)');
+    }
+  }
+
+  return { ok: failures.length === 0, failures };
+}
+
+// ── Cross-request cache of failed article IDs ───────────────────────
+// Populated once per static-generator run via computeFailedGateIds(), then
+// consumed by listing queries (home/publication/tag) to filter out broken
+// articles without a per-request DB round trip.
+
+let failedGateIds: Set<string> = new Set<string>();
+
+export function getFailedGateIds(): ReadonlySet<string> {
+  return failedGateIds;
+}
+
+/** Build a SQL fragment for WHERE clauses that filters failed-gate IDs. */
+export function failedGateSqlFragment(articleAlias = 'a'): string {
+  const ids = [...failedGateIds];
+  if (ids.length === 0) {return 'TRUE';}
+  const list = ids.map((id) => `'${id.replace(/'/g, "''")}'`).join(',');
+  return `${articleAlias}.id NOT IN (${list})`;
+}
+
+/**
+ * Scan every article eligible for publication and run the publish gate.
+ * Populates the module-level failed-gate set and returns the detailed
+ * results for reporting / CLI use.
+ */
+export async function computeFailedGateIds(
+  pool: Pool,
+): Promise<Array<{ id: string; failures: string[] }>> {
+  const { rows } = await pool.query<{ id: string }>(
+    `SELECT id FROM app.articles
+     WHERE (rewritten_content_path IS NOT NULL OR is_consolidated = true)
+       AND consolidated_into IS NULL
+       AND image_path IS NOT NULL`,
+  );
+  const failed: Array<{ id: string; failures: string[] }> = [];
+  const set = new Set<string>();
+  for (const { id } of rows) {
+    const result = await runPublishGate(pool, id);
+    if (!result.ok) {
+      failed.push({ id, failures: result.failures });
+      set.add(id);
+    }
+  }
+  failedGateIds = set;
+  return failed;
+}
+
+/** Test-only hook. */
+export function _setFailedGateIdsForTest(ids: Iterable<string>): void {
+  failedGateIds = new Set(ids);
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────
+
+async function mainCli(): Promise<void> {
+  config();
+  const args = process.argv.slice(2);
+  if (!args.includes('--scan')) {
+    console.error('Usage: publish-gate.ts --scan [--hide]');
+    process.exit(2);
+  }
+  const hide = args.includes('--hide');
+
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('Error: DATABASE_URL not set');
+    process.exit(1);
+  }
+
+  const { createPool } = await import('../../src/db/queries.js');
+  const pool = createPool(databaseUrl);
+  try {
+    console.info('Publish gate: scanning eligible articles...');
+    const failed = await computeFailedGateIds(pool);
+    console.info(`\n${failed.length} article(s) failed the publish gate:\n`);
+    for (const f of failed) {
+      console.info(`  ${f.id}`);
+      for (const reason of f.failures) {
+        console.info(`    - ${reason}`);
+      }
+    }
+    if (hide && failed.length > 0) {
+      console.info(`\n--hide: NULLing image_path on ${failed.length} article(s)...`);
+      await pool.query(
+        `UPDATE app.articles SET image_path = NULL WHERE id = ANY($1::text[])`,
+        [failed.map((f) => f.id)],
+      );
+      console.info('Done.');
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+// Run CLI only when invoked directly (not when imported).
+const isDirectRun = (() => {
+  try {
+    const argv1 = process.argv[1] ?? '';
+    return argv1.endsWith('publish-gate.ts') || argv1.endsWith('publish-gate.js');
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectRun) {
+  mainCli().catch((err: unknown) => {
+    console.error('Error:', err);
+    process.exit(1);
+  });
+}

--- a/tools/static-site/generate.ts
+++ b/tools/static-site/generate.ts
@@ -31,9 +31,11 @@ import { generateWeeklyEpubs } from './pages/weekly.js';
 import { generateAboutPage } from './pages/about.js';
 import { generatePrivacyPage, generateTermsPage } from './pages/legal.js';
 import { ensureDir } from './utils.js';
-import { rm, cp, readFile, writeFile, readdir } from 'fs/promises';
+import { computeFailedGateIds } from '../editorial/publish-gate.js';
+import { rm, cp, readFile, writeFile, readdir, stat } from 'fs/promises';
 import { join } from 'path';
 import { existsSync } from 'fs';
+import type { Pool } from 'pg';
 
 config();
 
@@ -107,6 +109,28 @@ async function main(): Promise<void> {
 
     await ensureDir(OUTPUT_DIR);
 
+    // Publish gate: pre-scan eligible articles so listing queries and the
+    // article generator can skip broken articles consistently. Skipped for
+    // single-article runs (article.ts handles those inline).
+    if (!singleArticleId) {
+      console.info('Running publish gate pre-scan...');
+      const failed = await computeFailedGateIds(pool);
+      console.info(`  ${failed.length} article(s) hidden by publish gate\n`);
+    }
+
+    // Wikipedia staleness check: if the caller didn't ask for wikipedia
+    // regen explicitly, but new wiki articles have landed since the
+    // newest file in docs/wikipedia/ — or any article body references a
+    // /wikipedia/<slug>/ that's missing on disk — force a wiki regen.
+    // This is the systemic root cause of HX-002/003/004.
+    let forceWikipedia = false;
+    if (!singleArticleId && onlySet && !onlySet.has('wikipedia')) {
+      forceWikipedia = await wikipediaIsStale(pool, OUTPUT_DIR);
+      if (forceWikipedia) {
+        console.info('Wikipedia pages are stale — forcing wikipedia regen this run.\n');
+      }
+    }
+
     // Copy static assets
     if (shouldRun('assets') || (!onlySet && !singleArticleId)) {
       console.info('Copying static assets...');
@@ -141,7 +165,7 @@ async function main(): Promise<void> {
       console.info(`  ${articleResult.pagesGenerated} pages\n`);
     }
 
-    if (shouldRun('wikipedia')) {
+    if (shouldRun('wikipedia') || forceWikipedia) {
       console.info('Generating Wikipedia pages...');
       const wikiResult = await generateWikipediaPages(pool, OUTPUT_DIR);
       console.info(`  ${wikiResult.pagesGenerated} pages\n`);
@@ -189,6 +213,72 @@ async function main(): Promise<void> {
   } finally {
     await pool.end();
   }
+}
+
+/**
+ * Detect whether docs/wikipedia/ is stale relative to the database.
+ *
+ * Returns true if EITHER:
+ *   (a) Any wikipedia_articles row has updated_at newer than the newest
+ *       index.html under docs/wikipedia/, OR
+ *   (b) Any rewritten article body references a /wikipedia/<slug>/ path
+ *       whose docs/wikipedia/<slug>/index.html is missing on disk.
+ *
+ * This protects against the HX-002/003/004 root cause: running
+ * `--only home,articles,tags` and forgetting `wikipedia`.
+ */
+async function wikipediaIsStale(pool: Pool, outputDir: string): Promise<boolean> {
+  const wikiDir = join(outputDir, 'wikipedia');
+  if (!existsSync(wikiDir)) {return true;}
+
+  // Newest mtime under docs/wikipedia/. We sample by reading the
+  // top-level entries' index.html mtimes — sufficient for staleness.
+  let newestMs = 0;
+  try {
+    const entries = await readdir(wikiDir);
+    for (const slug of entries) {
+      try {
+        const st = await stat(join(wikiDir, slug, 'index.html'));
+        if (st.mtimeMs > newestMs) {newestMs = st.mtimeMs;}
+      } catch { /* skip */ }
+    }
+  } catch {
+    return true;
+  }
+
+  // (a) Any wiki row updated since the newest file?
+  try {
+    const { rows } = await pool.query<{ count: string }>(
+      `SELECT COUNT(*) AS count FROM app.wikipedia_articles
+       WHERE COALESCE(status, 'complete') = 'complete'
+         AND content_path IS NOT NULL
+         AND updated_at > to_timestamp($1)`,
+      [newestMs / 1000],
+    );
+    if (parseInt(rows[0]?.count ?? '0', 10) > 0) {return true;}
+  } catch {
+    // Column may not exist in some envs — fall through to check (b).
+  }
+
+  // (b) Any inline /wikipedia/<slug>/ referenced by an article body that
+  //     doesn't exist on disk yet?
+  try {
+    const { rows } = await pool.query<{ slug: string }>(
+      `SELECT DISTINCT w.slug
+       FROM app.article_wikipedia_links awl
+       JOIN app.wikipedia_articles w ON w.id = awl.wikipedia_id
+       WHERE COALESCE(w.status, 'complete') = 'complete'
+         AND w.rewrite_dirty = false
+         AND w.content_path IS NOT NULL`,
+    );
+    for (const { slug } of rows) {
+      if (!existsSync(join(wikiDir, slug, 'index.html'))) {return true;}
+    }
+  } catch {
+    /* ignore */
+  }
+
+  return false;
 }
 
 main().catch((err: unknown) => {

--- a/tools/static-site/pages/article.ts
+++ b/tools/static-site/pages/article.ts
@@ -6,6 +6,7 @@
 import type { Pool } from 'pg';
 import { staticReadingLayout, renderArticleMeta, renderInterlacedSourcesAndDeepDives, type CommentarySource } from '../templates.js';
 import { writeFile, extractHtmlExcerpt, escapeHtml, formatDate, buildAmazonUrl, buildBWBUrl, loadAffiliateBooks, cleanTranscript } from '../utils.js';
+import { computeFailedGateIds, getFailedGateIds, runPublishGate } from '../../editorial/publish-gate.js';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
 
@@ -535,8 +536,32 @@ export async function generateArticlePages(
   const affiliateTag = process.env.AMAZON_AFFILIATE_TAG ?? '';
   let pagesGenerated = 0;
 
+  // Publish gate: ensure the failed-set is populated for batch runs.
+  // generate.ts populates this before page generation, but tests and
+  // direct callers may bypass that path. For --article single runs we
+  // run the gate inline below instead of pre-scanning the whole DB.
+  if (!articleId && getFailedGateIds().size === 0) {
+    await computeFailedGateIds(pool);
+  }
+  const failedSet = getFailedGateIds();
+
   let _skipped = 0;
   for (const article of articles) {
+    // Publish gate: skip articles with broken internal links, missing
+    // bodies, or (for consolidated commentaries) zero deep dives.
+    if (articleId) {
+      const gate = await runPublishGate(pool, article.id);
+      if (!gate.ok) {
+        console.warn(`publish-gate: skipping ${article.id}: ${gate.failures.join('; ')}`);
+        _skipped++;
+        continue;
+      }
+    } else if (failedSet.has(article.id)) {
+      console.warn(`publish-gate: skipping ${article.id} (failed pre-scan)`);
+      _skipped++;
+      continue;
+    }
+
     // Runtime defense: NULL out broken content/rewrite paths in the DB.
     const auto = await autoNullBrokenArticlePaths({
       pool,

--- a/tools/static-site/pages/home.ts
+++ b/tools/static-site/pages/home.ts
@@ -12,6 +12,7 @@ import {
   type TrendingArticle,
 } from '../templates.js';
 import { writeFile, extractExcerpt } from '../utils.js';
+import { failedGateSqlFragment } from '../../editorial/publish-gate.js';
 import { getDisplayTagsBulk, getConsolidationBulk } from './tag.js';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
@@ -51,16 +52,20 @@ interface ArticleRow {
 /**
  * Get total article count
  */
-/** WHERE clause filtering out in-flight (not-yet-rewritten) articles and absorbed sources. */
-const READY_WHERE = `(
-  (a.rewritten_content_path IS NOT NULL OR a.is_consolidated = true)
-  AND (a.consolidated_into IS NULL)
-  AND (a.image_path IS NOT NULL)
-)`;
+/** WHERE clause filtering out in-flight (not-yet-rewritten) articles, absorbed
+ *  sources, and articles that failed this run's publish gate. */
+function readyWhereSql(): string {
+  return `(
+    (a.rewritten_content_path IS NOT NULL OR a.is_consolidated = true)
+    AND (a.consolidated_into IS NULL)
+    AND (a.image_path IS NOT NULL)
+    AND ${failedGateSqlFragment('a')}
+  )`;
+}
 
 async function getTotalArticleCount(pool: Pool): Promise<number> {
   const result = await pool.query<{ count: string }>(`
-    SELECT COUNT(*) as count FROM app.articles a WHERE ${READY_WHERE}
+    SELECT COUNT(*) as count FROM app.articles a WHERE ${readyWhereSql()}
   `);
   return parseInt(result.rows[0].count, 10);
 }
@@ -88,7 +93,7 @@ async function getArticlesForPage(
       a.original_url
     FROM app.articles a
     JOIN app.publications p ON a.publication_id = p.id
-    WHERE ${READY_WHERE}
+    WHERE ${readyWhereSql()}
     ORDER BY a.published_at DESC NULLS LAST
     LIMIT $1 OFFSET $2
   `, [ARTICLES_PER_PAGE, offset]);
@@ -155,7 +160,7 @@ export async function getTrendingConsolidations(
       HAVING MAX(GREATEST(COALESCE(src.published_at, 'epoch'::timestamptz), src.created_at))
              >= NOW() - INTERVAL '7 days'
     ) mr ON mr.commentary_article_id = a.id
-    WHERE ${READY_WHERE}
+    WHERE ${readyWhereSql()}
       AND a.is_consolidated = true
     ORDER BY mr.most_recent_source_created_at DESC
   `);

--- a/tools/static-site/pages/publication.ts
+++ b/tools/static-site/pages/publication.ts
@@ -10,6 +10,7 @@ import {
   type StaticArticle,
 } from '../templates.js';
 import { writeFile, extractExcerpt, escapeHtml } from '../utils.js';
+import { failedGateSqlFragment } from '../../editorial/publish-gate.js';
 import { getDisplayTagsBulk, getConsolidationBulk } from './tag.js';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
@@ -78,11 +79,12 @@ async function getPublicationArticleCount(
   publicationId: string
 ): Promise<number> {
   const result = await pool.query<{ count: string }>(`
-    SELECT COUNT(*) as count FROM app.articles
-    WHERE publication_id = $1
-      AND (rewritten_content_path IS NOT NULL OR is_consolidated = true)
-      AND consolidated_into IS NULL
-      AND image_path IS NOT NULL
+    SELECT COUNT(*) as count FROM app.articles a
+    WHERE a.publication_id = $1
+      AND (a.rewritten_content_path IS NOT NULL OR a.is_consolidated = true)
+      AND a.consolidated_into IS NULL
+      AND a.image_path IS NOT NULL
+      AND ${failedGateSqlFragment('a')}
   `, [publicationId]);
   return parseInt(result.rows[0].count, 10);
 }
@@ -99,20 +101,21 @@ async function getPublicationArticles(
 
   const result = await pool.query<ArticleRow>(`
     SELECT
-      id,
-      title,
-      author_name,
-      published_at,
-      estimated_read_time_minutes,
-      content_path,
-      image_path,
-      original_url
-    FROM app.articles
-    WHERE publication_id = $1
-      AND (rewritten_content_path IS NOT NULL OR is_consolidated = true)
-      AND consolidated_into IS NULL
-      AND image_path IS NOT NULL
-    ORDER BY published_at DESC NULLS LAST
+      a.id,
+      a.title,
+      a.author_name,
+      a.published_at,
+      a.estimated_read_time_minutes,
+      a.content_path,
+      a.image_path,
+      a.original_url
+    FROM app.articles a
+    WHERE a.publication_id = $1
+      AND (a.rewritten_content_path IS NOT NULL OR a.is_consolidated = true)
+      AND a.consolidated_into IS NULL
+      AND a.image_path IS NOT NULL
+      AND ${failedGateSqlFragment('a')}
+    ORDER BY a.published_at DESC NULLS LAST
     LIMIT $2 OFFSET $3
   `, [publicationId, ARTICLES_PER_PAGE, offset]);
 

--- a/tools/static-site/pages/tag.ts
+++ b/tools/static-site/pages/tag.ts
@@ -11,6 +11,7 @@ import {
   type StaticArticle,
 } from '../templates.js';
 import { writeFile, extractExcerpt } from '../utils.js';
+import { failedGateSqlFragment } from '../../editorial/publish-gate.js';
 import { join } from 'path';
 import { readFile } from 'fs/promises';
 
@@ -81,6 +82,7 @@ async function getArticlesForTagPage(
       AND (a.rewritten_content_path IS NOT NULL OR a.is_consolidated = true)
       AND a.consolidated_into IS NULL
       AND a.image_path IS NOT NULL
+      AND ${failedGateSqlFragment('a')}
   `, [tagSlug]);
   const total = parseInt(countRows[0].count, 10);
 
@@ -106,6 +108,7 @@ async function getArticlesForTagPage(
     LEFT JOIN app.tags alt_t ON alt_t.slug = alt_tag.tag_slug
     WHERE (a.rewritten_content_path IS NOT NULL OR a.is_consolidated = true)
       AND a.consolidated_into IS NULL
+      AND ${failedGateSqlFragment('a')}
     ORDER BY a.published_at DESC NULLS LAST
     LIMIT $2 OFFSET $3
   `, [tagSlug, ARTICLES_PER_PAGE, offset]);


### PR DESCRIPTION
## Summary

- New `tools/editorial/publish-gate.ts` exporting `runPublishGate(pool, articleId)` plus a `--scan [--hide]` CLI. Validates that an article has a non-trivial body file, that every inline `/wikipedia/<slug>/` link resolves to a complete + non-dirty + on-disk wikipedia row, and that consolidated commentaries have at least one deep-dive link.
- Wired into the static-site generator: `generate.ts` runs the gate pre-scan once per run, `article.ts` skips failing articles, and the `home` / `publication` / `tag` listing queries filter them via a `NOT IN (...)` fragment so broken articles never appear in cards either.
- New wikipedia-staleness detector in `generate.ts`: when invoked with `--only home,articles,tags` (or any subset that omits `wikipedia`), if any `wikipedia_articles.updated_at` is newer than the newest file under `docs/wikipedia/`, or any inline link references a slug whose `docs/wikipedia/<slug>/index.html` is missing, wikipedia regen is forced for this run. This is the systemic fix for HX-002, HX-003, and HX-004 (see `docs-internal/quality-tracker.md`).
- The consolidated-without-deep-dives check fails the publish gate by default for HX-001, hiding affected articles until the consolidation pipeline starts seeding wiki-discover for them.
- New `tools/editorial/publish-gate.test.ts` covers: missing body, broken wiki link, dirty wiki row, consolidated-without-dives (HX-001), and all-good passing.

Background: `docs-internal/quality-tracker.md` (HX-001 through HX-004 postmortem and standing rules).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test` — 333/333 vitest tests pass (6 new in `publish-gate.test.ts`)
- [ ] Manual: `npx tsx tools/editorial/publish-gate.ts --scan` against prod DB and confirm the failing-article list matches the currently-hidden HX-001 set
- [ ] Manual: run `npm run static:generate -- --only home,articles,tags` and confirm the staleness detector forces a wikipedia regen when expected

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>