### PR TITLE
chore(infra): move build-weekly from Thu 23:00 to Fri 05:00

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ There is exactly **one** Claude Code session running at a time, driven by a 5-mi
 - `ingest`, `yt-ingest` — article/video acquisition
 - `gen-images` — Gemini image generation
 - `wiki-discover`, `wiki-rewrite`, `article-rewrite`, `affiliate-suggest` — Qwen content generation
-- `build-weekly` (Thu 23:00), `send-weekly` (Fri 07:30) — weekly Reader pipeline
+- `build-weekly` (Fri 05:00), `send-weekly` (Fri 07:30) — weekly Reader pipeline
 - `postgres-watchdog` — DB health
 
 **This unified loop is responsible for everything else:**
@@ -31,7 +31,7 @@ There is exactly **one** Claude Code session running at a time, driven by a 5-mi
 3. **Format error scanning** — run `tools/editorial/find-format-errors.ts` + `fix-format-errors.ts` on new content. Markdown artifacts in HTML break Speechify.
 4. **PR pipeline** — review open PRs, merge green ones, fix red ones, triage Claude/Gemini review comments (critical → fix; non-critical → file issue).
 5. **Main branch CI health** — if `gh run list --branch main` shows failures, fix.
-6. **Weekly epub verification** — Thursday night after 23:00, confirm build-weekly produced a current epub in `docs/weekly/` and it was committed + pushed. Before Friday 07:30 CT, do editorial review. After 07:30, confirm send-weekly fired (email + SMS).
+6. **Weekly epub verification** — Friday morning after 05:00, confirm build-weekly produced a current epub in `docs/weekly/` and it was committed + pushed. Before Friday 07:30 CT, do editorial review. After 07:30, confirm send-weekly fired (email + SMS).
 7. **Content quality audits** — periodically sample recent Qwen output for refusals, `<think>` tags, mojibake, LLM preamble, missing quotes/counterpoints/Bottom Line.
 8. **Issue triage** — create GH issues for things you notice but can't fix in-loop.
 9. **Dependabot / upgrades** — keep deps current.
@@ -84,8 +84,8 @@ ODD HOURS (01, 03, 05, ..., 23):
 
 WEEKLY:
   Thu 22:00  Stop Qwen, consolidate
-  Thu 23:00  build-weekly                  [no LLM]
-  Thu 23:30–Fri 07:00  epub editorial review window
+  Fri 05:00  build-weekly                  [no LLM]
+  Fri 05:30–07:00  epub editorial review window
   Fri 07:30  send-weekly                   [no LLM, email + text]
 
 ALWAYS:

--- a/infra/launchd/com.hex-index.build-weekly.plist
+++ b/infra/launchd/com.hex-index.build-weekly.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.hex-index.build-weekly</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/bedwards/hex-index/tools/cron/build-weekly.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>5</integer>
+        <key>Hour</key>
+        <integer>5</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>/Users/bedwards/hex-index</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/bedwards/hex-index/logs/launchd-build-weekly.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/bedwards/hex-index/logs/launchd-build-weekly.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Moves `com.hex-index.build-weekly` launchd schedule from Thursday 23:00 CT to Friday 05:00 CT so the weekly Reader epub captures Thursday-night and early-Friday content before `send-weekly` fires at Fri 07:30 CT.
- Commits the plist to `infra/launchd/com.hex-index.build-weekly.plist` as the source of truth (previously only lived in `~/Library/LaunchAgents/`).
- Updates `CLAUDE.md` schedule table and editorial review window description to reflect the new time.

Closes #441.

## Manual step required after merge

The plist in `~/Library/LaunchAgents/` is what launchd actually reads, so Brian needs to reload it after merge:

```
launchctl unload ~/Library/LaunchAgents/com.hex-index.build-weekly.plist && \
  cp infra/launchd/com.hex-index.build-weekly.plist ~/Library/LaunchAgents/ && \
  launchctl load ~/Library/LaunchAgents/com.hex-index.build-weekly.plist
```

## Test plan

- [x] `plutil -lint` on the new plist (OK)
- [x] `PlistBuddy -c "Print :StartCalendarInterval"` shows `Weekday=5, Hour=5, Minute=0`
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] `npm run test` — 395/395 passing
- [ ] Post-merge: Brian runs the launchctl unload/cp/load sequence above
- [ ] Post-merge: verify next Friday 05:00 CT that a fresh epub appears in `docs/weekly/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)