### PR TITLE
fix(ui): trending hero title case + breathing room (#499)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,10 @@ If the database is empty, that's a bug. Test with actual content, not mocks. No 
 - Include **1-2 pull quotes**
 - **Never delete content** — mark dirty for re-processing instead
 
+### Casing Convention
+- **Article titles** (the `app.articles.title` column): sentence case. Implementation in `src/shared/sentence-case.ts`.
+- **Section / UI headers** (page titles, hero labels, navigation): Title Case. Never use `text-transform: uppercase` — Speechify and screen readers pronounce the literal string.
+
 ## Code Standards
 
 ### Lint: Zero Warnings

--- a/docs/article/06feec37-145f-41f0-8008-32731bc2c880/index.html
+++ b/docs/article/06feec37-145f-41f0-8008-32731bc2c880/index.html
@@ -30,7 +30,7 @@
       <div class="content-label">
         <span class="label-text">Commentary by <a href="../../about/index.html">Brian Edwards</a></span>
         <nav class="content-nav">
-          
+          <a href="#deep-dives">Deep dives</a><span class="separator">&middot;</span>
           <a href="https://ruhlman.substack.com/p/taking-stock-52a" target="_blank" rel="noopener">Original article &rarr;</a>
         </nav>
       </div>
@@ -120,6 +120,12 @@
         <span class="read-time"><a href="https://www.amazon.com/s?k=1416566112&i=stripbooks&tag=hexindex0d-20" target="_blank" rel="noopener sponsored" class="buy-link">Amazon</a></span>
         <span class="deep-dive-author">by Michael Ruhlman</span>
         <p class="topic-summary">Ruhlman distills cooking to its fundamental ratios — the same first-principles approach he brings to stock in this article.</p>
+      </li>
+      <li class="deep-dive-item">
+        <a href="../../wikipedia/maillard-reaction/index.html">
+          <strong>Maillard reaction</strong>
+        </a>
+        <p class="topic-summary">While the article emphasizes low-temperature extraction to avoid cloudiness, understanding the Maillard reaction explains why Ruhlman insists on using roasted carcasses and why boiling stock creates a different, often muddier, flavor profile than the gentle gelatin extraction he advocates.</p>
       </li>
         </ul>
       </section>

--- a/docs/article/0f27f4b4-b2c3-4c09-9530-9ab38f32a24d/index.html
+++ b/docs/article/0f27f4b4-b2c3-4c09-9530-9ab38f32a24d/index.html
@@ -96,10 +96,10 @@
       </li>
 
       <li class="deep-dive-item">
-        <a href="../../wikipedia/ilke-homes/index.html">
-          <strong>Ilke Homes</strong>
+        <a href="../../wikipedia/lustron-house/index.html">
+          <strong>Lustron house</strong>
         </a>
-        <p class="topic-summary">This modern UK prefabrication startup serves as a contemporary case study for the persistent difficulty of achieving economies of scale in modular housing despite advanced manufacturing techniques.</p>
+        <p class="topic-summary">While the article mentions Lustron&#039;s massive government funding, its Wikipedia entry details the specific engineering failure of its enameled steel panels cracking in transit and the company&#039;s rapid collapse, illustrating why the promise of factory-built homes has historically been undermined by logistical realities rather than just production costs.</p>
       </li>
         </ul>
       </section>

--- a/docs/article/334440af-4101-4bea-aaf5-6a4e103a2d64/index.html
+++ b/docs/article/334440af-4101-4bea-aaf5-6a4e103a2d64/index.html
@@ -141,10 +141,10 @@
       </li>
 
       <li class="deep-dive-item">
-        <a href="../../wikipedia/perpetual-futures/index.html">
-          <strong>Perpetual futures</strong>
+        <a href="../../wikipedia/foreign-agents-registration-act/index.html">
+          <strong>Foreign Agents Registration Act</strong>
         </a>
-        <p class="topic-summary">The article uses this specific derivative instrument on Ventuals to demonstrate how prediction markets priced Anthropic&#039;s valuation before and after the Pentagon&#039;s designation, revealing market resilience.</p>
+        <p class="topic-summary">The article highlights the unprecedented nature of designating a domestic American company as a &#039;supply chain risk,&#039; making the FARA&#039;s historical use against foreign entities a crucial contrast to understand why this Pentagon move is legally and politically anomalous.</p>
       </li>
         </ul>
       </section>

--- a/docs/article/38f5281b-4182-42e3-a673-c81c6b1355a9/index.html
+++ b/docs/article/38f5281b-4182-42e3-a673-c81c6b1355a9/index.html
@@ -144,10 +144,10 @@
       </li>
 
       <li class="deep-dive-item">
-        <a href="../../wikipedia/2026-iran-war/index.html">
-          <strong>2026 Iran War</strong>
+        <a href="../../wikipedia/strait-of-hormuz/index.html">
+          <strong>Strait of Hormuz</strong>
         </a>
-        <p class="topic-summary">This fictionalized event serves as the article&#039;s central case study for analyzing the catastrophic risks of decapitation strikes and the collapse of nuclear diplomacy.</p>
+        <p class="topic-summary">The article identifies this narrow waterway as a critical choke point where a conflict could instantly shatter global energy markets, making its specific geography and strategic vulnerability essential to understanding the &#039;powder-keg&#039; stakes of the described war.</p>
       </li>
         </ul>
       </section>

--- a/docs/article/6a7168d9-b8f1-4f98-aadc-957c70fa244d/index.html
+++ b/docs/article/6a7168d9-b8f1-4f98-aadc-957c70fa244d/index.html
@@ -143,13 +143,6 @@
         </a>
         <p class="topic-summary">The main subject of the article, Japanese-American animator who worked at Disney and designed characters for Hanna-Barbera</p>
       </li>
-
-      <li class="deep-dive-item">
-        <a href="../../wikipedia/headphones/index.html">
-          <strong>Headphones</strong>
-        </a>
-        <p class="topic-summary">Included as a placeholder example in the prompt instructions, not actually present in the article text.</p>
-      </li>
         </ul>
       </section>
     

--- a/docs/article/7128fb78-deea-4396-8d90-ff564d5b99c2/index.html
+++ b/docs/article/7128fb78-deea-4396-8d90-ff564d5b99c2/index.html
@@ -141,13 +141,6 @@
         </a>
         <p class="topic-summary">This specific military action serves as the immediate catalyst for the article&#039;s analysis of how short interventions risk becoming protracted conflicts.</p>
       </li>
-
-      <li class="deep-dive-item">
-        <a href="../../wikipedia/2026-united-states-military-buildup-in-the-middle-east/index.html">
-          <strong>2026 United States military buildup in the Middle East</strong>
-        </a>
-        <p class="topic-summary">This specific deployment serves as the immediate catalyst for the article&#039;s analysis of how short interventions risk becoming protracted conflicts in a post-Pax Americana era.</p>
-      </li>
         </ul>
       </section>
     

--- a/docs/article/74716c84-ce20-4872-90f6-9650a52bbe9d/index.html
+++ b/docs/article/74716c84-ce20-4872-90f6-9650a52bbe9d/index.html
@@ -93,6 +93,13 @@
         </a>
         <p class="topic-summary">The article introduces this concept to set up the Grossman-Stiglitz Paradox as a counter-argument regarding information incorporation in markets.</p>
       </li>
+
+      <li class="deep-dive-item">
+        <a href="../../wikipedia/green-revolution/index.html">
+          <strong>Green Revolution</strong>
+        </a>
+        <p class="topic-summary">The article credits this specific agricultural transformation with disproving Paul Ehrlich&#039;s famine predictions, making it essential to understand the mechanism that saved India from the starvation Ehrlich insisted was inevitable.</p>
+      </li>
         </ul>
       </section>
     

--- a/docs/article/841f14e9-8a8d-4325-8cdd-0dd6def6adda/index.html
+++ b/docs/article/841f14e9-8a8d-4325-8cdd-0dd6def6adda/index.html
@@ -80,10 +80,10 @@
       </li>
 
       <li class="deep-dive-item">
-        <a href="../../wikipedia/flow-psychology/index.html">
-          <strong>Flow (psychology)</strong>
+        <a href="../../wikipedia/maker-culture/index.html">
+          <strong>Maker culture</strong>
         </a>
-        <p class="topic-summary">The article identifies &#039;human coordination&#039; as the primary barrier to entering a state of flow with AI, making this psychological concept essential for understanding the author&#039;s argument that soft skills, not just tools, are required to unlock the remaining 75% of human capacity.</p>
+        <p class="topic-summary">The article&#039;s focus on solo founders achieving multi-million dollar revenues with zero employees mirrors the historical shift from industrial-scale production to individual craftsmanship that defined the maker movement, offering a concrete historical precedent for the &#039;solo founder&#039; phenomenon described.</p>
       </li>
         </ul>
       </section>

--- a/docs/article/9ac9aab6-582d-424e-aa3a-c072c33415b2/index.html
+++ b/docs/article/9ac9aab6-582d-424e-aa3a-c072c33415b2/index.html
@@ -140,10 +140,10 @@
       </li>
 
       <li class="deep-dive-item">
-        <a href="../../wikipedia/yimby/index.html">
-          <strong>YIMBY</strong>
+        <a href="../../wikipedia/2014-california-proposition-47/index.html">
+          <strong>2014 California Proposition 47</strong>
         </a>
-        <p class="topic-summary">This movement directly challenges the &#039;anti-gentrification&#039; ideology the author critiques by advocating for increased housing supply to lower rents, offering the specific policy counter-narrative central to the article&#039;s argument about San Francisco&#039;s governance failure.</p>
+        <p class="topic-summary">This ballot measure decriminalized certain property crimes and drug possession, serving as the primary legislative catalyst for the public order decline and &#039;progressive governance&#039; critique central to the article&#039;s argument.</p>
       </li>
         </ul>
       </section>

--- a/docs/article/a4a706c3-a1d7-481a-85b8-a4d6752e2148/index.html
+++ b/docs/article/a4a706c3-a1d7-481a-85b8-a4d6752e2148/index.html
@@ -137,6 +137,13 @@
         </a>
         <p class="topic-summary">Related to &quot;Faith and Influence in Moldova: The Orthodox Church Schism Explained&quot; (6 min read)</p>
       </li>
+
+      <li class="deep-dive-item">
+        <a href="../../wikipedia/vladimir-cantarean/index.html">
+          <strong>Vladimir Cantarean</strong>
+        </a>
+        <p class="topic-summary">Identifying the specific individual who served as Metropolitan Vladimir clarifies the human leadership continuity within the Moscow-aligned church structure that the article critiques as a vehicle for foreign influence.</p>
+      </li>
         </ul>
       </section>
     

--- a/docs/article/ab03a62f-ba0d-4e7a-86df-079a935833fd/index.html
+++ b/docs/article/ab03a62f-ba0d-4e7a-86df-079a935833fd/index.html
@@ -30,7 +30,7 @@
       <div class="content-label">
         <span class="label-text">Commentary by <a href="../../about/index.html">Brian Edwards</a></span>
         <nav class="content-nav">
-          <a href="#deep-dives">Deep dives</a><span class="separator">&middot;</span>
+          
           <a href="https://www.theintrinsicperspective.com/p/bits-in-bits-out" target="_blank" rel="noopener">Original article &rarr;</a>
         </nav>
       </div>
@@ -84,12 +84,6 @@
         <span class="read-time"><a href="https://www.amazon.com/s?k=1429522798&i=stripbooks&tag=hexindex0d-20" target="_blank" rel="noopener sponsored" class="buy-link">Amazon</a> · <a href="https://www.betterworldbooks.com/product/detail/9780593163269" target="_blank" rel="noopener sponsored" class="buy-link">Better World Books</a></span>
         <span class="deep-dive-author">by Ray Kurzweil</span>
         <p class="topic-summary"></p>
-      </li>
-      <li class="deep-dive-item">
-        <a href="../../wikipedia/alphago-versus-lee-sedol/index.html">
-          <strong>AlphaGo versus Lee Sedol</strong>
-        </a>
-        <p class="topic-summary">This specific match serves as the historical pivot point where the author contrasts the tangible, physical tool-making of Homo faber with the abstract, conversational capabilities of modern LLMs.</p>
       </li>
         </ul>
       </section>

--- a/docs/article/acd1d0da-6325-4368-bc17-f497493cedd0/index.html
+++ b/docs/article/acd1d0da-6325-4368-bc17-f497493cedd0/index.html
@@ -30,7 +30,7 @@
       <div class="content-label">
         <span class="label-text">Commentary by <a href="../../about/index.html">Brian Edwards</a></span>
         <nav class="content-nav">
-          <a href="#deep-dives">Deep dives</a><span class="separator">&middot;</span>
+          
           <a href="https://www.youtube.com/watch?v=-bQcWs1Z9a0" target="_blank" rel="noopener">Original video &rarr;</a>
         </nav>
       </div>
@@ -81,12 +81,6 @@
         <span class="read-time"><a href="https://www.amazon.com/s?k=0735211299&i=stripbooks&tag=hexindex0d-20" target="_blank" rel="noopener sponsored" class="buy-link">Amazon</a> · <a href="https://www.betterworldbooks.com/product/detail/9780735211292" target="_blank" rel="noopener sponsored" class="buy-link">Better World Books</a></span>
         <span class="deep-dive-author">by James Clear</span>
         <p class="topic-summary">Small changes, remarkable results — the science of habit formation.</p>
-      </li>
-      <li class="deep-dive-item">
-        <a href="../../wikipedia/goodharts-law-Goodhart's_law/index.html">
-          <strong>Goodhart&#039;s law</strong>
-        </a>
-        <p class="topic-summary">The article&#039;s claim that the &#039;token&#039; is replacing the &#039;instruction&#039; as the unit of work illustrates how shifting the metric of software development from deterministic code to probabilistic inference risks distorting engineering judgment and quality control.</p>
       </li>
         </ul>
       </section>

--- a/docs/article/ad7bb394-8a1c-4ad1-8494-0028975b6f73/index.html
+++ b/docs/article/ad7bb394-8a1c-4ad1-8494-0028975b6f73/index.html
@@ -114,13 +114,6 @@
         </a>
         <p class="topic-summary">The company whose conflict with the Trump administration is the main subject of the article</p>
       </li>
-
-      <li class="deep-dive-item">
-        <a href="../../wikipedia/vehicle-ramming-attack/index.html">
-          <strong>Vehicle-ramming attack</strong>
-        </a>
-        <p class="topic-summary">The article uses this specific tactic as a concrete example of how AI could be weaponized to bypass traditional security measures, framing the broader debate on AI regulation.</p>
-      </li>
         </ul>
       </section>
     

--- a/docs/article/cdb2622d-1cbb-491e-928a-5cb72aa169d6/index.html
+++ b/docs/article/cdb2622d-1cbb-491e-928a-5cb72aa169d6/index.html
@@ -30,7 +30,7 @@
       <div class="content-label">
         <span class="label-text">Commentary by <a href="../../about/index.html">Brian Edwards</a></span>
         <nav class="content-nav">
-          
+          <a href="#deep-dives">Deep dives</a><span class="separator">&middot;</span>
           <a href="https://www.youtube.com/watch?v=RXmQIkV3SzU" target="_blank" rel="noopener">Original video &rarr;</a>
         </nav>
       </div>
@@ -64,6 +64,20 @@
 
       
       
+      <section id="deep-dives" class="deep-dives">
+        <h2>Deep Dives</h2>
+        <p class="deep-dives-intro">Explore these related deep dives:</p>
+        <ul class="deep-dive-list">
+          
+      <li class="deep-dive-item">
+        <a href="../../wikipedia/deep-operation/index.html">
+          <strong>Deep operation</strong>
+        </a>
+        <p class="topic-summary">The article contrasts the current grinding attrition with the mobile, operational-level warfare doctrines Russia originally intended to execute, making this 1920s military theory essential for understanding the gap between the Kremlin&#039;s initial strategic vision and the static reality of the fourth year.</p>
+      </li>
+        </ul>
+      </section>
+    
       
 
       <section id="excerpt"><section class="source-excerpts">

--- a/docs/article/e915ca49-baae-4d51-a27a-9ad229535d8a/index.html
+++ b/docs/article/e915ca49-baae-4d51-a27a-9ad229535d8a/index.html
@@ -71,10 +71,10 @@
       </li>
 
       <li class="deep-dive-item">
-        <a href="../../wikipedia/second-french-intervention-in-mexico/index.html">
-          <strong>Second French intervention in Mexico</strong>
+        <a href="../../wikipedia/the-execution-of-emperor-maximilian/index.html">
+          <strong>The Execution of Emperor Maximilian</strong>
         </a>
-        <p class="topic-summary">While the article summarizes the conflict, this article details the specific diplomatic maneuvering of the Tripartite Convention and how the British and Spanish withdrawal isolated France, revealing that the empire&#039;s collapse was as much a result of European realpolitik as American pressure.</p>
+        <p class="topic-summary">This event marks the definitive end of the Second Mexican Empire, serving as the historical counterfactual pivot point for the article&#039;s speculation on whether a Habsburg monarchy could have survived.</p>
       </li>
         </ul>
       </section>

--- a/docs/article/fa4177e4-ee4a-4733-9542-6a8db5d36fc8/index.html
+++ b/docs/article/fa4177e4-ee4a-4733-9542-6a8db5d36fc8/index.html
@@ -72,6 +72,13 @@
         </a>
         <p class="topic-summary">The elite Toronto school produced the colonial administrators and military officers who contested control of the Northwest Territory — a case study in how British institutions projected power across the frontier.</p>
       </li>
+
+      <li class="deep-dive-item">
+        <a href="../../wikipedia/royal-proclamation-of-1763/index.html">
+          <strong>Royal Proclamation of 1763</strong>
+        </a>
+        <p class="topic-summary">This royal decree established the boundary line that Tecumseh&#039;s confederacy sought to defend, providing the legal and historical context for why Harrison viewed the destruction of the Indian nation as essential to securing the Northwest Territory.</p>
+      </li>
         </ul>
       </section>
     

--- a/docs/index.html
+++ b/docs/index.html
@@ -22,8 +22,8 @@
     <div id="search-results" class="article-list" style="display:none"></div>
     <div id="main-content">
       
-    <section class="trending-hero" aria-label="Trending story lines">
-  <h2 class="trending-hero-title">Trending story lines</h2>
+    <section class="trending-hero" aria-label="Trending Story Lines">
+  <h2 class="trending-hero-title">Trending Story Lines</h2>
   <div class="trending-grid">
     <article class="trending-card">
   <a href="./article/da411e59-4929-49e2-883e-ab3d9ef761a9/index.html" class="trending-thumb-link"><img class="trending-thumb" src="./images/ce362d04-7b9e-4478-ad1d-8cf84ff05772.webp" alt="Three clocks and a closed strait: Why the Iran war resists a clean ending" loading="lazy"></a>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1314,14 +1314,12 @@ main {
 /* Trending story lines hero */
 .trending-hero {
   margin: 0 0 2.5rem 0;
-  padding: 0 0 2rem 0;
+  padding: 1rem 0 2rem 0;
   border-bottom: 3px double var(--ink);
 }
 .trending-hero-title {
   margin: 0 0 1.25rem 0;
   font-size: 1.5rem;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
 }
 .trending-grid {
   display: grid;

--- a/public/styles.css
+++ b/public/styles.css
@@ -1314,14 +1314,12 @@ main {
 /* Trending story lines hero */
 .trending-hero {
   margin: 0 0 2.5rem 0;
-  padding: 0 0 2rem 0;
+  padding: 1rem 0 2rem 0;
   border-bottom: 3px double var(--ink);
 }
 .trending-hero-title {
   margin: 0 0 1.25rem 0;
   font-size: 1.5rem;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
 }
 .trending-grid {
   display: grid;

--- a/tools/static-site/templates.test.ts
+++ b/tools/static-site/templates.test.ts
@@ -2,6 +2,9 @@
  * Snapshot tests for multi-source commentary rendering (#450).
  * Covers single-source (no change), 2-source, and 4-source cases.
  */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   renderArticleMeta,
@@ -259,7 +262,7 @@ describe('renderTrendingHero', () => {
   it('renders a section with header, card, image, badge, author, and time ago', () => {
     const html = renderTrendingHero([mkTrending({ id: 'abc', title: 'Big Story', sourceCount: 4 })], './');
     expect(html).toContain('class="trending-hero"');
-    expect(html).toContain('Trending story lines');
+    expect(html).toContain('Trending Story Lines');
     expect(html).toContain('class="trending-card"');
     expect(html).toContain('class="trending-grid"');
     expect(html).toContain('href="./article/abc/index.html"');
@@ -270,6 +273,18 @@ describe('renderTrendingHero', () => {
     expect(html).toContain('src="./images/foo.jpg"');
     // Should not emit an <hr> above the section (issue #492)
     expect(html).not.toMatch(/<hr\b/);
+  });
+
+  it('CSS regression (#499): .trending-hero-title does not uppercase', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const css = readFileSync(resolve(here, '../../public/styles.css'), 'utf8');
+    const match = css.match(/\.trending-hero-title\s*\{[^}]*\}/);
+    expect(match, '.trending-hero-title rule not found').toBeTruthy();
+    expect(match![0]).not.toContain('text-transform: uppercase');
+    // And .trending-hero should have padding-top for breathing room (#499)
+    const heroMatch = css.match(/\.trending-hero\s*\{[^}]*\}/);
+    expect(heroMatch, '.trending-hero rule not found').toBeTruthy();
+    expect(heroMatch![0]).toMatch(/padding:\s*1rem/);
   });
 
   it('renders multiple cards in order', () => {

--- a/tools/static-site/templates.ts
+++ b/tools/static-site/templates.ts
@@ -52,7 +52,7 @@ export function formatTimeAgo(iso: string, now: Date = new Date()): string {
 }
 
 /**
- * Render the "Trending story lines" hero section for the home page.
+ * Render the "Trending Story Lines" hero section for the home page.
  * Returns an empty string when there are no qualifying consolidations,
  * so the home page renders identically to before.
  */
@@ -83,8 +83,8 @@ export function renderTrendingHero(
 </article>`;
   }).join('\n');
 
-  return `<section class="trending-hero" aria-label="Trending story lines">
-  <h2 class="trending-hero-title">Trending story lines</h2>
+  return `<section class="trending-hero" aria-label="Trending Story Lines">
+  <h2 class="trending-hero-title">Trending Story Lines</h2>
   <div class="trending-grid">
     ${cards}
   </div>


### PR DESCRIPTION
## Summary
- Drop `text-transform: uppercase` (and the now-unneeded `letter-spacing`) from `.trending-hero-title` in `public/styles.css` and `docs/styles.css` so "Trending Story Lines" renders as natural Title Case.
- Add `padding-top: 1rem` to `.trending-hero` for breathing room between the page header's bottom border and the hero title.
- Use the Title Case string "Trending Story Lines" in the home-page template, aria-label, and existing test (was "Trending story lines").
- Document the project's casing convention in `CLAUDE.md`: section headers = Title Case; article titles (DB `app.articles.title`) = sentence case.
- Add a CSS regression test in `tools/static-site/templates.test.ts` asserting `.trending-hero-title` does not contain `text-transform: uppercase` and `.trending-hero` has `padding: 1rem ...`.
- Regenerated `docs/` via the pre-commit hook.

Preserves the prior #492 fix (no `<hr>` above the trending section) and the #496 trending border cleanup.

Closes #499

## Test plan
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 396/396 passing, including new CSS regression assertion
- [x] Pre-commit hook regenerated `docs/` against local Postgres
- [x] Spot-checked `docs/index.html`: `<h2 class="trending-hero-title">Trending Story Lines</h2>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review fixes
- Rebased onto current main; resolved docs/ conflicts by taking main's version, then re-ran `npm run static:generate --only home,articles,tags,assets` against the real DB so the regenerated pages preserve Amazon affiliate links (earlier regen had stripped them because the worker environment lacked affiliate data). Verified `docs/article/00097ad1-.../index.html` contains `amazon.com` links.
- Addressed Gemini's CLAUDE.md medium: trimmed the casing convention section to a short, timeless two-bullet rule and removed historical PR references (#498/#499/#500).
