### PR TITLE
feat(editorial): bulk source-bio generator + first batch of 25

### DIFF
--- a/content/source-bios.yml
+++ b/content/source-bios.yml
@@ -4516,3 +4516,284 @@ raisinggoodhumans:
   political_leaning: "Gentle-parenting newsletter, culturally-liberal, non-partisan."
   url: "https://raisinggoodhumans.substack.com/about"
   bio_last_audited_at: "2026-04-08"
+
+asianometry:
+  name: "Asianometry"
+  type: "individual creator"
+  country: "Taiwan"
+  funding_model: "free Substack newsletter, complementary to YouTube channel"
+  affiliations:
+    - "Asianometry YouTube channel"
+  political_leaning: "Technocratic and business-analytical, focused on semiconductors, industrial policy, and Asian economic history; generally neutral on partisan politics but sympathetic to East Asian developmental-state perspectives."
+  url: "https://www.asianometry.com/about"
+  bio_last_audited_at: "2026-04-11"
+
+chinauncensored:
+  name: "China Uncensored"
+  type: "youtube channel"
+  country: "United States"
+  us_state: "New York"
+  funding_model: "viewer memberships via Uscreen subscription platform"
+  affiliations:
+    - "Produced by America Uncovered LLC, an independently owned New York company"
+    - "Sister shows: China Unscripted podcast, America Uncovered, Gamers Unbeaten"
+  political_leaning: "Staunchly anti-Chinese Communist Party, sympathetic to dissidents and traditional Chinese culture, delivered through satirical comedy that treats Beijing's official narratives as the primary target."
+  url: "https://www.chinauncensored.tv/about"
+  bio_last_audited_at: "2026-04-11"
+
+closereadingpoetry:
+  name: "Close Reading Poetry"
+  type: "youtube channel"
+  country: "United States"
+  funding_model: "YouTube audience plus Patreon memberships"
+  affiliations:
+    - "Harvard University (founder Adam Walker holds a PhD from Harvard)"
+  political_leaning: "Apolitical literary criticism; a scholar-practitioner making the close reading of English-language verse accessible outside the academy, with no discernible partisan posture."
+  url: "https://www.patreon.com/closereadingpoetry/about"
+  bio_last_audited_at: "2026-04-11"
+
+cosmicskeptic:
+  name: "Cosmic Skeptic (Alex O'Connor)"
+  type: "individual creator"
+  country: "United Kingdom"
+  funding_model: "YouTube ad revenue, sponsorships, and paid Substack subscriptions"
+  affiliations:
+    - "Within Reason Podcast (host)"
+  political_leaning: "Philosophically oriented rather than partisan; an agnostic focused on philosophy of religion, biblical scholarship, and ethics, with self-described interests in free speech and monarchy abolitionism."
+  url: "https://alexoconnor.com/about"
+  bio_last_audited_at: "2026-04-11"
+
+dropsite:
+  name: "Drop Site News"
+  type: "independent newsletter"
+  country: "United States"
+  funding_model: "reader-supported paid subscriptions, no corporate advertising"
+  affiliations: []
+  political_leaning: "Adversarial left, deeply skeptical of US foreign-policy and national-security consensus, with sustained investigative focus on US involvement in overt and covert conflicts — especially the Middle East."
+  url: "https://www.dropsitenews.com/about"
+  bio_last_audited_at: "2026-04-11"
+
+freddiedeboer:
+  name: "Freddie deBoer"
+  type: "independent newsletter"
+  country: "United States"
+  us_state: "Connecticut"
+  funding_model: "paid Substack subscriptions"
+  affiliations: []
+  political_leaning: "Self-described Marxist who is equally scathing toward mainstream progressive 'social justice' discourse and reactionary 'anti-woke' politics. Writes as a media critic focused on corruption and hypocrisy across the political spectrum."
+  url: "https://freddiedeboer.substack.com/about"
+  bio_last_audited_at: "2026-04-11"
+
+goodtimesbadtimes:
+  name: "Good Times Bad Times"
+  type: "youtube channel"
+  country: "Poland"
+  funding_model: "Patreon memberships and YouTube ad revenue"
+  affiliations: []
+  political_leaning: "Independent geopolitics explainer with a realist, great-power-competition frame; broadly Atlanticist and skeptical of Russian and Chinese state narratives, while positioning itself as an alternative to mainstream Western coverage."
+  url: "https://www.patreon.com/GTBT"
+  bio_last_audited_at: "2026-04-11"
+
+jhspedals:
+  name: "JHS Pedals"
+  type: "youtube channel"
+  country: "United States"
+  us_state: "Missouri"
+  funding_model: "company-owned YouTube channel promoting a guitar-effects-pedal business founded by Josh Scott"
+  affiliations:
+    - "JHS Pedals LLC (Kansas City, Missouri; founded 2008 by Joshua Heath Scott)"
+  political_leaning: "Apolitical gear-nerd territory: the channel is about guitar effects pedals, their history, and the boutique-builder scene, with no discernible political posture."
+  url: "https://en.wikipedia.org/wiki/JHS_Pedals"
+  bio_last_audited_at: "2026-04-11"
+
+justhaveathink:
+  name: "Just Have a Think"
+  type: "youtube channel"
+  country: "United Kingdom"
+  funding_model: "Patreon subscriptions"
+  affiliations: []
+  political_leaning: "Climate-forward and solutions-oriented, treating the climate emergency as settled science and advocating for rapid decarbonization and collective action."
+  url: "https://www.justhaveathink.com/about"
+  bio_last_audited_at: "2026-04-11"
+
+kingsandgenerals:
+  name: "Kings and Generals"
+  type: "youtube channel"
+  country: "Unknown"
+  funding_model: "YouTube ad revenue and Patreon patronage"
+  affiliations: []
+  political_leaning: "Apolitical military-history popularization, focused on narrative accounts of battles and campaigns rather than contemporary politics."
+  url: "https://www.patreon.com/KingsandGenerals"
+  bio_last_audited_at: "2026-04-11"
+
+legaleagle:
+  name: "LegalEagle"
+  type: "youtube channel"
+  country: "United States"
+  us_state: "District of Columbia"
+  funding_model: "YouTube ad revenue, channel memberships, and sponsorships, supplemented by the creator's law firm and exam-prep business"
+  affiliations:
+    - "Founded and hosted by Devin Stone, a practicing attorney (Stone Law DC / Eagle Team Law)"
+    - "Stone is an adjunct professor at Georgetown University Law Center"
+  political_leaning: "Mainstream legal-explainer sensibility grounded in defense of rule-of-law norms and procedural regularity; generally skeptical of officials and litigants who flout courts, without a partisan axis."
+  url: "https://en.wikipedia.org/wiki/LegalEagle"
+  bio_last_audited_at: "2026-04-11"
+
+likestoriesofold:
+  name: "Like Stories of Old"
+  type: "youtube channel"
+  country: "Netherlands"
+  funding_model: "Patreon memberships plus YouTube ad revenue"
+  affiliations:
+    - "Cinema of Meaning podcast (co-hosted with Thomas Flight)"
+  political_leaning: "Apolitical in the partisan sense; a humanist, philosophically-minded video essayist drawn to myth, meaning, and inner life rather than contemporary politics."
+  url: "https://www.patreon.com/LikeStoriesofOld"
+  bio_last_audited_at: "2026-04-11"
+
+medlifecrisis:
+  name: "Medlife Crisis"
+  type: "youtube channel"
+  country: "United Kingdom"
+  funding_model: "YouTube ad revenue and viewer support"
+  affiliations:
+    - "East Suffolk and North Essex NHS Foundation Trust (Rohin Francis, consultant cardiologist)"
+    - "University College London (PhD, cardiac imaging)"
+  political_leaning: "Evidence-based medical skepticism in the British public-health tradition, impatient with pseudoscience, anti-vax narratives, and wellness grift; broadly sympathetic to the NHS and publicly funded research."
+  url: "https://en.wikipedia.org/wiki/Rohin_Francis"
+  bio_last_audited_at: "2026-04-11"
+
+metropolitanreview:
+  name: "The Metropolitan Review"
+  type: "nonprofit"
+  country: "United States"
+  funding_model: "501(c)(3) nonprofit funded by reader subscriptions and donations"
+  affiliations:
+    - "Published via Substack"
+  political_leaning: "A literary and cultural magazine positioning itself against what it calls a 'tech-addled, philistine-friendly' mainstream; aesthetically serious and writer-centric rather than overtly partisan, with a sensibility shaped by its New York literary milieu."
+  url: "https://www.metropolitanreview.org/about"
+  bio_last_audited_at: "2026-04-11"
+
+moreperfectunion:
+  name: "More Perfect Union"
+  type: "nonprofit"
+  country: "United States"
+  funding_model: "grassroots donations and values-aligned philanthropic grants; no corporate or union funding"
+  affiliations:
+    - "Faiz Shakir, Executive Director (former Bernie Sanders 2020 campaign manager)"
+  political_leaning: "Populist left, explicitly pro-labor and anti-corporate, framing nearly every story through a working-class power lens. Advocacy journalism that treats organizing and union-building as normative goods rather than neutral subjects."
+  url: "https://perfectunion.us/about/"
+  bio_last_audited_at: "2026-04-11"
+
+noahpinion:
+  name: "Noahpinion"
+  type: "independent newsletter"
+  country: "United States"
+  us_state: "California"
+  funding_model: "paid Substack subscriptions"
+  affiliations: []
+  political_leaning: "Self-described standard center-left liberal and techno-optimist, bullish on growth, innovation, and industrial policy as engines of broad prosperity."
+  url: "https://www.noahpinion.blog/about"
+  bio_last_audited_at: "2026-04-11"
+
+novaramedia:
+  name: "Novara Media"
+  type: "nonprofit"
+  country: "United Kingdom"
+  funding_model: "supporter donations, merchandise, event tickets, YouTube revenue, occasional grants; no ads or sponsored content"
+  affiliations:
+    - "Thousand Hands Ltd (not-for-profit company limited by guarantee)"
+    - "Regulated by IMPRESS"
+  political_leaning: "Openly left-wing and anti-capitalist, self-describing as politically committed rather than neutral. Sympathetic to organized labor, climate action, and critiques of racism and capitalism from a British socialist perspective."
+  url: "https://novaramedia.com/about/"
+  bio_last_audited_at: "2026-04-11"
+
+patrickboyle:
+  name: "Patrick Boyle"
+  type: "youtube channel"
+  country: "United Kingdom"
+  funding_model: "YouTube ad revenue and viewer support, supplemented by academic salary and book sales"
+  affiliations:
+    - "King's Business School, King's College London (Visiting Professor of Finance)"
+    - "Palomar Capital Management (founding partner, hedge fund sold 2018)"
+  political_leaning: "Dryly skeptical City-of-London finance professional; institutionalist on markets and central banking, but quick to mock speculative manias, crypto hype, and corporate malfeasance with deadpan wit."
+  url: "https://www.kcl.ac.uk/people/patrick-boyle"
+  bio_last_audited_at: "2026-04-11"
+
+philosophizethis:
+  name: "Philosophize This!"
+  type: "individual creator"
+  country: "United States"
+  us_state: "Washington"
+  funding_model: "paid Substack subscriptions"
+  affiliations:
+    - "Philosophize This! podcast (companion text edition)"
+  political_leaning: "Nonpartisan and resolutely apolitical in framing, aiming to humanize the history of philosophy for a general audience rather than advance any contemporary ideological agenda."
+  url: "https://philosophizethis.substack.com/about"
+  bio_last_audited_at: "2026-04-11"
+
+religionforbreakfast:
+  name: "Religion For Breakfast"
+  type: "youtube channel"
+  country: "United States"
+  us_state: "Massachusetts"
+  funding_model: "YouTube ad revenue and viewer support"
+  affiliations:
+    - "Religion For Breakfast LLC"
+  political_leaning: "Academically nonsectarian and deliberately apolitical, presenting religious studies from a scholarly rather than devotional or ideological vantage."
+  url: "https://en.wikipedia.org/wiki/Religion_for_Breakfast"
+  bio_last_audited_at: "2026-04-11"
+
+rickbeato:
+  name: "Rick Beato"
+  type: "youtube channel"
+  country: "United States"
+  us_state: "Georgia"
+  funding_model: "ad-supported YouTube channel with paid music-education courses and merchandise"
+  affiliations:
+    - "Black Dog Sound Studios (owner/operator, Stone Mountain, Georgia)"
+    - "Everything Music (YouTube channel brand)"
+  political_leaning: "Apolitical in practice: a working music producer and educator whose channel sticks to song analysis, theory, and industry interviews rather than partisan commentary."
+  url: "https://www.youtube.com/@RickBeato"
+  bio_last_audited_at: "2026-04-11"
+
+slowboring:
+  name: "Slow Boring"
+  type: "independent newsletter"
+  country: "United States"
+  funding_model: "freemium paid Substack subscriptions"
+  affiliations: []
+  political_leaning: "Center-left and self-consciously pragmatic, skeptical of progressive orthodoxy on cultural and economic issues while remaining broadly within the Democratic coalition. Favors wonky, data-driven policy argument over movement rhetoric."
+  url: "https://www.slowboring.com/about"
+  bio_last_audited_at: "2026-04-11"
+
+thebulwark:
+  name: "The Bulwark"
+  type: "independent newsletter"
+  country: "United States"
+  funding_model: "reader-supported Bulwark+ memberships on Substack"
+  affiliations:
+    - "Bulwark Media (Center Enterprises, Inc.)"
+    - "Substack"
+  political_leaning: "Anti-Trump conservative turned broad pro-democracy coalition, founded by Never Trump Republicans and now welcoming center-left allies under a 'country over party' banner."
+  url: "https://www.thebulwark.com/about"
+  bio_last_audited_at: "2026-04-11"
+
+thehatedone:
+  name: "The Hated One"
+  type: "youtube channel"
+  country: "Unknown"
+  funding_model: "Patreon memberships and YouTube ad revenue"
+  affiliations: []
+  political_leaning: "Anti-establishment and anti-surveillance, deeply skeptical of Big Tech, intelligence agencies, and corporate power; civil-libertarian in posture with a strong privacy-rights focus."
+  url: "https://www.patreon.com/thehatedone"
+  bio_last_audited_at: "2026-04-11"
+
+thenandnow:
+  name: "Then & Now"
+  type: "youtube channel"
+  country: "United Kingdom"
+  funding_model: "Patreon subscriptions and YouTube ad revenue"
+  affiliations: []
+  political_leaning: "Left-leaning and academically grounded, drawing on critical theory and continental philosophy to interrogate liberalism, capitalism, and mainstream political narratives."
+  url: "https://www.patreon.com/ThenAndNow"
+  bio_last_audited_at: "2026-04-11"

--- a/tools/editorial/generate-source-bios.test.ts
+++ b/tools/editorial/generate-source-bios.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Unit tests for generate-source-bios (issue #511).
+ *
+ * Covers prompt construction, YAML extraction from Claude stdout, schema
+ * validation, YAML rendering, and the end-to-end orchestration with a
+ * fake DB and a fake Claude runner. No live DB, no live Claude.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  buildBioPrompt,
+  extractYamlFragment,
+  parseAndValidateFragment,
+  renderBioYaml,
+  appendBiosToFile,
+  generateBios,
+  type Publication,
+  type PublicationQueries,
+  type ClaudeRunner,
+  type GeneratedBio,
+} from './generate-source-bios.js';
+
+const TODAY = '2026-04-11';
+
+function makeFakeDb(pubs: Publication[]): PublicationQueries {
+  return {
+    getMissingPublications(existingSlugs, limit) {
+      return Promise.resolve(
+        pubs.filter((p) => !existingSlugs.has(p.slug)).slice(0, limit)
+      );
+    },
+  };
+}
+
+function makeFakeClaude(responses: Record<string, string>): ClaudeRunner {
+  return {
+    run(prompt: string): Promise<string> {
+      for (const [slug, out] of Object.entries(responses)) {
+        if (prompt.includes(`slug: ${slug}\n`) || prompt.includes(`"${slug}"`)) {
+          return Promise.resolve(out);
+        }
+      }
+      return Promise.reject(
+        new Error(`fake claude: no response for prompt starting ${prompt.slice(0, 80)}`)
+      );
+    },
+  };
+}
+
+function goodBioYaml(slug: string, today: string): string {
+  return [
+    `${slug}:`,
+    `  name: "${slug} Example"`,
+    `  type: "independent newsletter"`,
+    `  country: "United States"`,
+    `  funding_model: "paid Substack subscriptions"`,
+    `  affiliations: []`,
+    `  political_leaning: "Center-left, skeptical of consensus framings, sympathetic to labor and institutional accountability."`,
+    `  url: "https://example.com/about"`,
+    `  bio_last_audited_at: "${today}"`,
+    ``,
+  ].join('\n');
+}
+
+describe('buildBioPrompt', () => {
+  it('includes slug, name, and home URL', () => {
+    const prompt = buildBioPrompt(
+      { slug: 'foobar', name: 'FooBar Weekly', base_url: 'https://foobar.example' },
+      TODAY
+    );
+    expect(prompt).toContain('slug: foobar');
+    expect(prompt).toContain('FooBar Weekly');
+    expect(prompt).toContain('https://foobar.example');
+    expect(prompt).toContain(TODAY);
+    expect(prompt.toLowerCase()).toContain('defamation');
+  });
+
+  it('falls back to slug when name is null', () => {
+    const prompt = buildBioPrompt({ slug: 'bare', name: null, base_url: null }, TODAY);
+    expect(prompt).toContain('name: bare');
+    expect(prompt).toContain('slug: bare');
+  });
+});
+
+describe('extractYamlFragment', () => {
+  it('strips surrounding code fences', () => {
+    const stdout = '```yaml\n' + goodBioYaml('foo', TODAY) + '```\n';
+    const frag = extractYamlFragment(stdout, 'foo');
+    expect(frag.startsWith('foo:')).toBe(true);
+    expect(frag).toContain('name: "foo Example"');
+  });
+
+  it('ignores prose preamble', () => {
+    const stdout = 'Sure, here is the bio:\n\n' + goodBioYaml('foo', TODAY);
+    const frag = extractYamlFragment(stdout, 'foo');
+    expect(frag.startsWith('foo:')).toBe(true);
+  });
+
+  it('stops at the next unindented entry', () => {
+    const stdout =
+      goodBioYaml('foo', TODAY) + '\nbar:\n  name: "should not appear"\n';
+    const frag = extractYamlFragment(stdout, 'foo');
+    expect(frag).not.toContain('bar:');
+    expect(frag).not.toContain('should not appear');
+  });
+
+  it('throws when slug is absent', () => {
+    expect(() => extractYamlFragment('nothing here', 'foo')).toThrow(/could not find/);
+  });
+});
+
+describe('parseAndValidateFragment', () => {
+  it('returns a typed bio for well-formed YAML', () => {
+    const bio = parseAndValidateFragment(goodBioYaml('foo', TODAY), 'foo', TODAY);
+    expect(bio.slug).toBe('foo');
+    expect(bio.country).toBe('United States');
+    expect(bio.affiliations).toEqual([]);
+  });
+
+  it('rejects a mismatched slug', () => {
+    expect(() =>
+      parseAndValidateFragment(goodBioYaml('foo', TODAY), 'bar', TODAY)
+    ).toThrow(/does not match expected slug/);
+  });
+
+  it('rejects wrong audit date', () => {
+    expect(() =>
+      parseAndValidateFragment(goodBioYaml('foo', '2020-01-01'), 'foo', TODAY)
+    ).toThrow(/bio_last_audited_at must be/);
+  });
+
+  it('rejects too-short political_leaning', () => {
+    const bad = goodBioYaml('foo', TODAY).replace(
+      /political_leaning:.*$/m,
+      'political_leaning: "left"'
+    );
+    expect(() => parseAndValidateFragment(bad, 'foo', TODAY)).toThrow(
+      /political_leaning too short/
+    );
+  });
+
+  it('rejects multi-entry fragments', () => {
+    const bad = goodBioYaml('foo', TODAY) + goodBioYaml('bar', TODAY);
+    expect(() => parseAndValidateFragment(bad, 'foo', TODAY)).toThrow(/expected exactly 1/);
+  });
+});
+
+describe('renderBioYaml', () => {
+  const bio: GeneratedBio = {
+    slug: 'foo',
+    name: 'Foo Weekly',
+    type: 'independent newsletter',
+    country: 'United States',
+    funding_model: 'paid Substack subscriptions',
+    affiliations: ['Parent Co.'],
+    political_leaning: 'Center-left, pro-labor, skeptical of tech consolidation.',
+    url: 'https://foo.example/about',
+    bio_last_audited_at: TODAY,
+  };
+
+  it('matches the existing file style', () => {
+    const rendered = renderBioYaml(bio);
+    expect(rendered).toMatch(/^foo:\n/);
+    expect(rendered).toContain('  name: "Foo Weekly"');
+    expect(rendered).toContain('  affiliations:\n    - "Parent Co."');
+    expect(rendered).toContain(`  bio_last_audited_at: "${TODAY}"`);
+  });
+
+  it('uses inline [] for empty affiliations', () => {
+    const rendered = renderBioYaml({ ...bio, affiliations: [] });
+    expect(rendered).toContain('affiliations: []');
+  });
+
+  it('emits us_state when present', () => {
+    const rendered = renderBioYaml({ ...bio, us_state: 'California' });
+    expect(rendered).toContain('us_state: "California"');
+  });
+
+  it('escapes double quotes', () => {
+    const rendered = renderBioYaml({ ...bio, name: 'Foo "Quoted" Weekly' });
+    expect(rendered).toContain('name: "Foo \\"Quoted\\" Weekly"');
+  });
+});
+
+describe('appendBiosToFile', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gen-source-bios-'));
+    path = join(dir, 'bios.yml');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('appends new bios alphabetically and preserves existing content', () => {
+    const existing =
+      '# header comment\n\n' +
+      'zebra:\n' +
+      '  name: "Zebra"\n' +
+      '  type: "independent newsletter"\n' +
+      '  country: "United States"\n' +
+      '  funding_model: "paid Substack subscriptions"\n' +
+      '  affiliations: []\n' +
+      '  political_leaning: "Center-left, pro-labor, pro-institutional accountability."\n' +
+      '  url: "https://zebra.example"\n' +
+      `  bio_last_audited_at: "${TODAY}"\n`;
+    writeFileSync(path, existing, 'utf8');
+
+    const bios: GeneratedBio[] = [
+      {
+        slug: 'charlie',
+        name: 'Charlie',
+        type: 'individual creator',
+        country: 'United States',
+        funding_model: 'Patreon, YouTube ads',
+        affiliations: [],
+        political_leaning: 'Pro-science, skeptical of corporate research capture.',
+        url: 'https://charlie.example',
+        bio_last_audited_at: TODAY,
+      },
+      {
+        slug: 'alpha',
+        name: 'Alpha',
+        type: 'independent newsletter',
+        country: 'United Kingdom',
+        funding_model: 'paid Substack subscriptions',
+        affiliations: [],
+        political_leaning: 'Urbanist centre-left, skeptical of car-centric policy.',
+        url: 'https://alpha.example',
+        bio_last_audited_at: TODAY,
+      },
+    ];
+
+    appendBiosToFile(path, bios);
+
+    const out = readFileSync(path, 'utf8');
+    expect(out).toContain('zebra:');
+    // alpha should appear before charlie in the appended batch
+    expect(out.indexOf('alpha:')).toBeLessThan(out.indexOf('charlie:'));
+    // zebra must still be there, unmodified
+    expect(out.indexOf('zebra:')).toBeLessThan(out.indexOf('alpha:'));
+  });
+
+  it('refuses to overwrite existing slugs', () => {
+    const existing =
+      'foo:\n' +
+      '  name: "Foo"\n' +
+      '  type: "independent newsletter"\n' +
+      '  country: "United States"\n' +
+      '  funding_model: "paid Substack subscriptions"\n' +
+      '  affiliations: []\n' +
+      '  political_leaning: "Center-left, pro-labor, pro-institutional accountability."\n' +
+      '  url: "https://foo.example"\n' +
+      `  bio_last_audited_at: "${TODAY}"\n`;
+    writeFileSync(path, existing, 'utf8');
+
+    const bios: GeneratedBio[] = [
+      {
+        slug: 'foo',
+        name: 'Foo Dupe',
+        type: 'independent newsletter',
+        country: 'United States',
+        funding_model: 'paid Substack subscriptions',
+        affiliations: [],
+        political_leaning: 'Center-left, pro-labor, pro-institutional accountability.',
+        url: 'https://foo.example',
+        bio_last_audited_at: TODAY,
+      },
+    ];
+
+    expect(() => appendBiosToFile(path, bios)).toThrow(/already present/);
+    // File unchanged.
+    expect(readFileSync(path, 'utf8')).toBe(existing);
+  });
+});
+
+describe('generateBios orchestration', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'gen-bios-orch-'));
+    path = join(dir, 'bios.yml');
+    writeFileSync(path, '', 'utf8');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('dry-run writes nothing and returns empty generated array', async () => {
+    const db = makeFakeDb([
+      { slug: 'foo', name: 'Foo', base_url: 'https://foo.example' },
+    ]);
+    const claude: ClaudeRunner = {
+      run() {
+        return Promise.reject(new Error('should not be called in dry-run'));
+      },
+    };
+    const result = await generateBios({
+      db,
+      claude,
+      biosPath: path,
+      limit: 25,
+      dryRun: true,
+      today: TODAY,
+      log: () => undefined,
+    });
+    expect(result.generated).toHaveLength(0);
+    expect(readFileSync(path, 'utf8')).toBe('');
+  });
+
+  it('happy path: generates, validates, and appends', async () => {
+    const db = makeFakeDb([
+      { slug: 'foo', name: 'Foo', base_url: 'https://foo.example' },
+      { slug: 'bar', name: 'Bar', base_url: 'https://bar.example' },
+    ]);
+    const claude = makeFakeClaude({
+      foo: goodBioYaml('foo', TODAY),
+      bar: goodBioYaml('bar', TODAY),
+    });
+    const result = await generateBios({
+      db,
+      claude,
+      biosPath: path,
+      limit: 25,
+      dryRun: false,
+      today: TODAY,
+      log: () => undefined,
+    });
+    expect(result.generated.map((b) => b.slug).sort()).toEqual(['bar', 'foo']);
+    expect(result.failed).toHaveLength(0);
+    const out = readFileSync(path, 'utf8');
+    expect(out).toContain('foo:');
+    expect(out).toContain('bar:');
+    expect(out.indexOf('bar:')).toBeLessThan(out.indexOf('foo:'));
+  });
+
+  it('records failures for malformed claude output without aborting', async () => {
+    const db = makeFakeDb([
+      { slug: 'foo', name: 'Foo', base_url: 'https://foo.example' },
+      { slug: 'bar', name: 'Bar', base_url: 'https://bar.example' },
+    ]);
+    const claude = makeFakeClaude({
+      foo: 'nonsense, no yaml',
+      bar: goodBioYaml('bar', TODAY),
+    });
+    const result = await generateBios({
+      db,
+      claude,
+      biosPath: path,
+      limit: 25,
+      dryRun: false,
+      today: TODAY,
+      log: () => undefined,
+    });
+    expect(result.generated.map((b) => b.slug)).toEqual(['bar']);
+    expect(result.failed.map((f) => f.slug)).toEqual(['foo']);
+  });
+});

--- a/tools/editorial/generate-source-bios.ts
+++ b/tools/editorial/generate-source-bios.ts
@@ -1,0 +1,520 @@
+/**
+ * generate-source-bios — issue #511
+ *
+ * Bulk-generate "About this source" bios for publications that don't yet
+ * have an entry in content/source-bios.yml. Uses Claude (NOT Qwen) via the
+ * `claude -p` subprocess. Claude is asked to fetch each publication's own
+ * about page and return a strict YAML fragment matching the schema at the
+ * top of content/source-bios.yml.
+ *
+ * Usage:
+ *   tsx tools/editorial/generate-source-bios.ts                 # default 25
+ *   tsx tools/editorial/generate-source-bios.ts --limit 10
+ *   tsx tools/editorial/generate-source-bios.ts --dry-run       # no claude, no write
+ *
+ * Safety rules (per issue #511):
+ *  - Never overwrite existing bios.
+ *  - Append-only — existing entries in source-bios.yml are left untouched.
+ *  - New entries are written in alphabetical order by slug, appended at EOF.
+ *  - After every batch, validate the full file by parsing it through
+ *    src/shared/source-bios.ts's parseSourceBios() so we fail loudly if
+ *    Claude returned malformed YAML.
+ *  - Skips publications on the banned-slug list.
+ *  - Uses `claude -p` with the Max subscription; does NOT call Qwen.
+ *  - Defamation hygiene: the prompt instructs Claude to stick to facts the
+ *    source has published about itself and to cite the about page URL.
+ */
+
+import 'dotenv/config';
+import { spawn } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Pool } from 'pg';
+import { parse as parseYaml } from 'yaml';
+import { parseSourceBios } from '../../src/shared/source-bios.js';
+import { BANNED_SLUGS } from '../../src/shared/banned-publications.js';
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface Publication {
+  slug: string;
+  name: string | null;
+  base_url: string | null;
+}
+
+export interface GeneratedBio {
+  slug: string;
+  name: string;
+  type: string;
+  country: string;
+  us_state?: string;
+  funding_model: string;
+  affiliations: string[];
+  political_leaning: string;
+  url: string;
+  bio_last_audited_at: string;
+}
+
+export interface PublicationQueries {
+  getMissingPublications(existingSlugs: Set<string>, limit: number): Promise<Publication[]>;
+}
+
+export interface ClaudeRunner {
+  run(prompt: string): Promise<string>;
+}
+
+// ── Default Postgres implementation ──────────────────────────────────
+
+const DEFAULT_DB_URL = 'postgresql://postgres@localhost:5432/hex-index';
+
+export function makePgQueries(pool: Pool): PublicationQueries {
+  return {
+    async getMissingPublications(
+      existingSlugs: Set<string>,
+      limit: number
+    ): Promise<Publication[]> {
+      // Publications that have at least one article and whose slug is not
+      // already in source-bios.yml. Ordered alphabetically by slug so
+      // batches are deterministic across runs.
+      const result = await pool.query<{
+        slug: string;
+        name: string | null;
+        base_url: string | null;
+      }>(
+        `SELECT DISTINCT p.slug, p.name, p.base_url
+           FROM app.publications p
+           JOIN app.articles a ON a.publication_id = p.id
+          ORDER BY p.slug ASC`
+      );
+      const missing: Publication[] = [];
+      for (const row of result.rows) {
+        if (existingSlugs.has(row.slug)) { continue; }
+        if (BANNED_SLUGS.has(row.slug)) { continue; }
+        missing.push({ slug: row.slug, name: row.name, base_url: row.base_url });
+        if (missing.length >= limit) { break; }
+      }
+      return missing;
+    },
+  };
+}
+
+// ── Default `claude -p` subprocess runner ────────────────────────────
+
+export function makeClaudeCliRunner(): ClaudeRunner {
+  return {
+    async run(prompt: string): Promise<string> {
+      return await new Promise<string>((resolvePromise, reject) => {
+        const proc = spawn('claude', ['-p', prompt], {
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let out = '';
+        let err = '';
+        proc.stdout.on('data', (c: Buffer) => { out += c.toString(); });
+        proc.stderr.on('data', (c: Buffer) => { err += c.toString(); });
+        proc.on('error', reject);
+        proc.on('close', (code) => {
+          if (code === 0) { resolvePromise(out); }
+          else { reject(new Error(`claude -p exited ${code}: ${err}`)); }
+        });
+      });
+    },
+  };
+}
+
+// ── Prompt construction ──────────────────────────────────────────────
+
+export function buildBioPrompt(pub: Publication, today: string): string {
+  const displayName = pub.name && pub.name.trim().length > 0 ? pub.name : pub.slug;
+  const homeUrl = pub.base_url ?? '(unknown — infer from slug)';
+  return [
+    `You are drafting an "About this source" bio for Hex Index, a curated news reading library. The bio will appear beneath excerpts of this publication's articles on hex-index.com and in weekly epubs read aloud via Speechify.`,
+    ``,
+    `Publication`,
+    `  name: ${displayName}`,
+    `  slug: ${pub.slug}`,
+    `  home URL: ${homeUrl}`,
+    ``,
+    `Task`,
+    `  1. Fetch the publication's own "about" page (or the about section of their homepage / YouTube channel page). If you cannot reach a direct about URL, use the home URL above and try /about, /about-us, or the channel's "about" tab.`,
+    `  2. Based ONLY on facts the source has published about itself, draft a bio matching the schema below.`,
+    `  3. Cite the exact URL you relied on in the "url" field.`,
+    ``,
+    `Defamation hygiene (CRITICAL)`,
+    `  - Stick to facts the source states about itself: funding model, affiliations, stated mission, country/location, author background.`,
+    `  - Do NOT repeat accusations, gossip, or third-party smears.`,
+    `  - "political_leaning" must be a SENTENCE-FORM editorial judgement (1-2 sentences, opinionated but fair), NOT a left/center/right label. Own it as Hex Index's editorial voice. Example: "Center-left, skeptical of US foreign-policy consensus, sympathetic to organized labor."`,
+    `  - Keep claims specific and verifiable. If you are unsure about a fact, leave it out rather than guess.`,
+    ``,
+    `Schema (YAML, keyed by the exact slug "${pub.slug}")`,
+    `  ${pub.slug}:`,
+    `    name: "Human-readable name"`,
+    `    type: "independent newsletter" | "individual creator" | "youtube channel" | "corporate outlet" | "academic" | "think-tank organ" | "public broadcaster" | "nonprofit"`,
+    `    country: "ISO country name, e.g. United States"`,
+    `    us_state: "Optional, only if US-based and known" # omit if not applicable`,
+    `    funding_model: "short phrase, e.g. paid Substack subscriptions"`,
+    `    affiliations:`,
+    `      - "each affiliation as its own list item"`,
+    `    political_leaning: "Opinionated 1-2 sentence editorial judgement."`,
+    `    url: "https://..."`,
+    `    bio_last_audited_at: "${today}"`,
+    ``,
+    `Output format (STRICT)`,
+    `  - Return ONLY the YAML fragment starting with "${pub.slug}:". No prose preamble, no code fences, no commentary after.`,
+    `  - Use double-quoted strings. Do not use YAML anchors.`,
+    `  - If "affiliations" is empty, use "affiliations: []".`,
+    `  - "bio_last_audited_at" MUST be exactly "${today}".`,
+    `  - All fields except "us_state" are required.`,
+  ].join('\n');
+}
+
+// ── YAML extraction / validation ─────────────────────────────────────
+
+/**
+ * Extract the first YAML fragment keyed by the expected slug from Claude's
+ * stdout. Claude may wrap the fragment in code fences or add preamble —
+ * we trim both. Returns the raw YAML text (not parsed).
+ */
+export function extractYamlFragment(stdout: string, slug: string): string {
+  // Strip code fences if present.
+  let text = stdout;
+  const fence = text.match(/```(?:yaml|yml)?\s*([\s\S]*?)```/);
+  if (fence) {
+    text = fence[1];
+  }
+  // Find the first line starting with "<slug>:" at column 0.
+  const lines = text.split('\n');
+  const startIdx = lines.findIndex((l) => l.trimEnd() === `${slug}:`);
+  if (startIdx < 0) {
+    throw new Error(`extractYamlFragment: could not find "${slug}:" in claude output`);
+  }
+  // Collect subsequent indented lines until an unindented non-empty line.
+  const out: string[] = [lines[startIdx]];
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.length === 0) { out.push(line); continue; }
+    if (/^\s/.test(line)) { out.push(line); continue; }
+    break;
+  }
+  // Trim trailing blank lines.
+  while (out.length > 0 && out[out.length - 1].trim() === '') { out.pop(); }
+  return out.join('\n');
+}
+
+/**
+ * Parse a single-entry YAML fragment and validate it via parseSourceBios.
+ * Returns the typed bio. Throws on any schema issue.
+ */
+export function parseAndValidateFragment(
+  fragment: string,
+  expectedSlug: string,
+  today: string
+): GeneratedBio {
+  // Defensive: make sure Claude didn't tack on extra entries.
+  const doc = parseYaml(fragment) as Record<string, unknown> | null;
+  if (!doc || typeof doc !== 'object') {
+    throw new Error(`parseAndValidateFragment: fragment did not parse as a YAML mapping`);
+  }
+  const keys = Object.keys(doc);
+  if (keys.length !== 1) {
+    throw new Error(
+      `parseAndValidateFragment: expected exactly 1 entry, got ${keys.length} (${keys.join(', ')})`
+    );
+  }
+  if (keys[0] !== expectedSlug) {
+    throw new Error(
+      `parseAndValidateFragment: entry key "${keys[0]}" does not match expected slug "${expectedSlug}"`
+    );
+  }
+  // Reuse the canonical schema validator.
+  const parsed = parseSourceBios(fragment);
+  if (parsed.length !== 1) {
+    throw new Error(`parseAndValidateFragment: validator returned ${parsed.length} bios`);
+  }
+  const bio = parsed[0];
+  if (bio.bio_last_audited_at !== today) {
+    throw new Error(
+      `parseAndValidateFragment: bio_last_audited_at must be ${today}, got ${bio.bio_last_audited_at}`
+    );
+  }
+  if (bio.political_leaning.length < 20) {
+    throw new Error(
+      `parseAndValidateFragment: political_leaning too short (${bio.political_leaning.length} chars), must be sentence-form`
+    );
+  }
+  return {
+    slug: bio.slug,
+    name: bio.name,
+    type: bio.type,
+    country: bio.country,
+    us_state: bio.us_state,
+    funding_model: bio.funding_model,
+    affiliations: bio.affiliations,
+    political_leaning: bio.political_leaning,
+    url: bio.url,
+    bio_last_audited_at: bio.bio_last_audited_at,
+  };
+}
+
+// ── YAML rendering (stable format matching existing file style) ──────
+
+/**
+ * Render a single bio as a YAML block that matches the existing
+ * content/source-bios.yml style: 2-space indent, double-quoted strings,
+ * block-style affiliations list (or inline [] when empty).
+ */
+export function renderBioYaml(bio: GeneratedBio): string {
+  const lines: string[] = [];
+  lines.push(`${bio.slug}:`);
+  lines.push(`  name: ${yamlQuote(bio.name)}`);
+  lines.push(`  type: ${yamlQuote(bio.type)}`);
+  lines.push(`  country: ${yamlQuote(bio.country)}`);
+  if (bio.us_state && bio.us_state.length > 0) {
+    lines.push(`  us_state: ${yamlQuote(bio.us_state)}`);
+  }
+  lines.push(`  funding_model: ${yamlQuote(bio.funding_model)}`);
+  if (bio.affiliations.length === 0) {
+    lines.push(`  affiliations: []`);
+  } else {
+    lines.push(`  affiliations:`);
+    for (const a of bio.affiliations) {
+      lines.push(`    - ${yamlQuote(a)}`);
+    }
+  }
+  lines.push(`  political_leaning: ${yamlQuote(bio.political_leaning)}`);
+  lines.push(`  url: ${yamlQuote(bio.url)}`);
+  lines.push(`  bio_last_audited_at: ${yamlQuote(bio.bio_last_audited_at)}`);
+  return lines.join('\n');
+}
+
+function yamlQuote(s: string): string {
+  // Double-quoted YAML string with \ and " escaped.
+  return `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+// ── File I/O ─────────────────────────────────────────────────────────
+
+function defaultBiosPath(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  return resolve(here, '..', '..', 'content', 'source-bios.yml');
+}
+
+/**
+ * Append new bios to the end of source-bios.yml. New entries are sorted
+ * alphabetically by slug among themselves. Existing content is preserved
+ * byte-for-byte up to its final newline.
+ *
+ * After writing, the whole file is re-parsed through parseSourceBios to
+ * catch YAML errors. If validation fails the file is rolled back to its
+ * previous contents and the error is re-thrown.
+ */
+export function appendBiosToFile(
+  biosPath: string,
+  newBios: GeneratedBio[]
+): void {
+  if (newBios.length === 0) { return; }
+  const existing = existsSync(biosPath) ? readFileSync(biosPath, 'utf8') : '';
+  // Guard against accidental overwrite — refuse if any new slug already
+  // appears as a top-level key in the existing file.
+  const existingParsed = existing.length > 0 ? parseSourceBios(existing) : [];
+  const existingSlugs = new Set(existingParsed.map((b) => b.slug));
+  for (const b of newBios) {
+    if (existingSlugs.has(b.slug)) {
+      throw new Error(`appendBiosToFile: slug "${b.slug}" already present; refusing to overwrite`);
+    }
+  }
+  // Sort the new batch alphabetically by slug.
+  const sorted = [...newBios].sort((a, b) => a.slug.localeCompare(b.slug));
+  // Ensure file ends with a single trailing newline, then append.
+  const base = existing.endsWith('\n') ? existing : existing + '\n';
+  const blocks = sorted.map((b) => renderBioYaml(b)).join('\n\n');
+  // Leading blank line between the existing last entry and the new batch.
+  const appended = base.endsWith('\n\n') ? base + blocks + '\n' : base + '\n' + blocks + '\n';
+  writeFileSync(biosPath, appended, 'utf8');
+  // Validate the whole file.
+  try {
+    const reparsed = parseSourceBios(readFileSync(biosPath, 'utf8'));
+    // Sanity: reparsed should contain every new slug.
+    const reparsedSlugs = new Set(reparsed.map((b) => b.slug));
+    for (const b of newBios) {
+      if (!reparsedSlugs.has(b.slug)) {
+        throw new Error(`appendBiosToFile: post-write re-parse missing slug "${b.slug}"`);
+      }
+    }
+  } catch (err) {
+    // Roll back.
+    writeFileSync(biosPath, existing, 'utf8');
+    throw err;
+  }
+}
+
+// ── Orchestration ────────────────────────────────────────────────────
+
+export interface GenerateOptions {
+  db: PublicationQueries;
+  claude: ClaudeRunner;
+  biosPath: string;
+  limit: number;
+  dryRun: boolean;
+  today: string;
+  log?: (msg: string) => void;
+}
+
+export interface GenerateResult {
+  generated: GeneratedBio[];
+  failed: Array<{ slug: string; reason: string }>;
+  skipped: string[];
+}
+
+export async function generateBios(opts: GenerateOptions): Promise<GenerateResult> {
+  const log = opts.log ?? ((m: string) => { console.error(m); });
+  // Seed existing slug set from the on-disk YAML.
+  const biosText = existsSync(opts.biosPath)
+    ? readFileSync(opts.biosPath, 'utf8')
+    : '';
+  const existingBios = biosText.length > 0 ? parseSourceBios(biosText) : [];
+  const existingSlugs = new Set(existingBios.map((b) => b.slug));
+
+  log(`generate-source-bios: ${existingSlugs.size} existing bios on disk`);
+  const targets = await opts.db.getMissingPublications(existingSlugs, opts.limit);
+  log(`generate-source-bios: ${targets.length} target publications (limit ${opts.limit})`);
+
+  if (opts.dryRun) {
+    log(`generate-source-bios: DRY RUN — would generate bios for:`);
+    for (const t of targets) {
+      log(`  - ${t.slug}  (${t.name ?? '(no name)'} — ${t.base_url ?? 'no url'})`);
+    }
+    return { generated: [], failed: [], skipped: [] };
+  }
+
+  const generated: GeneratedBio[] = [];
+  const failed: Array<{ slug: string; reason: string }> = [];
+
+  for (const pub of targets) {
+    log(`generate-source-bios: drafting bio for ${pub.slug}...`);
+    const prompt = buildBioPrompt(pub, opts.today);
+    let stdout: string;
+    try {
+      stdout = await opts.claude.run(prompt);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log(`  FAILED (claude invocation): ${msg}`);
+      failed.push({ slug: pub.slug, reason: `claude invocation: ${msg}` });
+      continue;
+    }
+    let bio: GeneratedBio;
+    try {
+      const fragment = extractYamlFragment(stdout, pub.slug);
+      bio = parseAndValidateFragment(fragment, pub.slug, opts.today);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log(`  FAILED (parse/validate): ${msg}`);
+      failed.push({ slug: pub.slug, reason: `parse/validate: ${msg}` });
+      continue;
+    }
+    generated.push(bio);
+    log(`  OK — ${bio.name} (${bio.country})`);
+  }
+
+  if (generated.length > 0) {
+    appendBiosToFile(opts.biosPath, generated);
+    log(`generate-source-bios: appended ${generated.length} bios to ${opts.biosPath}`);
+  } else {
+    log(`generate-source-bios: nothing to append`);
+  }
+
+  return { generated, failed, skipped: [] };
+}
+
+// ── CLI entrypoint ───────────────────────────────────────────────────
+
+function parseArgs(argv: string[]): { limit: number; dryRun: boolean } {
+  let limit = 25;
+  let dryRun = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dry-run') { dryRun = true; continue; }
+    if (a === '--limit') {
+      const next = argv[i + 1];
+      if (!next) { throw new Error('--limit requires a value'); }
+      const n = Number(next);
+      if (!Number.isInteger(n) || n < 1) {
+        throw new Error(`--limit must be a positive integer, got "${next}"`);
+      }
+      limit = n;
+      i++;
+      continue;
+    }
+    if (a === '--help' || a === '-h') {
+      console.info(
+        'Usage: tsx tools/editorial/generate-source-bios.ts [--limit N] [--dry-run]'
+      );
+      process.exit(0);
+    }
+    throw new Error(`unknown argument: ${a}`);
+  }
+  return { limit, dryRun };
+}
+
+function todayIso(): string {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}
+
+async function main(): Promise<void> {
+  const { limit, dryRun } = parseArgs(process.argv.slice(2));
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL ?? DEFAULT_DB_URL,
+  });
+  try {
+    const db = makePgQueries(pool);
+    const claude = makeClaudeCliRunner();
+    const result = await generateBios({
+      db,
+      claude,
+      biosPath: defaultBiosPath(),
+      limit,
+      dryRun,
+      today: todayIso(),
+    });
+    console.info('');
+    console.info(`Generated: ${result.generated.length}`);
+    console.info(`Failed:    ${result.failed.length}`);
+    if (result.failed.length > 0) {
+      for (const f of result.failed) {
+        console.info(`  - ${f.slug}: ${f.reason}`);
+      }
+    }
+    if (result.generated.length > 0) {
+      console.info('');
+      console.info('Added slugs:');
+      for (const b of result.generated) {
+        console.info(`  - ${b.slug}`);
+      }
+    }
+  } finally {
+    await pool.end().catch(() => undefined);
+  }
+}
+
+// Only run main() when executed directly (so unit tests can import without
+// triggering the DB connection or argv parsing).
+const isMain = (() => {
+  try {
+    const entry = process.argv[1];
+    if (!entry) { return false; }
+    return resolve(entry) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  main().catch((err: unknown) => {
+    console.error('generate-source-bios:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Refs #511. Follow-up to PR #510 (which landed the data model + 5 seed bios).

## What's in this PR

### 1. New tool: `tools/editorial/generate-source-bios.ts`
Iterates over every publication in `app.publications` that lacks an entry in `content/source-bios.yml` and drafts a bio via `claude -p` (NOT Qwen — Brian's Max subscription). Key behaviors:

- **Prompt** tells Claude to fetch the publication's own about page, cite the URL, write `political_leaning` as a 1-2 sentence editorial judgement (not a label), and stick to facts the source has published about itself (defamation hygiene).
- **Strict output** — demands a YAML fragment keyed by the exact slug, `bio_last_audited_at` exactly `today`, no code fences, no preamble. `extractYamlFragment` strips fences / prose defensively.
- **Validation** — every fragment is parsed through `parseSourceBios()` from `src/shared/source-bios.ts` before being appended; malformed output is recorded as a failure and the loop continues.
- **Append-only** — new bios are sorted alphabetically within the batch and appended at EOF. Existing entries are left untouched byte-for-byte. If any new slug collides with an existing entry, the tool refuses and rolls back.
- **Skips banned slugs** automatically via `BANNED_SLUGS` from `src/shared/banned-publications.ts`.
- **Flags:** `--limit N` (default 25), `--dry-run` (prints targets, skips Claude and writes).
- **Testable** — DB and Claude CLI are behind interfaces. 20 unit tests in `generate-source-bios.test.ts` cover prompt construction, YAML extraction, schema validation, rendering, append semantics, and the orchestration happy path + failure path.

Usage:
```
tsx tools/editorial/generate-source-bios.ts            # default 25
tsx tools/editorial/generate-source-bios.ts --limit 10
tsx tools/editorial/generate-source-bios.ts --dry-run
```

### 2. First batch of 25 generated bios
Ran the tool against the live DB. All 25 Claude drafts parsed and validated on the first pass with zero failures. The file now has 455 bios covering all but 5 active publications:

- asianometry
- chinauncensored
- closereadingpoetry
- cosmicskeptic
- dropsite
- freddiedeboer
- goodtimesbadtimes
- jhspedals
- justhaveathink
- kingsandgenerals
- legaleagle
- likestoriesofold
- medlifecrisis
- metropolitanreview
- moreperfectunion
- noahpinion
- novaramedia
- patrickboyle
- philosophizethis
- religionforbreakfast
- rickbeato
- slowboring
- thebulwark
- thehatedone
- thenandnow

### Remaining after merge
Only 5 publications still lack bios: `thewalrusca`, `veritasium`, `wendoverproductions`, `wescecil`, `yalecourses`. A future loop can run `--limit 10` to finish the backlog, then flip `check-source-bios.ts` to hard mode (third follow-up item from #487).

## Out of scope (follow-ups tracked in #511)
- Flipping `tools/editorial/check-source-bios.ts` from soft to hard-blocking.
- Periodic re-audit / staleness checking.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 487 passing (20 new)
- [x] `--dry-run` against live DB — lists 25 targets correctly
- [x] Full run against live DB — 25/25 generated, 0 failures
- [x] Post-run `parseSourceBios()` on the whole file — 455 bios, 455 unique slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)