### PR TITLE
fix(epub): compute read time for consolidations, use unicode in source

### DIFF
--- a/tools/editorial/consolidate.ts
+++ b/tools/editorial/consolidate.ts
@@ -356,6 +356,14 @@ export async function runModeA(opts: ModeAOptions): Promise<ConsolidationPlan | 
   const primaryRow =
     rows.find((r) => r.id === synth.primarySourceId) ?? rows[0];
 
+  // Compute word count + estimated read time from the generated HTML so the
+  // weekly epub chapter header can render "X min read" without null holes.
+  const wordCount = synth.html
+    .replace(/<[^>]+>/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean).length;
+  const estimatedReadTimeMinutes = Math.max(1, Math.ceil(wordCount / 200));
+
   // Insert commentary article row. Slug derived from commentary id.
   const slug = `consolidated-${commentaryId.slice(0, 8)}`;
   // Inherit image_path from the primary source so the new commentary
@@ -364,8 +372,9 @@ export async function runModeA(opts: ModeAOptions): Promise<ConsolidationPlan | 
     `INSERT INTO app.articles
        (id, publication_id, title, slug, original_url,
         rewritten_content_path, author_name,
-        media_type, is_consolidated, affiliate_links, image_path)
-     VALUES ($1, $2, $3, $4, $5, $6, $7, 'text', true, $8, $9)`,
+        media_type, is_consolidated, affiliate_links, image_path,
+        word_count, estimated_read_time_minutes)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'text', true, $8, $9, $10, $11)`,
     [
       commentaryId,
       primaryRow.publication_id,
@@ -376,6 +385,8 @@ export async function runModeA(opts: ModeAOptions): Promise<ConsolidationPlan | 
       'Hex Index staff',
       JSON.stringify([]),
       primaryRow.image_path,
+      wordCount,
+      estimatedReadTimeMinutes,
     ],
   );
 

--- a/tools/static-site/pages/epub-helpers.ts
+++ b/tools/static-site/pages/epub-helpers.ts
@@ -328,7 +328,7 @@ function renderSourceExcerptBlock(src: EpubChapterSource): string {
   return `
   <div class="source-excerpt">
     <h3>${escAttr(src.title)}</h3>
-    <p class="source-meta">by ${escAttr(src.author)} &#183; ${escAttr(src.publicationName)} &#183; <a href="${escAttr(src.originalUrl)}">${linkLabel}</a></p>
+    <p class="source-meta">by ${escAttr(src.author)} · ${escAttr(src.publicationName)} · <a href="${escAttr(src.originalUrl)}">${linkLabel}</a></p>
     ${src.excerptHtml}
   </div>`;
 }
@@ -353,7 +353,7 @@ export function renderEpubChapterBody(input: EpubChapterInput): string {
   ${input.imageHtml}
   <div class="article-header">
     <h1>${escAttr(input.title)}</h1>
-    <p class="article-meta">${escAttr(input.authorName)} &#183; ${escAttr(input.publicationName)}${date ? ` &#183; ${date}` : ''} &#183; ${input.estimatedReadTimeMinutes} min read</p>
+    <p class="article-meta">${escAttr(input.authorName)} · ${escAttr(input.publicationName)}${date ? ` · ${date}` : ''}${input.estimatedReadTimeMinutes ? ` · ${input.estimatedReadTimeMinutes} min read` : ''}</p>
   </div>
   ${input.bodyHtml}
   ${input.affiliateHtml}
@@ -364,7 +364,7 @@ export function renderEpubChapterBody(input: EpubChapterInput): string {
   const ordered = [...input.sources].sort((a, b) => a.position - b.position);
   const primary = ordered.find(s => s.isPrimary) ?? ordered[0];
   const attribution = primary
-    ? `by Brian Edwards &#8212; multiple sources including ${escAttr(primary.author)}, ${escAttr(primary.publicationName)}`
+    ? `by Brian Edwards — multiple sources including ${escAttr(primary.author)}, ${escAttr(primary.publicationName)}`
     : `by Brian Edwards`;
 
   const interlacedParts: string[] = [];
@@ -385,7 +385,7 @@ export function renderEpubChapterBody(input: EpubChapterInput): string {
   ${input.imageHtml}
   <div class="article-header">
     <h1>${escAttr(input.title)}</h1>
-    <p class="article-meta">${attribution}${date ? ` &#183; ${date}` : ''} &#183; ${input.estimatedReadTimeMinutes} min read</p>
+    <p class="article-meta">${attribution}${date ? ` · ${date}` : ''}${input.estimatedReadTimeMinutes ? ` · ${input.estimatedReadTimeMinutes} min read` : ''}</p>
   </div>
   ${input.bodyHtml}${sourcesAndDeepDives}
   ${input.affiliateHtml}`;


### PR DESCRIPTION
## Summary
Root-cause fixes pulled out of the stale PRs #523 and #530, applied cleanly against current main.

1. `consolidate.ts` computes `word_count` + `estimated_read_time_minutes` when inserting a new commentary, so new consolidations never trip the null read-time bug in the weekly epub.
2. `epub-helpers.ts` uses literal unicode `·` and `—` instead of HTML entities (Speechify reads `&#183;` literally). Read-time segment is null-guarded so old rows without a backfill render cleanly.

Supersedes #523 and #530.

## Test plan
- [x] typecheck passes
- [ ] CI lint + tests
- [ ] Next weekly epub (Fri) shows clean meta lines