### PR TITLE
feat(consolidate): add --auto-limit for conditional 3-or-1 application

### DIFF
--- a/tools/editorial/consolidate.test.ts
+++ b/tools/editorial/consolidate.test.ts
@@ -12,6 +12,8 @@ import type { CandidateGroup } from './consolidation-candidates.js';
 import {
   type ConsolidationPlan,
   buildBackfillChunks,
+  chooseAutoLimit,
+  countTrendingConsolidations,
   findExtendMatches,
   formatPlan,
   makeStubSynthesizer,
@@ -463,6 +465,7 @@ describe('parseArgs', () => {
       backfillStatus: false,
       extendRecent: false,
       auto: false,
+      autoLimit: false,
     });
   });
   it('parses --apply --limit 3', () => {
@@ -476,7 +479,17 @@ describe('parseArgs', () => {
       backfillStatus: false,
       extendRecent: false,
       auto: false,
+      autoLimit: false,
     });
+  });
+  it('parses --apply --auto-limit (issue #485)', () => {
+    const p = parseArgs(['node', 'x', '--apply', '--auto-limit']);
+    expect(p.autoLimit).toBe(true);
+    expect(p.apply).toBe(true);
+  });
+  it('does NOT set autoLimit when flag absent (backward compat)', () => {
+    expect(parseArgs(['node', 'x', '--apply']).autoLimit).toBe(false);
+    expect(parseArgs(['node', 'x', '--apply', '--limit', '5']).autoLimit).toBe(false);
   });
   it('parses --backfill --apply --limit 5', () => {
     const p = parseArgs(['node', 'x', '--backfill', '--apply', '--limit', '5']);
@@ -1104,5 +1117,71 @@ describe('runModeC apply', () => {
     });
     expect(matches.length).toBeGreaterThan(0);
     expect(db.commentarySources.length).toBe(before);
+  });
+});
+
+// ── --auto-limit (issue #485) ───────────────────────────────────────
+
+describe('chooseAutoLimit', () => {
+  it('returns 3 when zero trending commentaries exist', () => {
+    expect(chooseAutoLimit(0)).toBe(3);
+  });
+  it('returns 3 when fewer than 3 trending commentaries exist', () => {
+    expect(chooseAutoLimit(1)).toBe(3);
+    expect(chooseAutoLimit(2)).toBe(3);
+  });
+  it('returns 1 when exactly 3 trending commentaries exist', () => {
+    expect(chooseAutoLimit(3)).toBe(1);
+  });
+  it('returns 1 when more than 3 trending commentaries exist', () => {
+    expect(chooseAutoLimit(5)).toBe(1);
+    expect(chooseAutoLimit(42)).toBe(1);
+  });
+});
+
+describe('countTrendingConsolidations', () => {
+  /** Minimal mock that returns a single COUNT(*) row. */
+  function mockDbWithCount(n: number): Parameters<typeof countTrendingConsolidations>[0] {
+    return {
+      query: <T>(_sql: string, _params?: unknown[]): Promise<{ rows: T[] }> => {
+        return Promise.resolve({
+          rows: [{ count: String(n) } as unknown as T],
+        });
+      },
+    } as unknown as Parameters<typeof countTrendingConsolidations>[0];
+  }
+
+  it('parses the COUNT(*) row into a number (count=0 → 3 via chooseAutoLimit)', async () => {
+    const count = await countTrendingConsolidations(mockDbWithCount(0));
+    expect(count).toBe(0);
+    expect(chooseAutoLimit(count)).toBe(3);
+  });
+  it('count=2 → limit=3', async () => {
+    const count = await countTrendingConsolidations(mockDbWithCount(2));
+    expect(count).toBe(2);
+    expect(chooseAutoLimit(count)).toBe(3);
+  });
+  it('count=3 → limit=1', async () => {
+    const count = await countTrendingConsolidations(mockDbWithCount(3));
+    expect(count).toBe(3);
+    expect(chooseAutoLimit(count)).toBe(1);
+  });
+  it('count=5 → limit=1', async () => {
+    const count = await countTrendingConsolidations(mockDbWithCount(5));
+    expect(count).toBe(5);
+    expect(chooseAutoLimit(count)).toBe(1);
+  });
+  it('issues the trending SQL (filters by 7-day window + is_consolidated)', async () => {
+    let capturedSql = '';
+    const mock = {
+      query: <T>(sql: string, _params?: unknown[]): Promise<{ rows: T[] }> => {
+        capturedSql = sql;
+        return Promise.resolve({ rows: [{ count: '1' } as unknown as T] });
+      },
+    } as unknown as Parameters<typeof countTrendingConsolidations>[0];
+    await countTrendingConsolidations(mock);
+    expect(capturedSql).toMatch(/INTERVAL '7 days'/);
+    expect(capturedSql).toMatch(/is_consolidated\s*=\s*true/);
+    expect(capturedSql).toMatch(/consolidated_into IS NULL/);
   });
 });

--- a/tools/editorial/consolidate.ts
+++ b/tools/editorial/consolidate.ts
@@ -967,6 +967,52 @@ interface CliArgs {
   backfillStatus: boolean;
   extendRecent: boolean;
   auto: boolean;
+  /**
+   * When true, the per-cycle apply limit is chosen dynamically based on
+   * how many trending consolidated commentaries (≥1 source ≤7 days old)
+   * exist in the DB:
+   *   - count < 3 → limit 3
+   *   - count ≥ 3 → limit 1
+   * Any explicit `--limit N` is ignored when `--auto-limit` is set.
+   * See issue #485.
+   */
+  autoLimit: boolean;
+}
+
+/**
+ * Count consolidated commentaries with at least one source ≤7 days old.
+ * Mirrors the SQL in tools/static-site/pages/trending.ts
+ * (`getTrendingConsolidationRefs`) — kept inline so consolidate.ts has
+ * no static dependency on the static-site module (which itself imports
+ * the publish-gate). Both queries must stay in sync; see issue #485.
+ */
+export async function countTrendingConsolidations(db: DbClient): Promise<number> {
+  const { rows } = await db.query<{ count: string }>(
+    `SELECT COUNT(*)::text AS count
+       FROM app.articles a
+       JOIN (
+         SELECT cs.commentary_article_id
+           FROM app.commentary_sources cs
+           JOIN app.articles src ON src.id = cs.source_article_id
+          GROUP BY cs.commentary_article_id
+         HAVING MAX(GREATEST(
+                  COALESCE(src.published_at, 'epoch'::timestamptz),
+                  src.created_at
+                )) >= NOW() - INTERVAL '7 days'
+       ) mr ON mr.commentary_article_id = a.id
+      WHERE a.is_consolidated = true
+        AND a.consolidated_into IS NULL`,
+  );
+  return Number(rows[0]?.count ?? 0);
+}
+
+/**
+ * Decide the per-cycle apply limit. If fewer than 3 trending hero
+ * commentaries exist, bump the limit to 3 to refill the hero faster;
+ * otherwise hold to the slow trickle of 1. Issue #485.
+ */
+export function chooseAutoLimit(trendingCount: number): number {
+  return trendingCount < 3 ? 3 : 1;
 }
 
 export function parseArgs(argv: string[]): CliArgs {
@@ -987,6 +1033,7 @@ export function parseArgs(argv: string[]): CliArgs {
       backfillStatus: false,
       extendRecent: false,
       auto: false,
+      autoLimit: false,
     };
   }
   const apply = args.includes('--apply');
@@ -997,6 +1044,7 @@ export function parseArgs(argv: string[]): CliArgs {
   const backfillStatus = args.includes('--backfill-status');
   const extendRecent = args.includes('--extend-recent');
   const auto = args.includes('--auto');
+  const autoLimit = args.includes('--auto-limit');
   return {
     dryRun,
     apply,
@@ -1006,6 +1054,7 @@ export function parseArgs(argv: string[]): CliArgs {
     backfillStatus,
     extendRecent,
     auto,
+    autoLimit,
   };
 }
 
@@ -1053,10 +1102,19 @@ async function cliMain(): Promise<void> {
       return;
     }
 
+    let effectiveLimit = cli.limit;
+    if (cli.autoLimit) {
+      const trendingCount = await countTrendingConsolidations(pool);
+      effectiveLimit = chooseAutoLimit(trendingCount);
+      console.info(
+        `auto-limit: ${trendingCount} trending commentaries → applying up to ${effectiveLimit} this run`,
+      );
+    }
+
     const runModeAPass = async (): Promise<void> => {
       const groups = await findConsolidationCandidates(pool as unknown as QueryableDb, { limit: 2000 });
       console.info(`Found ${groups.length} candidate group(s)`);
-      const capped = groups.slice(0, cli.limit);
+      const capped = groups.slice(0, effectiveLimit);
       for (let i = 0; i < capped.length; i++) {
         try {
           const plan = await runModeA({
@@ -1086,7 +1144,7 @@ async function cliMain(): Promise<void> {
         db: pool,
         synthesizer,
         apply: cli.apply,
-        limit: cli.limit,
+        limit: effectiveLimit,
       });
       console.info(`Extend-recent: ${matches.length} match(es)`);
       for (const m of matches) {


### PR DESCRIPTION
Closes #485.

## Summary
- Adds `--auto-limit` flag to `tools/editorial/consolidate.ts`. When set, the per-cycle apply cap is chosen dynamically from a count of trending consolidated commentaries (≥1 source ≤7 days old): `< 3` → limit 3, `≥ 3` → limit 1.
- Any explicit `--limit N` is ignored when `--auto-limit` is passed. `--apply` without `--auto-limit` is unchanged (backward compat).
- The chosen limit is printed at the start of the run so it shows up in the unified loop output.
- New `countTrendingConsolidations()` mirrors the SQL in `tools/static-site/pages/trending.ts` (same 7-day window, `is_consolidated = true`, `consolidated_into IS NULL`).
- New pure helper `chooseAutoLimit(count)` makes the policy trivially testable.

Self-throttling: once the trending hero is full, the loop returns to 1/cycle.

## Test plan
- [x] `chooseAutoLimit`: count=0 → 3, count=1 → 3, count=2 → 3, count=3 → 1, count=5 → 1, count=42 → 1
- [x] `countTrendingConsolidations`: parses COUNT(*) row; SQL contains `INTERVAL '7 days'`, `is_consolidated = true`, `consolidated_into IS NULL`
- [x] `parseArgs`: `--auto-limit` parsed; absent flag stays `false` (backward compat); existing default-shape tests updated
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm test` — 406/406 passing

Pairs with #489 (recency-first ordering) and #491 (relaxed peer growth) — both already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)