### PR TITLE
fix(prompts): add tone guidance for war/conflict to Qwen prompts

### DIFF
--- a/tools/jobs/article-rewrite.ts
+++ b/tools/jobs/article-rewrite.ts
@@ -254,6 +254,13 @@ Select the single most striking sentence — either a direct quote from the auth
 5. BOTTOM LINE (final section):
 End with a ## Bottom Line section — 2-3 sentences of editorial judgment. Not a summary. A verdict: What's the strongest part of this argument? What's its biggest vulnerability? What should the reader watch for next?
 
+TONE — CRITICAL:
+- For articles involving conflict, war, or violence: center the human cost. Civilian casualties are not footnotes. Give them weight.
+- Never glorify military operations or use breathless language about weapons/strikes. Write with gravity.
+- Present multiple perspectives: military rationale AND humanitarian consequences, government claims AND civilian experience.
+- Question official framing when the evidence warrants it. If "precision strikes" hit schools, say so plainly.
+- For any topic with human suffering: write with empathy, not detachment.
+
 FORMATTING:
 - Do NOT start with the title. It's displayed separately.
 - Do NOT start with "Imagine..." or any hypothetical device.

--- a/tools/jobs/wikipedia-rewrite.ts
+++ b/tools/jobs/wikipedia-rewrite.ts
@@ -244,6 +244,13 @@ STYLE GUIDE:
 - Aim for 1500-3000 words.
 - Write with authority and specificity. Cite dates, names, numbers.
 
+TONE — CRITICAL:
+- For articles involving conflict, war, or violence: center the human cost. Civilian casualties are not footnotes between strike descriptions. Give them weight and specificity — names, places, ages when available.
+- Never glorify military operations. No "hammer," "fury," "symphony of explosions," or breathless descriptions of weapons platforms. Write with the gravity the subject demands.
+- Present multiple perspectives: military rationale AND humanitarian consequences, government claims AND civilian experience, strategic logic AND its failures.
+- Question official framing when the evidence warrants it. If "precision strikes" hit schools, say so plainly.
+- For any topic with human suffering: write with empathy, not detachment. Cold recitation of facts without human context is a failure of the essay.
+
 BAD OPENING: "Imagine walking into a bank and being told your neighborhood is too risky..."
 GOOD OPENING: "In 1935, the federal government drew red lines around Black neighborhoods on city maps and declared them unfit for investment. The practice was called redlining, and its effects persist ninety years later."
 


### PR DESCRIPTION
## Summary
- wikipedia-rewrite.ts: added TONE section after STYLE GUIDE
- article-rewrite.ts: added TONE section before FORMATTING

Both now require centering human cost, no glorification, multiple perspectives, empathy for suffering. Triggered by the tone-deaf Iran war timeline rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)