### PR TITLE
fix(send-weekly): duck-type Twilio RestException for ESM interop

### DIFF
--- a/tools/jobs/send-weekly.ts
+++ b/tools/jobs/send-weekly.ts
@@ -103,7 +103,15 @@ interface SmsFailure {
 }
 
 function isTwilioRestException(err: unknown): err is RestException {
-  return err instanceof RestException;
+  if (err instanceof RestException) { return true; }
+  // Fallback: ESM interop can break instanceof — duck-type check
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'status' in err &&
+    'code' in err &&
+    'message' in err
+  );
 }
 
 function isTransientError(err: unknown): boolean {


### PR DESCRIPTION
## Summary
- `instanceof RestException` fails under tsx ESM interop (module object vs class)
- Crash killed subscriber loop before reaching second subscriber (Kelley missed)
- Duck-type fallback checks for status/code/message properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)