### PR TITLE
fix(ui): remove HR above Trending Story Lines section

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1314,8 +1314,7 @@ main {
 /* Trending story lines hero */
 .trending-hero {
   margin: 0 0 2.5rem 0;
-  padding: 1.5rem 0 2rem 0;
-  border-top: 3px double var(--ink);
+  padding: 0 0 2rem 0;
   border-bottom: 3px double var(--ink);
 }
 .trending-hero-title {

--- a/public/styles.css
+++ b/public/styles.css
@@ -1314,8 +1314,7 @@ main {
 /* Trending story lines hero */
 .trending-hero {
   margin: 0 0 2.5rem 0;
-  padding: 1.5rem 0 2rem 0;
-  border-top: 3px double var(--ink);
+  padding: 0 0 2rem 0;
   border-bottom: 3px double var(--ink);
 }
 .trending-hero-title {

--- a/tools/static-site/templates.test.ts
+++ b/tools/static-site/templates.test.ts
@@ -252,6 +252,8 @@ describe('renderTrendingHero', () => {
     expect(html).toContain('4 sources');
     expect(html).toContain('days ago');
     expect(html).toContain('src="./images/foo.jpg"');
+    // Should not emit an <hr> above the section (issue #492)
+    expect(html).not.toMatch(/<hr\b/);
   });
 
   it('renders multiple cards in order', () => {


### PR DESCRIPTION
## Summary
- Closes #492.
- Removes the `border-top: 3px double var(--ink)` from `.trending-hero` (in both `public/styles.css` and the generated `docs/styles.css`). That top border was butting up against the site header's bottom border on https://hex-index.com/, producing the appearance of a stacked double horizontal rule above the "Trending story lines" heading.
- The bottom double-border on the hero is preserved as the visual separator from the article list.
- Drops the now-unneeded top padding (`1.5rem` -> `0`) so spacing under the header looks intentional rather than gappy.
- Adds a guard test in `tools/static-site/templates.test.ts` asserting `renderTrendingHero` never emits an `<hr>` tag, per the issue's acceptance criteria.

## Diff snippet (`docs/styles.css`)
```diff
 .trending-hero {
   margin: 0 0 2.5rem 0;
-  padding: 1.5rem 0 2rem 0;
-  border-top: 3px double var(--ink);
+  padding: 0 0 2rem 0;
   border-bottom: 3px double var(--ink);
 }
```

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` -> 350/350 passing
- [x] Pre-commit static regen ran (`--only assets`) and re-staged `docs/styles.css`
- [ ] After merge: visually confirm on https://hex-index.com/ that the hero sits cleanly under the page header with no double-line above the "Trending story lines" heading