### PR TITLE
feat(editorial): source discovery tool with Claude-driven proposals

### DIFF
--- a/tools/editorial/discover-sources.test.ts
+++ b/tools/editorial/discover-sources.test.ts
@@ -1,0 +1,424 @@
+import { mkdtemp, mkdir, readFile, writeFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  BLACKLIST_PATTERNS,
+  CULTIVATED_TAGS,
+  EDITORIAL_CRITERIA,
+  MIN_ARTICLES_PER_TAG,
+  buildDiscoveryPrompt,
+  computeSourceMix,
+  discoverSources,
+  normalizeUrl,
+  parseProposals,
+  parseProposalsDetailed,
+  proposalFilename,
+  validateProposals,
+  type ClaudeRunner,
+  type ExistingSource,
+  type Proposal,
+  type ProposalFile,
+  type QueryableDb,
+  type TagCount,
+} from './discover-sources.js';
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+const FAKE_SUBSTACK: ExistingSource[] = [
+  { name: 'Aeon', slug: 'aeon', url: 'https://aeon.co', type: 'substack' },
+  { name: 'ChinaTalk', slug: 'chinatalk', url: 'https://www.chinatalk.media', type: 'substack' },
+];
+
+const FAKE_YOUTUBE: ExistingSource[] = [
+  { name: 'Caspian Report', slug: 'caspian', url: 'https://www.youtube.com/@CaspianReport', type: 'youtube' },
+];
+
+function mkProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    name: 'Example Review',
+    url: 'https://example.substack.com',
+    rss_or_channel_id: 'https://example.substack.com/feed',
+    type: 'substack',
+    rationale: 'Fills an urbanism gap with original fieldwork and primary-source citations.',
+    criterion_matched: 'topic-mix',
+    topic_filled: 'urbanism',
+    draft_bio: 'Example Review is a long-form publication covering urbanism from Lagos.',
+    ...overrides,
+  };
+}
+
+// ── computeSourceMix ────────────────────────────────────────────────
+
+describe('computeSourceMix', () => {
+  it('flags tags with fewer than MIN_ARTICLES_PER_TAG as under-represented', () => {
+    const tagCounts: TagCount[] = [
+      { tag: 'geopolitics', count: 40 },
+      { tag: 'urbanism', count: 1 },
+      { tag: 'ancient-history', count: 0 },
+      { tag: 'ai', count: 12 },
+    ];
+    const mix = computeSourceMix(FAKE_SUBSTACK, FAKE_YOUTUBE, tagCounts);
+    expect(mix.substackCount).toBe(2);
+    expect(mix.youtubeCount).toBe(1);
+    expect(mix.underRepresentedTags).toContain('urbanism');
+    expect(mix.underRepresentedTags).toContain('ancient-history');
+    // A cultivated tag with zero rows in the DB result should also count.
+    expect(mix.underRepresentedTags).toContain('climate');
+    expect(mix.underRepresentedTags).not.toContain('geopolitics');
+    // Sorted descending by count.
+    expect(mix.tagCounts[0].tag).toBe('geopolitics');
+  });
+
+  it('returns no under-represented tags when every cultivated tag is well above threshold', () => {
+    const tagCounts: TagCount[] = CULTIVATED_TAGS.map((t) => ({
+      tag: t,
+      count: MIN_ARTICLES_PER_TAG + 10,
+    }));
+    const mix = computeSourceMix(FAKE_SUBSTACK, FAKE_YOUTUBE, tagCounts);
+    expect(mix.underRepresentedTags).toEqual([]);
+  });
+});
+
+// ── buildDiscoveryPrompt ────────────────────────────────────────────
+
+describe('buildDiscoveryPrompt', () => {
+  it('includes criteria, tag mix, and under-represented list', () => {
+    const tagCounts: TagCount[] = [
+      { tag: 'geopolitics', count: 40 },
+      { tag: 'urbanism', count: 1 },
+    ];
+    const mix = computeSourceMix(FAKE_SUBSTACK, FAKE_YOUTUBE, tagCounts);
+    const prompt = buildDiscoveryPrompt(mix, FAKE_SUBSTACK, FAKE_YOUTUBE, 12);
+    for (const c of EDITORIAL_CRITERIA) {
+      expect(prompt).toContain(c);
+    }
+    expect(prompt).toContain('urbanism');
+    expect(prompt).toContain('Aeon');
+    expect(prompt).toContain('Caspian Report');
+    expect(prompt).toContain('Propose 12');
+    expect(prompt).toContain('JSON array');
+  });
+});
+
+// ── parseProposals ──────────────────────────────────────────────────
+
+describe('parseProposals', () => {
+  it('extracts a JSON array even when Claude wraps it in prose', () => {
+    const stdout = 'Here you go:\n[{"name":"X","url":"https://x.example","rss_or_channel_id":"https://x.example/feed","type":"substack","rationale":"r","criterion_matched":"c","topic_filled":"urbanism","draft_bio":"b"}]\nDone.';
+    const out = parseProposals(stdout);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('X');
+  });
+
+  it('drops malformed entries silently', () => {
+    const stdout = '[{"name":"good","url":"https://g.example","rss_or_channel_id":"r","type":"youtube","rationale":"r","criterion_matched":"c","topic_filled":"defense","draft_bio":"b"},{"name":"bad"}]';
+    const out = parseProposals(stdout);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe('good');
+  });
+
+  it('throws when no JSON array is present', () => {
+    expect(() => parseProposals('sorry I cannot help')).toThrow(/no JSON array/);
+  });
+});
+
+// ── validateProposals ──────────────────────────────────────────────
+
+describe('validateProposals', () => {
+  const existing: ExistingSource[] = [...FAKE_SUBSTACK, ...FAKE_YOUTUBE];
+
+  it('rejects duplicates by normalized name', () => {
+    const result = validateProposals([mkProposal({ name: 'aeon' })], existing);
+    expect(result.accepted).toHaveLength(0);
+    expect(result.rejected[0].reason).toMatch(/duplicate/);
+  });
+
+  it('rejects duplicates by url (ignoring trailing slash)', () => {
+    const result = validateProposals(
+      [mkProposal({ name: 'Unique Name', url: 'https://aeon.co/' })],
+      existing,
+    );
+    expect(result.accepted).toHaveLength(0);
+    expect(result.rejected[0].reason).toMatch(/duplicate/);
+  });
+
+  it('rejects blacklisted names (John Campbell)', () => {
+    const result = validateProposals(
+      [mkProposal({ name: 'Dr. John Campbell', url: 'https://jc.example' })],
+      existing,
+    );
+    expect(result.accepted).toHaveLength(0);
+    expect(result.rejected[0].reason).toMatch(/blacklist/);
+  });
+
+  it('does NOT blacklist on mentions inside the rationale field', () => {
+    // Descriptive mentions in the rationale ("similar to Payload but broader")
+    // must not cause a rejection — the blacklist only scans name/url/bio.
+    const result = validateProposals(
+      [mkProposal({ name: 'Space News', url: 'https://sn.example', rationale: 'similar to Payload but broader' })],
+      existing,
+    );
+    expect(result.accepted).toHaveLength(1);
+    expect(result.rejected).toHaveLength(0);
+  });
+
+  it('still rejects blacklisted terms in draft_bio', () => {
+    const result = validateProposals(
+      [mkProposal({ name: 'Clean Name', url: 'https://clean.example', draft_bio: 'A Payload-style newsletter.' })],
+      existing,
+    );
+    expect(result.accepted).toHaveLength(0);
+    expect(result.rejected[0].reason).toMatch(/blacklist/);
+  });
+
+  it('rejects intra-batch duplicates', () => {
+    const result = validateProposals(
+      [
+        mkProposal({ name: 'Dup Name', url: 'https://a.example' }),
+        mkProposal({ name: 'Dup Name', url: 'https://b.example' }),
+      ],
+      existing,
+    );
+    expect(result.accepted).toHaveLength(1);
+    expect(result.rejected).toHaveLength(1);
+  });
+
+  it('accepts clean novel proposals', () => {
+    const result = validateProposals([mkProposal()], existing);
+    expect(result.accepted).toHaveLength(1);
+    expect(result.rejected).toHaveLength(0);
+  });
+
+  it('all blacklist patterns compile and match intended strings', () => {
+    expect(BLACKLIST_PATTERNS.length).toBeGreaterThan(0);
+    for (const re of BLACKLIST_PATTERNS) {
+      expect(re).toBeInstanceOf(RegExp);
+    }
+  });
+});
+
+// ── normalizeUrl ──────────────────────────────────────────────────
+
+describe('normalizeUrl', () => {
+  it('collapses protocol/www/trailing-slash/query/fragment variants to the same canonical key', () => {
+    const variants = [
+      'https://example.com',
+      'http://www.example.com/',
+      'HTTPS://Example.com',
+      'https://example.com/',
+      'http://example.com/?utm=foo',
+      'https://www.example.com/#frag',
+      'https://example.com?a=1&b=2',
+    ];
+    const normalized = new Set(variants.map(normalizeUrl));
+    expect(normalized.size).toBe(1);
+    expect([...normalized][0]).toBe('example.com');
+  });
+
+  it('preserves meaningful path segments', () => {
+    expect(normalizeUrl('https://www.example.com/feed')).toBe('example.com/feed');
+    expect(normalizeUrl('https://example.com/feed/?utm=foo')).toBe('example.com/feed');
+  });
+
+  it('detects duplicates across variants in validateProposals', () => {
+    const existing: ExistingSource[] = [
+      { name: 'Example', slug: 'example', url: 'https://example.com', type: 'substack' },
+    ];
+    const result = validateProposals(
+      [mkProposal({ name: 'Totally New Name', url: 'http://www.example.com/?utm=foo' })],
+      existing,
+    );
+    expect(result.accepted).toHaveLength(0);
+    expect(result.rejected[0].reason).toMatch(/duplicate/);
+  });
+});
+
+// ── proposalFilename ───────────────────────────────────────────────
+
+describe('proposalFilename', () => {
+  it('includes UTC date and HHMM so same-day runs do not clobber', () => {
+    expect(proposalFilename(new Date('2026-04-08T12:34:56Z'))).toBe(
+      'source-proposals-2026-04-08-1234.json',
+    );
+  });
+
+  it('generates distinct filenames for the same day at different times', () => {
+    const a = proposalFilename(new Date('2026-04-08T09:00:00Z'));
+    const b = proposalFilename(new Date('2026-04-08T17:30:00Z'));
+    expect(a).not.toBe(b);
+  });
+});
+
+// ── parseProposalsDetailed (malformed capture) ────────────────────
+
+describe('parseProposalsDetailed', () => {
+  it('captures malformed entries with a reason', () => {
+    const stdout = JSON.stringify([
+      mkProposal({ name: 'ok' }),
+      { name: 'missing-fields' },
+      'not-an-object',
+      { ...mkProposal({ name: 'bad-type' }), type: 'podcast' },
+    ]);
+    const result = parseProposalsDetailed(stdout);
+    expect(result.proposals).toHaveLength(1);
+    expect(result.proposals[0].name).toBe('ok');
+    expect(result.malformed).toHaveLength(3);
+    expect(result.malformed[0].reason).toMatch(/missing/);
+    expect(result.malformed[1].reason).toMatch(/not an object/);
+    expect(result.malformed[2].reason).toMatch(/invalid type/);
+  });
+
+  it('throws a descriptive error on invalid JSON', () => {
+    expect(() => parseProposalsDetailed('[not json')).toThrow(/no JSON array|not valid JSON/);
+  });
+});
+
+// ── discoverSources (end-to-end with fakes) ────────────────────────
+
+describe('discoverSources', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(tmpdir(), 'discover-sources-'));
+    await mkdir(path.join(tmp, 'content'), { recursive: true });
+    await writeFile(
+      path.join(tmp, 'content/ingest-subscribed.json'),
+      JSON.stringify({
+        publications: [
+          { name: 'Aeon', slug: 'aeon', url: 'https://aeon.co', feedUrl: 'https://aeon.co/feed.rss' },
+          { name: 'ChinaTalk', slug: 'chinatalk', url: 'https://www.chinatalk.media' },
+        ],
+      }),
+    );
+    await writeFile(
+      path.join(tmp, 'content/youtube-sources.json'),
+      JSON.stringify({
+        channels: [
+          { name: 'Caspian Report', slug: 'caspian', url: 'https://www.youtube.com/@CaspianReport' },
+        ],
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  const fakeDb: QueryableDb = {
+    getTagCounts() {
+      return Promise.resolve([
+        { tag: 'geopolitics', count: 30 },
+        { tag: 'urbanism', count: 0 },
+      ]);
+    },
+  };
+
+  it('writes a proposal file containing accepted proposals and the source mix', async () => {
+    const canned: Proposal[] = [
+      mkProposal({ name: 'Lagos Urbanist', url: 'https://lagos.example' }),
+      mkProposal({ name: 'Aeon' }), // duplicate, should be rejected
+      mkProposal({ name: 'Dr John Campbell', url: 'https://jc.example' }), // blacklisted
+    ];
+    const claude: ClaudeRunner = {
+      run() {
+        return Promise.resolve(JSON.stringify(canned));
+      },
+    };
+
+    const now = new Date('2026-04-08T10:00:00Z');
+    const result = await discoverSources({
+      repoRoot: tmp,
+      db: fakeDb,
+      claude,
+      count: 3,
+      now,
+    });
+
+    expect(result.filePath).toBe(
+      path.join(tmp, 'docs-internal', 'source-proposals-2026-04-08-1000.json'),
+    );
+    expect(result.proposalFile.proposals).toHaveLength(1);
+    expect(result.proposalFile.proposals[0].name).toBe('Lagos Urbanist');
+    expect(result.rejected).toHaveLength(2);
+    expect(result.proposalFile.source_mix.underRepresentedTags).toContain('urbanism');
+    expect(result.proposalFile.criteria).toEqual(EDITORIAL_CRITERIA);
+
+    const onDisk = JSON.parse(await readFile(result.filePath as string, 'utf8')) as ProposalFile;
+    expect(onDisk.proposals[0].name).toBe('Lagos Urbanist');
+    expect(onDisk.source_mix.substackCount).toBe(2);
+    expect(onDisk.source_mix.youtubeCount).toBe(1);
+  });
+
+  it('dry-run does not write a file', async () => {
+    const claude: ClaudeRunner = {
+      run() {
+        return Promise.resolve(
+          JSON.stringify([mkProposal({ name: 'Fresh', url: 'https://fresh.example' })]),
+        );
+      },
+    };
+    const result = await discoverSources({
+      repoRoot: tmp,
+      db: fakeDb,
+      claude,
+      dryRun: true,
+    });
+    expect(result.filePath).toBeNull();
+    expect(result.proposalFile.proposals).toHaveLength(1);
+  });
+
+  it('forwards the full prompt to the Claude runner', async () => {
+    let capturedPrompt = '';
+    const claude: ClaudeRunner = {
+      run(p) {
+        capturedPrompt = p;
+        return Promise.resolve('[]');
+      },
+    };
+    await discoverSources({
+      repoRoot: tmp,
+      db: fakeDb,
+      claude,
+      count: 7,
+      dryRun: true,
+    });
+    expect(capturedPrompt).toContain('Propose 7');
+    expect(capturedPrompt).toContain('Aeon');
+    expect(capturedPrompt).toContain('Caspian Report');
+    expect(capturedPrompt).toContain('urbanism');
+  });
+
+  it('wraps a failing claude runner in a descriptive error (no real shell-out)', async () => {
+    const claude: ClaudeRunner = {
+      run() {
+        return Promise.reject(new Error('spawn ENOENT'));
+      },
+    };
+    await expect(
+      discoverSources({ repoRoot: tmp, db: fakeDb, claude, dryRun: true }),
+    ).rejects.toThrow(/claude -p invocation failed/);
+  });
+
+  it('surfaces malformed Claude output as rejected entries', async () => {
+    const claude: ClaudeRunner = {
+      run() {
+        return Promise.resolve(
+          JSON.stringify([
+            mkProposal({ name: 'Good One', url: 'https://good.example' }),
+            { name: 'partial' },
+          ]),
+        );
+      },
+    };
+    const result = await discoverSources({
+      repoRoot: tmp,
+      db: fakeDb,
+      claude,
+      dryRun: true,
+    });
+    expect(result.proposalFile.proposals).toHaveLength(1);
+    expect(result.rejected.some((r) => /malformed/.test(r.reason))).toBe(true);
+  });
+});

--- a/tools/editorial/discover-sources.ts
+++ b/tools/editorial/discover-sources.ts
@@ -1,0 +1,576 @@
+/**
+ * Source discovery tool (issue #488).
+ *
+ * Uses Claude (NOT Qwen) to actively discover new YouTube channels and
+ * Substack publications that match our editorial criteria. Produces a
+ * JSON proposal file in docs-internal/ that Brian reviews before any
+ * merge into content/ingest-subscribed.json or content/youtube-sources.json.
+ *
+ * Run on demand — NEVER scheduled.
+ *
+ *   tsx tools/editorial/discover-sources.ts           # default: 15 candidates
+ *   tsx tools/editorial/discover-sources.ts --count 20
+ *   tsx tools/editorial/discover-sources.ts --dry-run # skip writing file
+ *
+ * The DB query and the `claude -p` subprocess are both hidden behind
+ * interfaces so the unit tests can inject fakes. See
+ * discover-sources.test.ts.
+ */
+
+import 'dotenv/config';
+import { spawn } from 'child_process';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// ── Editorial criteria (codified from issue #488) ───────────────────
+
+export const EDITORIAL_CRITERIA = [
+  'Long-form, written-for-reading or lecture-style. Substack newsletters and analytical YouTube channels. No short-form, no podcast-only feeds, no tweet aggregators.',
+  'Original analysis, not aggregator/wire reposts.',
+  'Topic mix that fills our existing tags: geopolitics, science, urbanism, economics, philosophy, history, AI, defense, climate, ancient history. Underrepresented topics get priority.',
+  'Globally diverse perspectives — non-US sources are explicitly valued. Caspian Report (NL), Perun (AU), Just Have a Think (UK), ChinaTalk are exemplars.',
+  'HARD EXCLUSION: no contrarian-science channels (e.g. Dr. John Campbell).',
+  'HARD EXCLUSION: no fringe/conspiracy framings.',
+  'HARD EXCLUSION: no AI-generated slop.',
+  'HARD EXCLUSION: nothing we would refuse to comment on (e.g. Payload).',
+  'Author cites primary sources, has a stable posting cadence, and has a public about/funding page.',
+] as const;
+
+/**
+ * Regex patterns that automatically disqualify a proposal. Keep these in
+ * sync with lessons learned — see the "hard exclusions" in EDITORIAL_CRITERIA.
+ */
+export const BLACKLIST_PATTERNS: RegExp[] = [
+  /john\s+campbell/i,
+  /payload/i,
+  /\bqanon\b/i,
+  /\bconspirac/i,
+  /ai[\s-]?generated/i,
+  /\bslop\b/i,
+];
+
+/**
+ * Tags we actively cultivate. If one of these has <MIN_ARTICLES_PER_TAG
+ * articles in the last TAG_WINDOW_DAYS, it's considered under-represented
+ * and gets escalated in the prompt to Claude.
+ */
+export const CULTIVATED_TAGS = [
+  'geopolitics',
+  'science',
+  'urbanism',
+  'economics',
+  'philosophy',
+  'history',
+  'ai',
+  'defense',
+  'climate',
+  'ancient-history',
+] as const;
+
+export const MIN_ARTICLES_PER_TAG = 5;
+export const TAG_WINDOW_DAYS = 90;
+export const DEFAULT_CANDIDATE_COUNT = 15;
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export interface ExistingSource {
+  name: string;
+  slug: string;
+  url: string;
+  type: 'substack' | 'youtube';
+}
+
+export interface TagCount {
+  tag: string;
+  count: number;
+}
+
+export interface SourceMix {
+  substackCount: number;
+  youtubeCount: number;
+  tagCounts: TagCount[];
+  underRepresentedTags: string[];
+}
+
+export interface Proposal {
+  name: string;
+  url: string;
+  rss_or_channel_id: string;
+  type: 'substack' | 'youtube';
+  rationale: string;
+  criterion_matched: string;
+  topic_filled: string;
+  draft_bio: string;
+}
+
+export interface ProposalFile {
+  generated_at: string;
+  criteria: readonly string[];
+  source_mix: SourceMix;
+  proposals: Proposal[];
+}
+
+/**
+ * Minimal DB surface this tool needs. Production passes a pg.Pool wrapper;
+ * tests inject a fake.
+ */
+export interface QueryableDb {
+  getTagCounts(windowDays: number): Promise<TagCount[]>;
+}
+
+/** Subprocess runner for `claude -p`. Tests inject a fake. */
+export interface ClaudeRunner {
+  run(prompt: string): Promise<string>;
+}
+
+// ── Source mix analysis ─────────────────────────────────────────────
+
+export function computeSourceMix(
+  substackSources: ExistingSource[],
+  youtubeSources: ExistingSource[],
+  tagCounts: TagCount[],
+): SourceMix {
+  const counts = new Map(tagCounts.map((t) => [t.tag, t.count]));
+  const underRepresentedTags = CULTIVATED_TAGS.filter(
+    (t) => (counts.get(t) ?? 0) < MIN_ARTICLES_PER_TAG,
+  );
+  return {
+    substackCount: substackSources.length,
+    youtubeCount: youtubeSources.length,
+    tagCounts: [...tagCounts].sort((a, b) => b.count - a.count),
+    underRepresentedTags,
+  };
+}
+
+// ── Prompt construction ─────────────────────────────────────────────
+
+export function buildDiscoveryPrompt(
+  mix: SourceMix,
+  substackSources: ExistingSource[],
+  youtubeSources: ExistingSource[],
+  count: number,
+): string {
+  const substackList = substackSources.map((s) => `- ${s.name} (${s.url})`).join('\n');
+  const youtubeList = youtubeSources.map((s) => `- ${s.name} (${s.url})`).join('\n');
+  const tagMixLines = mix.tagCounts
+    .map((t) => `  - ${t.tag}: ${t.count}`)
+    .join('\n');
+  const underRep = mix.underRepresentedTags.length
+    ? mix.underRepresentedTags.join(', ')
+    : '(none — mix is balanced)';
+
+  return [
+    'You are helping curate the hex-index reading library.',
+    '',
+    'EDITORIAL CRITERIA (every proposal must satisfy ALL of these):',
+    ...EDITORIAL_CRITERIA.map((c, i) => `${i + 1}. ${c}`),
+    '',
+    `CURRENT SOURCE MIX: ${mix.substackCount} Substack publications + ${mix.youtubeCount} YouTube channels.`,
+    '',
+    `Tag distribution (last ${TAG_WINDOW_DAYS} days):`,
+    tagMixLines || '  (no tag data)',
+    '',
+    `UNDER-REPRESENTED TAGS (fewer than ${MIN_ARTICLES_PER_TAG} articles in window): ${underRep}`,
+    'Prioritize proposals that fill these gaps.',
+    '',
+    'EXISTING SUBSTACK SOURCES (do not propose duplicates):',
+    substackList,
+    '',
+    'EXISTING YOUTUBE SOURCES (do not propose duplicates):',
+    youtubeList,
+    '',
+    `TASK: Propose ${count} new sources (mix of Substack and YouTube) that match the criteria`,
+    'and fill gaps. Respond with a JSON array only. No prose before or after.',
+    'Each element must have these fields:',
+    '  name: string',
+    '  url: string',
+    '  rss_or_channel_id: string  (RSS URL for Substack, channel handle like @foo for YouTube)',
+    '  type: "substack" | "youtube"',
+    '  rationale: string  (3 sentences, cite topic gap filled)',
+    '  criterion_matched: string  (which of the numbered criteria above applies most)',
+    '  topic_filled: string  (one of the cultivated tags)',
+    '  draft_bio: string  (2-3 sentence public bio in third person)',
+    '',
+    'Return ONLY the JSON array.',
+  ].join('\n');
+}
+
+// ── Parsing + validation ────────────────────────────────────────────
+
+export interface ParseResult {
+  proposals: Proposal[];
+  malformed: Array<{ raw: unknown; reason: string }>;
+}
+
+/**
+ * Parse + strictly validate the Claude output. Returns both well-formed
+ * Proposal objects and a list of malformed items (with a reason) so the
+ * caller can surface them as rejected candidates rather than dropping
+ * them silently.
+ */
+export function parseProposalsDetailed(stdout: string): ParseResult {
+  const match = stdout.match(/\[[\s\S]*\]/);
+  if (!match) {
+    throw new Error(`no JSON array in claude output: ${stdout.slice(0, 200)}`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[0]);
+  } catch (e) {
+    throw new Error(`claude output is not valid JSON: ${(e as Error).message}`, { cause: e });
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error('claude output is not a JSON array');
+  }
+  const proposals: Proposal[] = [];
+  const malformed: Array<{ raw: unknown; reason: string }> = [];
+  const requiredStringFields = [
+    'name',
+    'url',
+    'rss_or_channel_id',
+    'rationale',
+    'criterion_matched',
+    'topic_filled',
+    'draft_bio',
+  ] as const;
+
+  for (const raw of parsed) {
+    if (typeof raw !== 'object' || raw === null) {
+      malformed.push({ raw, reason: 'entry is not an object' });
+      continue;
+    }
+    const r = raw as Record<string, unknown>;
+    const missing = requiredStringFields.filter((f) => typeof r[f] !== 'string');
+    if (missing.length > 0) {
+      malformed.push({ raw, reason: `missing/invalid string fields: ${missing.join(', ')}` });
+      continue;
+    }
+    if (r.type !== 'substack' && r.type !== 'youtube') {
+      malformed.push({ raw, reason: `invalid type: ${String(r.type)}` });
+      continue;
+    }
+    proposals.push({
+      name: r.name as string,
+      url: r.url as string,
+      rss_or_channel_id: r.rss_or_channel_id as string,
+      type: r.type,
+      rationale: r.rationale as string,
+      criterion_matched: r.criterion_matched as string,
+      topic_filled: r.topic_filled as string,
+      draft_bio: r.draft_bio as string,
+    });
+  }
+  return { proposals, malformed };
+}
+
+/** Back-compat convenience wrapper that only returns the well-formed list. */
+export function parseProposals(stdout: string): Proposal[] {
+  return parseProposalsDetailed(stdout).proposals;
+}
+
+export interface ValidationResult {
+  accepted: Proposal[];
+  rejected: Array<{ proposal: Proposal; reason: string }>;
+}
+
+/**
+ * Canonicalize a URL for duplicate detection. Lower-cases the host,
+ * strips the protocol, leading `www.`, trailing slash(es), query string,
+ * and fragment. `https://Example.com`, `http://www.example.com/`,
+ * and `example.com/?utm=foo#x` all collapse to `example.com`.
+ */
+export function normalizeUrl(url: string): string {
+  let u = url.trim().toLowerCase();
+  u = u.replace(/^https?:\/\//, '');
+  u = u.replace(/^www\./, '');
+  // Strip query string and fragment.
+  const qIdx = u.search(/[?#]/);
+  if (qIdx >= 0) { u = u.slice(0, qIdx); }
+  // Strip trailing slashes.
+  u = u.replace(/\/+$/, '');
+  return u;
+}
+
+/**
+ * Reject proposals that duplicate an existing source (by name or
+ * canonicalized URL) or that match any BLACKLIST_PATTERNS against
+ * their name, URL, or bio. The `rationale` field is intentionally
+ * excluded from the blacklist scan to avoid false positives when
+ * the author mentions a blacklisted term descriptively.
+ */
+export function validateProposals(
+  proposals: Proposal[],
+  existing: ExistingSource[],
+): ValidationResult {
+  const accepted: Proposal[] = [];
+  const rejected: Array<{ proposal: Proposal; reason: string }> = [];
+
+  const normalize = (s: string): string => s.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  const existingNames = new Set(existing.map((s) => normalize(s.name)));
+  const existingUrls = new Set(existing.map((s) => normalizeUrl(s.url)));
+  const seenNames = new Set<string>();
+  const seenUrls = new Set<string>();
+
+  for (const p of proposals) {
+    const nameKey = normalize(p.name);
+    const urlKey = normalizeUrl(p.url);
+    // Deliberately exclude `rationale` — it commonly contains descriptive
+    // mentions of blacklisted terms (e.g. "similar to Payload but broader")
+    // that should not auto-reject an otherwise-valid proposal.
+    const haystack = `${p.name} ${p.url} ${p.draft_bio}`;
+
+    const blacklistHit = BLACKLIST_PATTERNS.find((re) => re.test(haystack));
+    if (blacklistHit) {
+      rejected.push({ proposal: p, reason: `blacklist match: ${blacklistHit}` });
+      continue;
+    }
+    if (existingNames.has(nameKey) || existingUrls.has(urlKey)) {
+      rejected.push({ proposal: p, reason: 'duplicate of existing source' });
+      continue;
+    }
+    if (seenNames.has(nameKey) || seenUrls.has(urlKey)) {
+      rejected.push({ proposal: p, reason: 'duplicate within batch' });
+      continue;
+    }
+    seenNames.add(nameKey);
+    seenUrls.add(urlKey);
+    accepted.push(p);
+  }
+
+  return { accepted, rejected };
+}
+
+// ── File I/O helpers ────────────────────────────────────────────────
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+export async function loadExistingSubstack(repoRoot: string): Promise<ExistingSource[]> {
+  const raw = await readFile(path.join(repoRoot, 'content/ingest-subscribed.json'), 'utf8');
+  const parsed = JSON.parse(raw) as { publications?: Array<Record<string, unknown>> };
+  return (parsed.publications ?? []).map((p) => ({
+    name: asString(p.name),
+    slug: asString(p.slug),
+    url: asString(p.url) || asString(p.feedUrl),
+    type: 'substack' as const,
+  }));
+}
+
+export async function loadExistingYoutube(repoRoot: string): Promise<ExistingSource[]> {
+  const raw = await readFile(path.join(repoRoot, 'content/youtube-sources.json'), 'utf8');
+  const parsed = JSON.parse(raw) as { channels?: Array<Record<string, unknown>> };
+  return (parsed.channels ?? []).map((c) => ({
+    name: asString(c.name),
+    slug: asString(c.slug),
+    url: asString(c.url),
+    type: 'youtube' as const,
+  }));
+}
+
+/**
+ * Filenames include a UTC HHMM suffix so that running the tool multiple
+ * times in a single day does not clobber previous proposal files.
+ */
+export function proposalFilename(date: Date): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  const h = String(date.getUTCHours()).padStart(2, '0');
+  const min = String(date.getUTCMinutes()).padStart(2, '0');
+  return `source-proposals-${y}-${m}-${d}-${h}${min}.json`;
+}
+
+// ── Default `claude -p` subprocess runner ───────────────────────────
+
+export function makeClaudeCliRunner(): ClaudeRunner {
+  return {
+    async run(prompt: string): Promise<string> {
+      return await new Promise<string>((resolvePromise, reject) => {
+        const proc = spawn('claude', ['-p', prompt], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let out = '';
+        let err = '';
+        proc.stdout.on('data', (c: Buffer) => { out += c.toString(); });
+        proc.stderr.on('data', (c: Buffer) => { err += c.toString(); });
+        proc.on('error', reject);
+        proc.on('close', (code) => {
+          if (code === 0) { resolvePromise(out); }
+          else { reject(new Error(`claude -p exited ${code}: ${err}`)); }
+        });
+      });
+    },
+  };
+}
+
+// ── Orchestration ───────────────────────────────────────────────────
+
+export interface DiscoverOptions {
+  repoRoot: string;
+  db: QueryableDb;
+  claude: ClaudeRunner;
+  count?: number;
+  now?: Date;
+  dryRun?: boolean;
+}
+
+export interface DiscoverResult {
+  filePath: string | null;
+  proposalFile: ProposalFile;
+  rejected: Array<{ proposal: Proposal; reason: string }>;
+}
+
+export async function discoverSources(opts: DiscoverOptions): Promise<DiscoverResult> {
+  const count = opts.count ?? DEFAULT_CANDIDATE_COUNT;
+  const now = opts.now ?? new Date();
+
+  const [substack, youtube, tagCounts] = await Promise.all([
+    loadExistingSubstack(opts.repoRoot),
+    loadExistingYoutube(opts.repoRoot),
+    opts.db.getTagCounts(TAG_WINDOW_DAYS),
+  ]);
+
+  const mix = computeSourceMix(substack, youtube, tagCounts);
+  const prompt = buildDiscoveryPrompt(mix, substack, youtube, count);
+
+  let stdout: string;
+  try {
+    stdout = await opts.claude.run(prompt);
+  } catch (e) {
+    throw new Error(`claude -p invocation failed: ${(e as Error).message}`, { cause: e });
+  }
+
+  const { proposals: raw, malformed } = parseProposalsDetailed(stdout);
+  const { accepted, rejected } = validateProposals(raw, [...substack, ...youtube]);
+  // Surface malformed Claude output as rejected candidates so reviewers
+  // can see what was dropped and why.
+  for (const m of malformed) {
+    rejected.push({
+      proposal: {
+        name: '(malformed)',
+        url: '',
+        rss_or_channel_id: '',
+        type: 'substack',
+        rationale: '',
+        criterion_matched: '',
+        topic_filled: '',
+        draft_bio: JSON.stringify(m.raw).slice(0, 200),
+      },
+      reason: `malformed claude output: ${m.reason}`,
+    });
+  }
+
+  const proposalFile: ProposalFile = {
+    generated_at: now.toISOString(),
+    criteria: EDITORIAL_CRITERIA,
+    source_mix: mix,
+    proposals: accepted,
+  };
+
+  let filePath: string | null = null;
+  if (!opts.dryRun) {
+    const outDir = path.join(opts.repoRoot, 'docs-internal');
+    await mkdir(outDir, { recursive: true });
+    filePath = path.join(outDir, proposalFilename(now));
+    await writeFile(filePath, JSON.stringify(proposalFile, null, 2) + '\n', 'utf8');
+  }
+
+  return { filePath, proposalFile, rejected };
+}
+
+// ── Production DB adapter ───────────────────────────────────────────
+
+/** Tag-counts query: recent (within windowDays) ready articles grouped by tag. */
+export function makePgQueryableDb(
+  pool: { query: (sql: string, params?: unknown[]) => Promise<{ rows: Array<Record<string, unknown>> }> },
+): QueryableDb {
+  return {
+    async getTagCounts(windowDays: number): Promise<TagCount[]> {
+      const sql = `
+        SELECT at.tag_slug AS tag, COUNT(DISTINCT a.id)::int AS count
+          FROM app.articles a
+          JOIN app.article_tags at ON at.article_id = a.id
+         WHERE a.created_at >= NOW() - ($1::int || ' days')::interval
+           AND (a.rewritten_content_path IS NOT NULL
+             OR (a.is_consolidated = true AND a.consolidated_into IS NULL))
+         GROUP BY at.tag_slug
+         ORDER BY count DESC
+      `;
+      const res = await pool.query(sql, [windowDays]);
+      return res.rows.map((r) => ({
+        tag: String(r.tag),
+        count: Number(r.count),
+      }));
+    },
+  };
+}
+
+// ── CLI entry point ─────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const countArg = args.indexOf('--count');
+  let count = DEFAULT_CANDIDATE_COUNT;
+  if (countArg >= 0) {
+    if (countArg + 1 >= args.length) {
+      console.error('--count requires a numeric value');
+      process.exit(2);
+    }
+    const n = Number(args[countArg + 1]);
+    if (!Number.isFinite(n) || n <= 0 || !Number.isInteger(n)) {
+      console.error(`--count must be a positive integer, got: ${args[countArg + 1]}`);
+      process.exit(2);
+    }
+    count = n;
+  }
+  const dryRun = args.includes('--dry-run');
+
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const repoRoot = path.resolve(here, '..', '..');
+
+  const { Pool } = await import('pg');
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL ?? 'postgres://hex:hex@localhost:5432/hex_index',
+  });
+  try {
+    const result = await discoverSources({
+      repoRoot,
+      db: makePgQueryableDb(pool),
+      claude: makeClaudeCliRunner(),
+      count,
+      dryRun,
+    });
+    if (result.filePath) {
+      const rel = path.relative(repoRoot, result.filePath);
+      const n = result.proposalFile.proposals.length;
+      // eslint-disable-next-line no-console
+      console.log(
+        `Wrote ${n} candidate sources to ${rel} — review then run merge-proposals.ts`,
+      );
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(
+        `Dry run: ${result.proposalFile.proposals.length} candidates, ${result.rejected.length} rejected`,
+      );
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+const isMain = (() => {
+  try {
+    return import.meta.url === `file://${process.argv[1]}`;
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  main().catch((err: unknown) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
Closes #488. Adds `tools/editorial/discover-sources.ts`, an on-demand tool that codifies our editorial criteria as `EDITORIAL_CRITERIA`, analyzes the DB tag mix over the last 90 days to detect under-represented cultivated tags, then asks `claude -p` to propose new Substack + YouTube sources that fill those gaps. Accepted proposals are written to `docs-internal/source-proposals-YYYY-MM-DD.json` for Brian to review; a follow-up PR will add the merge step.

- Hard-exclusion blacklist (`BLACKLIST_PATTERNS`) rejects John Campbell / Payload / conspiracy / AI-slop patterns before they hit disk.
- Duplicate detection is normalized against existing `content/ingest-subscribed.json` and `content/youtube-sources.json` by both name and URL, and also rejects intra-batch duplicates.
- DB (`QueryableDb`) and the `claude -p` subprocess (`ClaudeRunner`) are both behind small interfaces so the 17-case unit test drives the full pipeline with fakes — no real Postgres, no real Claude invocations.
- On-demand only. NOT scheduled. NOT wired to launchctl/svc/Qwen.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 412 passed (26 files), including 17 new tests in `discover-sources.test.ts`
- [ ] Manual first run against prod DB (deferred — not part of this PR per issue scope)

Not included (follow-ups):
- `merge-proposals.ts` command to accept/reject and write into `content/*.json` + `content/source-bios.yml`
- Cadence / monthly invocation

## Review fixes (2026-04-08 rebase)

Rebased onto current `main` and addressed all medium-priority Gemini review comments:

- **L264 — blacklist false positives on `rationale`**: The `rationale` field is the most common place a proposal *mentions* a blacklisted term descriptively ("similar to Payload but broader"). It is now excluded from the blacklist haystack; only `name`, `url`, and `draft_bio` are scanned. A new test asserts a rationale mention does NOT reject, while a bio mention still does.
- **L258 — URL normalization too basic**: Replaced with `normalizeUrl()` that lowercases, strips protocol, strips `www.`, strips query string and fragment, and strips trailing slash(es). New test proves `https://Example.com`, `http://www.example.com/`, and `http://example.com/?utm=foo#x` all collapse to the same canonical key `example.com`, and a validateProposals test proves duplicates are detected across those variants.
- **L320 — same-day filename collisions**: `proposalFilename()` now includes UTC `HHMM`, so multiple runs in one day produce distinct files. New test asserts two runs at different times yield different filenames.
- **L211 — malformed items dropped silently**: New `parseProposalsDetailed()` returns both well-formed proposals and a list of `{ raw, reason }` for malformed entries. `discoverSources()` surfaces malformed items in the `rejected` list so reviewers can see exactly what Claude returned that didn't parse. Validation is stricter (missing/invalid-type fields each produce a specific reason) and JSON.parse failures throw a descriptive error with `cause`.
- **L428 — `--count` flag without value**: The CLI now checks argv bounds and validates that the value is a positive integer, exiting with a clear error message otherwise.
- **Claude runner error handling**: `discoverSources()` wraps `opts.claude.run(prompt)` in a try/catch and re-throws as `claude -p invocation failed: …` with the original error attached as `cause`. New test uses a fake runner that rejects and asserts the wrapped message — no real shell-out.

Tests: **26/26** in `discover-sources.test.ts`, **450/450** overall. Lint clean, typecheck clean, no `--no-verify`.
